### PR TITLE
CRT-/Pixel-Skin + Optionen-Overlay (#41)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import { useReducer, useEffect, useRef, useState } from "react";
 import { reducer, initialState, menuState } from "./game/reducer.js";
 import { BASE_FLIP_MS, GHOST_STEP, TRICKS_PER_CYCLE, lossCostFor, lossTierFor } from "./game/constants.js";
 import { baseScoreMultFor } from "./game/perks.js";
-import { loadGhost, saveGhost, loadHighscores, recordHighscore } from "./game/storage.js";
+import { loadGhost, saveGhost, loadHighscores, recordHighscore, loadOptions, saveOptions } from "./game/storage.js";
 import { fmtDuration } from "./game/deck.js";
 import { StatusRail } from "./ui/StatusRail.jsx";
 import { Battlefield } from "./ui/Battlefield.jsx";
@@ -12,11 +12,14 @@ import { PerkSelect } from "./ui/PerkSelect.jsx";
 import { PredictionSelect } from "./ui/PredictionSelect.jsx";
 import { GameOver } from "./ui/GameOver.jsx";
 import { StartScreen } from "./ui/StartScreen.jsx";
+import { OptionsModal } from "./ui/OptionsModal.jsx";
 import { DeckHistogram } from "./ui/BuildSummary.jsx";
 
 export function Autostich() {
   const [state, dispatch] = useReducer(reducer, null, () => menuState());
   const [paused, setPaused] = useState(false);
+  const [options, setOptions] = useState(() => loadOptions());   // Optionen (#41): u. a. CRT-Skin
+  const [showOptions, setShowOptions] = useState(false);          // Optionen-Overlay offen? → pausiert den Run
   const [speedMult, setSpeedMult] = useState(1); // Ablaufbeschleunigung 1×/2×/3× (#27, kein Score-Effekt)
   const [, setClock] = useState(0); // erzwingt Re-Render fürs Ticken des Timers
   const [highscores, setHighscores] = useState(() => loadHighscores());
@@ -37,7 +40,9 @@ export function Autostich() {
   const segStart = useRef(null);
   const lastLossTier = useRef(0); // zuletzt angezeigte Niederlagenkosten-Stufe (#32)
   const prevMult = useRef(1);     // vorheriger Score-Mult (Puls nur bei Anstieg, #37)
-  const active = state.phase === "play" && !paused;
+  // Offenes Optionen-Overlay friert den Lauf ein (wie andere Overlays) — ohne den
+  // Nutzer-Pause-Toggle zu verändern: beim Schließen läuft es im vorherigen Zustand weiter.
+  const active = state.phase === "play" && !paused && !showOptions;
   // Effektive Flip-Zeit: Basis / (1+Speed) / Turbo (1×/2×/3×). Beschleunigt nur Ablauf + Animation,
   // NICHT den Score (speedPct/tempoScoreMult bleiben unberührt → kein Cheesen).
   const flipMs = (BASE_FLIP_MS / (1 + state.speedPct / 100)) / speedMult;
@@ -47,6 +52,15 @@ export function Autostich() {
     recordTraj.current = g.traj;
     recordTotal.current = g.total;
   }, []);
+
+  // CRT-Skin (#41): data-skin am <html> spiegelt die Option → alle skin-gated CSS-Regeln
+  // greifen global (auch das fixed Scanline-Overlay). Default („off") = Attribut entfernt.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (options.skin === "crt") root.setAttribute("data-skin", "crt");
+    else root.removeAttribute("data-skin");
+  }, [options.skin]);
+  const changeOptions = (patch) => setOptions((o) => saveOptions({ ...o, ...patch }));
 
   // Timer-Segmente: bei Wechsel aktiv <-> inaktiv die verstrichene Zeit verbuchen.
   useEffect(() => {
@@ -67,13 +81,13 @@ export function Autostich() {
   // Beim Auflösen die zeit-eskalierten Niederlagenkosten (#32) aus der LIVE aktiven Zeit berechnen
   // und als Payload injizieren (Determinismus: der reine Layer sieht kein Date).
   useEffect(() => {
-    if (state.phase !== "play" || paused) return;
+    if (state.phase !== "play" || paused || showOptions) return;
     const id = setTimeout(() => {
       const nowElapsed = timeBase.current + (segStart.current != null ? Date.now() - segStart.current : 0);
       dispatch({ type: "RESOLVE_TRICK", rng: Math.random, lossCost: lossCostFor(nowElapsed) });
     }, flipMs);
     return () => clearTimeout(id);
-  }, [state.phase, state.trickNo, paused, state.speedPct, speedMult]);
+  }, [state.phase, state.trickNo, paused, showOptions, state.speedPct, speedMult]);
 
   // Geist-Trajektorie des laufenden Runs mitschreiben.
   useEffect(() => {
@@ -160,13 +174,16 @@ export function Autostich() {
 
   return (
     <div className="min-h-screen w-full flex justify-center px-4 py-6">
+      {/* CRT-Scanline-/Vignette-Overlay (#41) — immer im DOM, nur unter [data-skin="crt"]
+          sichtbar (CSS), klick-durchlässig. */}
+      <div className="crt-overlay" aria-hidden="true" />
       <div className="w-full max-w-5xl grid gap-4">
         {state.phase === "menu" ? (
-          <StartScreen onStart={startRun} highscores={highscores} best={best} />
+          <StartScreen onStart={startRun} highscores={highscores} best={best} onOptions={() => setShowOptions(true)} />
         ) : (<>
           <header className="flex items-end justify-between flex-wrap gap-2">
             <div>
-              <h1 className="text-2xl font-bold tracking-tight">
+              <h1 className="text-2xl font-bold tracking-tight font-pixel crt-title as-wordmark-header">
                 AUTO<span style={{ color: "#8a7de0" }}>STICH</span>
               </h1>
               <p className="text-xs opacity-45">Roguelite-Autobattler-Stechspiel · Prototyp</p>
@@ -174,11 +191,11 @@ export function Autostich() {
             <div className="flex items-end gap-5">
               <div className="text-right">
                 <div className="text-[10px] uppercase tracking-wide opacity-50">Zeit{paused ? " ⏸" : ""}</div>
-                <div className="text-xl font-bold" style={{ fontVariantNumeric: "tabular-nums" }}>{fmtDuration(elapsedMs)}</div>
+                <div className="text-xl font-bold font-pixel-dense" style={{ fontVariantNumeric: "tabular-nums" }}>{fmtDuration(elapsedMs)}</div>
               </div>
               <div className="text-right">
                 <div className="text-[10px] uppercase tracking-wide opacity-50">Score</div>
-                <div className="text-xl font-bold" style={{ color: "#d4a63a" }}>
+                <div className="text-xl font-bold font-pixel-dense" style={{ color: "#d4a63a" }}>
                   {Math.floor(state.score).toLocaleString("de-DE")}
                   {ghost.hasGhost && (ghost.passed ? (
                     <span className="text-xs font-normal ml-2" style={{ color: "#8a7de0" }}>⚑ Rekord</span>
@@ -193,7 +210,7 @@ export function Autostich() {
               <div className="text-right">
                 <div className="text-[10px] uppercase tracking-wide opacity-50">Mult</div>
                 <div className="text-xl font-bold leading-none pt-0.5">
-                  <span key={multPulse} className="inline-block rounded px-1.5 py-0.5 text-base"
+                  <span key={multPulse} className="inline-block rounded px-1.5 py-0.5 text-base font-pixel-dense"
                     title="Score-Multiplikator: Siegesserie (Basis, immer +2 %/Stufe bis +30 %) × D1 × Tempo — D2 verstärkt die Serie zusätzlich"
                     style={{ fontVariantNumeric: "tabular-nums",
                              background: multHot ? "#d4a63a22" : "#ffffff0f",
@@ -205,7 +222,7 @@ export function Autostich() {
               </div>
               <div className="text-right">
                 <div className="text-[10px] uppercase tracking-wide opacity-50">Bester Score</div>
-                <div className="text-xl font-bold" style={{ color: "#d4a63a" }}>{best.toLocaleString("de-DE")}</div>
+                <div className="text-xl font-bold font-pixel-dense" style={{ color: "#d4a63a" }}>{best.toLocaleString("de-DE")}</div>
               </div>
             </div>
           </header>
@@ -213,7 +230,7 @@ export function Autostich() {
           <Controls
             paused={paused} onTogglePause={() => setPaused((p) => !p)}
             speedMult={speedMult} onSpeed={(m) => setSpeedMult((cur) => (cur === m ? 1 : m))}
-            onRestart={startRun} onAbort={toMenu}
+            onRestart={startRun} onAbort={toMenu} onOptions={() => setShowOptions(true)}
           />
 
           <div className="grid lg:grid-cols-[1fr_340px] gap-4 items-start">
@@ -225,7 +242,7 @@ export function Autostich() {
           </div>
 
           {/* Chronik — Deck-Werte-Histogramm, volle Breite ganz unten (#28) */}
-          <div className="rounded-xl p-4" style={{ background: "#17171c", border: "1px solid #26262e" }}>
+          <div className="rounded-xl p-4 as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
             <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">Chronik — Deck-Werte je Farbe</div>
             <DeckHistogram deck={state.deck} />
           </div>
@@ -241,6 +258,10 @@ export function Autostich() {
       {state.phase === "gameover" && (
         <GameOver state={{ ...state, runId: runId.current }} highscores={highscores} isRecord={isRecord} timeStr={fmtDuration(elapsedMs)}
           currentTraj={currentTraj.current} recordTraj={runStartRecordTraj.current} onRestart={startRun} onMenu={toMenu} />
+      )}
+
+      {showOptions && (
+        <OptionsModal options={options} onChange={changeOptions} onClose={() => setShowOptions(false)} />
       )}
     </div>
   );

--- a/src/game/storage.js
+++ b/src/game/storage.js
@@ -43,3 +43,18 @@ export function recordHighscore(entry) {
   try { localStorage.setItem("as_highscores", JSON.stringify(top)); } catch (e) {}
   return top;
 }
+
+/* OPTIONEN (#41) — bewusst als erweiterbares Objekt (künftig Sound, Tempo-Default …).
+   Aktuell nur `skin`: "off" (Default, heutiger Look) | "crt" (Retro-CRT-Skin). */
+const DEFAULT_OPTIONS = { skin: "off" };
+export function loadOptions() {
+  try {
+    const raw = localStorage.getItem("as_options");
+    if (raw) { const o = JSON.parse(raw); if (o && typeof o === "object") return { ...DEFAULT_OPTIONS, ...o }; }
+  } catch (e) {}
+  return { ...DEFAULT_OPTIONS };
+}
+export function saveOptions(opts) {
+  try { localStorage.setItem("as_options", JSON.stringify(opts)); } catch (e) {}
+  return opts;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,9 @@ button { font-family: inherit; }
 @keyframes as-deal-left  { from { transform: translateX(-150px) translateY(-10px) scale(.9); opacity:0; } to { transform:none; opacity:1; } }
 @keyframes as-deal-right { from { transform: translateX( 150px) translateY(-10px) scale(.9); opacity:0; } to { transform:none; opacity:1; } }
 
-/* Game-Feel / „Juice" beim Stich (#15). Dauer wird inline an den Flip-Takt gekoppelt. */
+/* Game-Feel / „Juice" beim Stich (#15). Dauer wird inline an den Flip-Takt gekoppelt.
+   Hinweis: as-pop / as-pop-crit sind aktuell ungenutzt — der Gewinnerkarten-Pop wurde
+   bewusst rausgenommen (Battlefield.jsx). Keyframes bleiben für ein leichtes Re-Enable. */
 @keyframes as-pop    { 0% { transform: scale(1); } 45% { transform: scale(1.14); } 100% { transform: scale(1); } }
 @keyframes as-float  { 0% { opacity:0; transform: translateY(8px); } 18% { opacity:1; } 100% { opacity:0; transform: translateY(-40px); } }
 @keyframes as-flash  { 0% { box-shadow: 0 0 0 0 transparent; } 30% { box-shadow: 0 0 0 2px var(--flash); } 100% { box-shadow: 0 0 0 0 transparent; } }
@@ -33,4 +35,100 @@ button { font-family: inherit; }
     animation-iteration-count: 1 !important;
     transition-duration: 0.001ms !important;
   }
+}
+
+/* ============================================================================
+   CRT-/PIXEL-SKIN (#41) — komplett additiv. Alles unten ist entweder ungenutzt
+   (Default) oder hinter [data-skin="crt"] gated, damit der aktuelle Look
+   unberührt bleibt, solange der Skin aus ist.
+   Pixel-Schriften self-hosted, aus src/ referenziert -> Vite bundlet und hasht
+   den Pfad (funktioniert unter dem Pages-Subpfad /autostich/).
+   ============================================================================ */
+@font-face {
+  font-family: "Press Start 2P";
+  src: url("./assets/fonts/PressStart2P.ttf") format("truetype");
+  font-weight: 400; font-style: normal; font-display: swap;
+}
+@font-face {
+  font-family: "VT323";
+  src: url("./assets/fonts/VT323-Regular.ttf") format("truetype");
+  font-weight: 400; font-style: normal; font-display: swap;
+}
+
+/* Font-Utilities — nur unter Skin aktiv, sonst No-op (Default-Font bleibt).
+   Selektiv angewandt (Titel/Kartenzahlen/Ueberschriften bzw. dichte Zahlen-Labels). */
+[data-skin="crt"] .font-pixel {
+  font-family: "Press Start 2P", ui-monospace, monospace;
+  letter-spacing: 0;
+  text-shadow: 0 0 6px currentColor, 0 0 14px currentColor; /* Neon-Glow, folgt der Textfarbe */
+}
+[data-skin="crt"] .font-pixel-dense {
+  font-family: "VT323", ui-monospace, monospace;
+  letter-spacing: 0.5px;
+}
+
+/* Gradient-Titel (weiss->violett) + Glow fuer die AUTOSTICH-Wortmarke.
+   Der `*`-Teil zieht auch farbige Inner-Spans (z. B. STICH) in den transparenten
+   Fill, damit der Verlauf durchgehend uebers ganze Wort laeuft. */
+[data-skin="crt"] .crt-title {
+  background: linear-gradient(90deg, #ffffff, #e6e1f7, #8a7de0, #b3a8ff, #8a7de0, #e6e1f7, #ffffff);
+  background-size: 200% auto;
+  -webkit-background-clip: text; background-clip: text;
+  filter: drop-shadow(0 0 8px #8a7de0aa);
+  animation: as-title-sweep 7s linear infinite;
+}
+@keyframes as-title-sweep { from { background-position: 0% center; } to { background-position: 200% center; } }
+[data-skin="crt"] .crt-title,
+[data-skin="crt"] .crt-title * {
+  color: transparent; -webkit-text-fill-color: transparent;
+  text-shadow: none;
+}
+
+/* Kartenzahl: Press Start 2P ist breit -> kleiner als das text-5xl-Original. */
+[data-skin="crt"] .card-num {
+  font-family: "Press Start 2P", ui-monospace, monospace;
+  font-size: 1.9rem; line-height: 1;
+  text-shadow: 0 0 8px currentColor;
+}
+
+/* Press Start 2P ist breiter -> Groessen der Wortmarke/des Banners herunterregeln. */
+[data-skin="crt"] .as-wordmark-header { font-size: 1rem; line-height: 1.3; }
+[data-skin="crt"] .as-wordmark-hero   { font-size: 1.9rem; line-height: 1.35; }
+[data-skin="crt"] .as-banner          { font-size: 0.9rem; letter-spacing: 0; }
+
+/* Scanline-/Vignette-Overlay — global ueber allem, aber klick-durchlaessig.
+   Immer im DOM (in App gerendert), nur unter Skin sichtbar. */
+.crt-overlay { display: none; }
+[data-skin="crt"] .crt-overlay {
+  display: block;
+  position: fixed; inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  background:
+    repeating-linear-gradient(to bottom, rgba(0,0,0,0) 0px, rgba(0,0,0,0) 2px, rgba(0,0,0,0.22) 3px, rgba(0,0,0,0) 4px),
+    radial-gradient(ellipse at center, rgba(0,0,0,0) 55%, rgba(0,0,0,0.5) 100%);
+}
+
+/* Dezentes Neon-Leuchten fuer Karten unter Skin (Default: keine Aenderung). */
+[data-skin="crt"] .as-card {
+  box-shadow: 0 0 0 1px rgba(138,125,224,0.25), 0 0 16px rgba(138,125,224,0.18);
+}
+
+/* Panel-Rahmen unter Skin: heller + animierter Verlauf wie der Titel. Longhands
+   (nicht `background`-Shorthand) mit !important, damit background-position frei fuer
+   die Animation bleibt und der Rahmen nicht statisch wird. */
+[data-skin="crt"] .as-panel {
+  border: 1px solid transparent !important;
+  background-image:
+    linear-gradient(#17171c, #17171c),
+    linear-gradient(90deg, #3a3a48 0%, #8a7de0 25%, #b3a8ff 50%, #8a7de0 75%, #3a3a48 100%) !important;
+  background-origin: padding-box, border-box !important;
+  background-clip: padding-box, border-box !important;
+  background-size: auto, 200% auto !important;
+  animation: as-panel-sweep 7s linear infinite;
+  box-shadow: 0 0 14px rgba(138,125,224,0.12);
+}
+@keyframes as-panel-sweep {
+  from { background-position: 0% center, 0% center; }
+  to   { background-position: 0% center, 200% center; }
 }

--- a/src/ui/Battlefield.jsx
+++ b/src/ui/Battlefield.jsx
@@ -64,24 +64,21 @@ export function Battlefield({ lastTrick, remaining = TRICKS_PER_CYCLE, flipMs = 
   // Effektdauern an den Flip-Takt koppeln; unter reduzierter Bewegung Animationen weglassen
   // (Element bleibt statisch sichtbar statt zu Ende-Opacity 0 zu springen).
   const anim = clamp(flipMs * 0.5, 120, 450);
-  const pop = clamp(flipMs * 0.35, 140, 320);
   const fx = (a) => (reduced ? undefined : a);
 
-  const dealStyle = (dealName, isWinner) => ({
-    animation: isWinner
-      ? `${dealName} ${anim}ms ease-out, ${isCrit ? "as-pop-crit" : "as-pop"} ${pop}ms ease-out ${anim}ms`
-      : `${dealName} ${anim}ms ease-out`,
-  });
+  // Karten „dealen" nur noch rein — der zusätzliche Pop-Bounce der Gewinnerkarte ist
+  // raus (Wunsch: ruhiger). Der Score-/Schaden-Float über der Karte bleibt erhalten.
+  const dealStyle = (dealName) => ({ animation: `${dealName} ${anim}ms ease-out` });
 
   const playerCard = t ? (
-    <div key={`p${t.trickNo}`} className="relative" style={dealStyle("as-deal-left", win)}>
+    <div key={`p${t.trickNo}`} className="relative" style={dealStyle("as-deal-left")}>
       <Card suit={t.pCard.suit} value={t.pCard.value} baseRank={t.pCard.baseRank}
             stichBonus={t.pValue - t.pCard.value} glow={win ? (isCrit ? critColor : "#5ab87a") : null} />
     </div>
   ) : <div className="relative"><CardBack label="" /></div>;
 
   const oppCard = t ? (
-    <div key={`o${t.trickNo}`} className="relative" style={dealStyle("as-deal-right", lost)}>
+    <div key={`o${t.trickNo}`} className="relative" style={dealStyle("as-deal-right")}>
       <Card suit={t.oCard.suit} value={t.oValue} baseRank={t.oCard.baseRank} glow={lost ? "#e0605a" : null} />
     </div>
   ) : <div className="relative"><CardBack label="" /></div>;
@@ -94,7 +91,7 @@ export function Battlefield({ lastTrick, remaining = TRICKS_PER_CYCLE, flipMs = 
   const comboStr = t ? t.comboMult.toFixed(1).replace(".", ",") : "";
 
   return (
-    <div className="rounded-xl p-6 overflow-hidden" style={{ background: "#17171c", border: "1px solid #26262e" }}>
+    <div className="rounded-xl p-6 overflow-hidden as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
       <div className="relative flex items-center justify-center gap-4 sm:gap-8">
         {/* KRITISCH-/JACKPOT-Text (#33) — bei reduzierter Bewegung statisch „… ×N". */}
         {isCrit && (
@@ -151,7 +148,7 @@ export function Battlefield({ lastTrick, remaining = TRICKS_PER_CYCLE, flipMs = 
 
       <div className="h-8 mt-4 flex items-center justify-center">
         {banner ? (
-          <span className="text-lg font-bold tracking-wide" style={{ color: banner.color }}>{banner.text}</span>
+          <span className="text-lg font-bold tracking-wide font-pixel as-banner" style={{ color: banner.color }}>{banner.text}</span>
         ) : (
           <span className="opacity-40 text-sm">Bereit — starte den Autobattler</span>
         )}

--- a/src/ui/BuildPanel.jsx
+++ b/src/ui/BuildPanel.jsx
@@ -4,7 +4,7 @@ import { PerkList } from "./BuildSummary.jsx";
    Das Deck-Histogramm ist als eigener „Chronik"-Block ganz nach unten gewandert (#28). */
 export function BuildPanel({ perks }) {
   return (
-    <div className="rounded-xl p-4" style={{ background: "#17171c", border: "1px solid #26262e" }}>
+    <div className="rounded-xl p-4 as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
       <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">
         Build — {perks.length} Perk{perks.length === 1 ? "" : "s"}
       </div>

--- a/src/ui/Card.jsx
+++ b/src/ui/Card.jsx
@@ -11,7 +11,7 @@ export function Card({ suit, value, baseRank = null, stichBonus = 0, dim = false
   const effective = value + stichBonus;
   return (
     <div
-      className="relative rounded-xl border-2 flex flex-col items-center justify-center select-none transition-all"
+      className="as-card relative rounded-xl border-2 flex flex-col items-center justify-center select-none transition-all"
       style={{
         borderColor: color,
         width: 104, height: 144, background: "#1c1c22",
@@ -29,7 +29,7 @@ export function Card({ suit, value, baseRank = null, stichBonus = 0, dim = false
           +{permBoost}
         </div>
       )}
-      <div className="text-5xl font-bold" style={{ color }}>{effective}</div>
+      <div className="text-5xl font-bold card-num" style={{ color }}>{effective}</div>
       <div className="absolute bottom-1.5 flex flex-col items-center leading-tight text-[10px]">
         {permBoost > 0 && <span className="opacity-55">Basis {baseRank}</span>}
         {stichBonus > 0 && <span style={{ color: "#e0605a" }}>⚔ +{stichBonus} Stich</span>}

--- a/src/ui/Controls.jsx
+++ b/src/ui/Controls.jsx
@@ -16,9 +16,9 @@ function Btn({ active, onClick, disabled, children, tone = "#5a8ade" }) {
 }
 
 /* Ablauf-Steuerung. Das Spiel läuft immer automatisch — nur Pause hält an (#29). */
-export function Controls({ paused, onTogglePause, speedMult, onSpeed, onRestart, onAbort }) {
+export function Controls({ paused, onTogglePause, speedMult, onSpeed, onRestart, onAbort, onOptions }) {
   return (
-    <div className="rounded-xl p-3 flex flex-wrap items-center gap-2" style={{ background: "#17171c", border: "1px solid #26262e" }}>
+    <div className="rounded-xl p-3 flex flex-wrap items-center gap-2 as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
       <Btn active={paused} onClick={onTogglePause} tone="#d4a63a">
         {paused ? "▶ Weiter" : "⏸ Pause"}
       </Btn>
@@ -28,6 +28,7 @@ export function Controls({ paused, onTogglePause, speedMult, onSpeed, onRestart,
       <Btn active={speedMult === 3} onClick={() => onSpeed(3)} tone="#8a7de0">3×</Btn>
 
       <div className="flex-1" />
+      {onOptions && <Btn onClick={onOptions} tone="#8a7de0" aria-label="Optionen">⚙ Optionen</Btn>}
       {onAbort && <Btn onClick={onAbort} tone="#8a8a92">Beenden</Btn>}
       <Btn onClick={onRestart} tone="#e0605a">Neustart</Btn>
     </div>

--- a/src/ui/OptionsModal.jsx
+++ b/src/ui/OptionsModal.jsx
@@ -1,0 +1,70 @@
+/* Optionen-Overlay (#41): erreichbar aus dem Menü UND im laufenden Run (dort pausiert
+   der Lauf, solange offen). Bewusst erweiterbar — künftig Sound, Tempo-Default etc.
+   Erste Option: der CRT-/Pixel-Skin-Toggle. */
+
+/* Ein/Aus-Schalter im Stil der übrigen UI. */
+function Toggle({ on, onClick }) {
+  return (
+    <button
+      role="switch"
+      aria-checked={on}
+      onClick={onClick}
+      className="relative rounded-full transition-all shrink-0"
+      style={{
+        width: 46, height: 26,
+        background: on ? "#5ab87a" : "#30303a",
+        border: `1px solid ${on ? "#5ab87a" : "#3a3a44"}`,
+      }}
+    >
+      <span
+        className="absolute top-1/2 rounded-full transition-all"
+        style={{
+          width: 20, height: 20, background: "#f2f2f4",
+          transform: "translateY(-50%)",
+          left: on ? 22 : 2,
+        }}
+      />
+    </button>
+  );
+}
+
+/* Eine Options-Zeile: Titel + Beschreibung links, Steuerung rechts. */
+function Row({ title, desc, children }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg p-3" style={{ background: "#20202a" }}>
+      <div className="flex-1">
+        <div className="font-bold text-sm">{title}</div>
+        {desc && <div className="text-sm opacity-70 leading-snug">{desc}</div>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function OptionsModal({ options, onChange, onClose }) {
+  const crtOn = options.skin === "crt";
+  return (
+    <div className="fixed inset-0 z-30 flex items-center justify-center p-4" style={{ background: "#0c0c10cc", backdropFilter: "blur(3px)" }}>
+      <div className="w-full max-w-lg rounded-2xl p-6 max-h-[90vh] overflow-y-auto" style={{ background: "#181820", border: "1px solid #33333e" }}>
+        <div className="text-center mb-4">
+          <div className="text-xs uppercase tracking-widest" style={{ color: "#8a7de0" }}>Optionen</div>
+          <h2 className="text-xl font-bold mt-1 font-pixel crt-title">Einstellungen</h2>
+        </div>
+
+        <div className="grid gap-2.5">
+          <Row title="Retro-Skin (CRT)" desc="Pixel-Schrift, Scanlines, Neon-Glow. Rein optisch — Layout & Spiel bleiben gleich.">
+            <Toggle on={crtOn} onClick={() => onChange({ skin: crtOn ? "off" : "crt" })} />
+          </Row>
+        </div>
+
+        <div className="rounded-lg p-3 mt-3 text-xs text-center leading-snug" style={{ background: "#8a7de022", color: "#c9c0f0" }}>
+          Weitere Optionen (Sound, Tempo-Default …) folgen hier.
+        </div>
+
+        <button onClick={onClose} className="w-full mt-5 py-2.5 rounded-lg font-bold transition-all" style={{ background: "#5ab87a", color: "#141419" }}>
+          Schließen
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/StartScreen.jsx
+++ b/src/ui/StartScreen.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { AnleitungModal } from "./AnleitungModal.jsx";
 
 /* Startbildschirm (#4): Einstieg mit „Neuer Run", Anleitung (#12) und lokaler Bestenliste. */
-export function StartScreen({ onStart, highscores, best }) {
+export function StartScreen({ onStart, highscores, best, onOptions }) {
   const [showGuide, setShowGuide] = useState(false);
 
   // Beim allerersten Start die Anleitung einmal automatisch zeigen (#12).
@@ -17,7 +17,7 @@ export function StartScreen({ onStart, highscores, best }) {
   return (
     <div className="grid gap-5 justify-items-center py-10">
       <div className="text-center">
-        <h1 className="text-4xl font-bold tracking-tight">
+        <h1 className="text-4xl font-bold tracking-tight font-pixel crt-title as-wordmark-hero">
           AUTO<span style={{ color: "#8a7de0" }}>STICH</span>
         </h1>
         <p className="text-sm opacity-45 mt-1">Roguelite-Autobattler-Stechspiel · Prototyp</p>
@@ -38,9 +38,19 @@ export function StartScreen({ onStart, highscores, best }) {
         >
           Anleitung
         </button>
+        {onOptions && (
+          <button
+            onClick={onOptions}
+            aria-label="Optionen"
+            className="px-6 py-3 rounded-xl text-lg font-semibold transition-all"
+            style={{ background: "#20202a", color: "#e8e8ea", border: "1px solid #30303a" }}
+          >
+            ⚙ Optionen
+          </button>
+        )}
       </div>
 
-      <div className="w-full max-w-sm rounded-xl p-4" style={{ background: "#17171c", border: "1px solid #26262e" }}>
+      <div className="w-full max-w-sm rounded-xl p-4 as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
         <div className="flex items-center justify-between mb-2">
           <span className="text-[11px] uppercase tracking-wide opacity-50">Highscore</span>
           <span className="text-sm font-bold" style={{ color: "#d4a63a" }}>

--- a/src/ui/StatusRail.jsx
+++ b/src/ui/StatusRail.jsx
@@ -45,7 +45,7 @@ export function StatusRail({ state, speedPct, lossCost = 10, currentTraj = [], r
   // Passiver Indikator der zeit-eskalierten Niederlagenkosten (#32): grün → gelb → rot je Stufe.
   const lossColor = lossCost <= 10 ? "#5ab87a" : lossCost <= 20 ? "#d4a63a" : "#e0605a";
   return (
-    <div className="rounded-xl p-4 grid gap-3" style={{ background: "#17171c", border: "1px solid #26262e" }}>
+    <div className="rounded-xl p-4 grid gap-3 as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
       {/* Leben */}
       <div>
         <div className="flex justify-between text-xs mb-1">


### PR DESCRIPTION
Schließt #41.

Zuschaltbarer **Retro-CRT-Skin** + neuer **Optionen**-Zugang (⚙) — im Menü **und** im laufenden Run. Der aktuelle Look bleibt **Default**; der Skin ist rein additiv und jederzeit umschaltbar.

## Umgesetzt

**Teil A — Optionen**
- Neues `OptionsModal.jsx` (bewusst erweiterbar; erste Option = Skin-Toggle), ⚙ in `StartScreen` und `Controls`.
- Run **pausiert** bei offenem Overlay (Timer + Auto-Play einfrieren), ohne den Pause-Toggle zu verändern.
- Persistenz via `loadOptions`/`saveOptions` (localStorage `as_options`), übersteht Reload.

**Teil 0 — Pixel-Fonts**
- Self-hosted Press Start 2P + VT323 (OFL) via `@font-face`, aus `src/` referenziert → Vite bundlet & hasht → subpfad-sicher unter `/autostich/`.
- `.font-pixel` (Titel/Kartenzahlen/Banner) + `.font-pixel-dense` (dichte Zahlen), selektiv, nie global.

**Teil B — CRT-Skin** (alles `[data-skin="crt"]`-gated am `<html>`)
- Scanline-/Vignette-Overlay (`fixed`, klick-durchlässig), Neon-Glow, Gradient-Titel.
- **Animierter Titel-Verlauf** (`as-title-sweep`) läuft durchs ganze Wort AUTOSTICH.
- **Hellere, animierte Panel-Rahmen** (`as-panel-sweep`) auf den 6 Haupt-Panels.

**Game-Feel (immer aktiv)**
- Gewinnerkarten-Pop entfernt; Score-/Leben-Float über der Karte bleibt.

## Akzeptanzkriterien (#41)
- [x] Optionen-Knopf im Menü **und** im Run; öffnet Overlay
- [x] Skin-Toggle an/aus; Default = aktueller Look, unberührt
- [x] Persistiert (localStorage), übersteht Reload
- [x] Pixel-Font self-hosted (kein CDN), lädt unter `/autostich/` — im Production-Build verifiziert (`url(/autostich/assets/…ttf)`)
- [x] `prefers-reduced-motion` respektiert (global neutralisiert)
- [x] Nichts extern gefetcht; Default-Look unberührt

## Verifikation
- Dev-Server: Skin-Toggle, Persistenz, Pause-on-open, Font-Anwendung, animierte Titel/Panel-Rahmen — per DOM/Computed-Styles geprüft.
- Sauberer Production-Build: Fonts gehasht unter `/autostich/`, alle Skin-Regeln/Keyframes vorhanden.
- `npm test`: 104/104 grün.

## Offene Nachzüge (bewusst nicht in v1)
- Deko-/Partikel-Sprites (Lorbeer/Schwerter) als optionaler Nachzug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)