### PR TITLE
StartScreen-Karten-Logo (#45) + StatusRail Tempo-Score statt Score-Mult-Pop (#46)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -114,6 +114,12 @@ button { font-family: inherit; }
   box-shadow: 0 0 0 1px rgba(138,125,224,0.25), 0 0 16px rgba(138,125,224,0.18);
 }
 
+/* Karten-Logo (#45): unter dem CRT-Skin kraeftigerer Neon-Glow in der jeweiligen Kartenfarbe.
+   --glow-ring / --glow-halo werden je Karte inline gesetzt (CardLogo.jsx). Default bleibt dezent. */
+[data-skin="crt"] .as-logo-card {
+  box-shadow: 0 0 0 2px var(--glow-ring), 0 0 26px var(--glow-halo);
+}
+
 /* Panel-Rahmen unter Skin: heller + animierter Verlauf wie der Titel. Longhands
    (nicht `background`-Shorthand) mit !important, damit background-position frei fuer
    die Animation bleibt und der Rahmen nicht statisch wird. */

--- a/src/ui/CardLogo.jsx
+++ b/src/ui/CardLogo.jsx
@@ -1,0 +1,32 @@
+/* Dekoratives Karten-Logo (#45): zwei überlappende, leicht gefächerte Karten im Stil unserer
+   echten Spielkarten (Farbe + Wert — keine K/Q/Pips), mit Neon-Glow. Unter dem CRT-Skin (#41)
+   verstärkt sich der Glow via [data-skin="crt"] .as-logo-card in index.css.
+   Rein dekorativ: aria-hidden, nicht interaktiv, statisch (keine Animation → reduced-motion-neutral). */
+function MiniCard({ suit, value, color, style }) {
+  return (
+    <div
+      className="as-logo-card absolute rounded-lg border-2 flex items-center justify-center"
+      style={{
+        width: 68, height: 96, background: "#1c1c22", borderColor: color,
+        // im Default dezent, tasteful; die Vars steuern die verstärkte CRT-Variante.
+        "--glow-ring": `${color}88`, "--glow-halo": `${color}55`,
+        boxShadow: `0 0 0 1.5px ${color}66, 0 0 14px ${color}44`,
+        ...style,
+      }}
+    >
+      <span className="absolute top-1 left-1.5 text-[8px] uppercase tracking-wide" style={{ color }}>{suit}</span>
+      <span className="text-3xl font-bold card-num" style={{ color }}>{value}</span>
+    </div>
+  );
+}
+
+export function CardLogo() {
+  return (
+    <div aria-hidden="true" className="relative pointer-events-none select-none" style={{ width: 132, height: 104 }}>
+      {/* hintere Karte (grün), nach links gefächert */}
+      <MiniCard suit="Grün" value={9} color="#5ab87a" style={{ left: 6, top: 6, transform: "rotate(-9deg)" }} />
+      {/* vordere Karte (rot), nach rechts gefächert, teils über der hinteren */}
+      <MiniCard suit="Rot" value={7} color="#e0605a" style={{ left: 58, top: 2, transform: "rotate(9deg)" }} />
+    </div>
+  );
+}

--- a/src/ui/StartScreen.jsx
+++ b/src/ui/StartScreen.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { AnleitungModal } from "./AnleitungModal.jsx";
+import { CardLogo } from "./CardLogo.jsx";
 
 /* Startbildschirm (#4): Einstieg mit „Neuer Run", Anleitung (#12) und lokaler Bestenliste. */
 export function StartScreen({ onStart, highscores, best, onOptions }) {
@@ -15,13 +16,16 @@ export function StartScreen({ onStart, highscores, best, onOptions }) {
   };
 
   return (
-    <div className="grid gap-5 justify-items-center py-10">
+    <div className="grid gap-5 justify-items-center content-start py-10">
       <div className="text-center">
         <h1 className="text-4xl font-bold tracking-tight font-pixel crt-title as-wordmark-hero">
           AUTO<span style={{ color: "#8a7de0" }}>STICH</span>
         </h1>
         <p className="text-sm opacity-45 mt-1">Roguelite-Autobattler-Stechspiel · Prototyp</p>
       </div>
+
+      {/* Dekoratives Karten-Logo (#45) — rein optisch, unter dem CRT-Skin mit stärkerem Neon-Glow. */}
+      <CardLogo />
 
       <div className="flex flex-wrap gap-3 justify-center">
         <button

--- a/src/ui/StatusRail.jsx
+++ b/src/ui/StatusRail.jsx
@@ -1,6 +1,6 @@
 import { xpToNext } from "../game/leveling.js";
 import { TRICKS_PER_CYCLE } from "../game/constants.js";
-import { critChanceFor, hasCritPerk, baseScoreMultFor, critMultiplierFor } from "../game/perks.js";
+import { critChanceFor, hasCritPerk, tempoScoreMultFor, critMultiplierFor } from "../game/perks.js";
 import { Sparkline } from "./Sparkline.jsx";
 
 function Bar({ value, max, color, height = 8 }) {
@@ -27,9 +27,10 @@ export function StatusRail({ state, speedPct, lossCost = 10, currentTraj = [], r
   const remaining = TRICKS_PER_CYCLE - pos; // Karten bis zum nächsten Mischen (#6)
   const decided = wins + losses;            // Gleichstände zählen nicht als entschieden (§4.4)
   const winPct = decided > 0 ? Math.round((wins / decided) * 100) : 0;
-  // Gesamt-Score-Multiplikator (#23) — geteilte Quelle mit dem Header-Chip (#37), kein Drift.
+  // Gesamt-Score-Mult sitzt dauerhaft im Header-Chip (#37) — hier NICHT doppeln (#46).
+  // Nur der Tempo-Score-Anteil (monoton, poppt nicht) bleibt im Panel sichtbar.
   const fmtMult = (x) => x.toFixed(2).replace(".", ",");
-  const baseScoreMult = baseScoreMultFor(perks, { winStreak, wins, trickNo, pos, speedPct });
+  const tempoScoreMult = tempoScoreMultFor(perks, speedPct);
   const ownsD4 = perks.includes("D4");
   const showCrit = hasCritPerk(perks) || (crits || 0) > 0;
   // Live-Crit-Chance des NÄCHSTEN Siegs: D8 nutzt die resultierende Serie (winStreak+1), analog zum
@@ -101,11 +102,12 @@ export function StatusRail({ state, speedPct, lossCost = 10, currentTraj = [], r
         </div>
         <Bar value={remaining} max={TRICKS_PER_CYCLE} color="#5a8ade" height={6} />
       </div>
-      {/* Score-Multiplikator, Tempo & Crit (#19/#23) */}
-      {(baseScoreMult > 1.001 || showCrit) && (
+      {/* Tempo-Score & Crit (#19/#46). Der Gesamt-Score-Mult steht dauerhaft im Header-Chip (#37);
+          hier bewusst nur der Tempo-Score-Anteil — monoton (folgt den Tempo-Perks), poppt nicht. */}
+      {(tempoScoreMult > 1.001 || ownsD4 || showCrit) && (
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs pt-1 border-t" style={{ borderColor: "#26262e" }}>
-          {baseScoreMult > 1.001 && (
-            <span title="D1 + Siegesserie + Tempo (aktuelle Serie)"><span className="opacity-50">Score </span><span style={{ color: "#d4a63a" }}>×{fmtMult(baseScoreMult)}</span></span>
+          {tempoScoreMult > 1.001 && (
+            <span title="Tempo erhöht den Score (Tempo-Perks; L6 verdoppelt den Anteil)"><span className="opacity-50">Tempo-Score </span><span style={{ color: "#5a8ade" }}>×{fmtMult(tempoScoreMult)}</span></span>
           )}
           {ownsD4 && <span className="opacity-45">×3 bei Rang ≤3</span>}
           {showCrit && (<>


### PR DESCRIPTION
Zwei kleine StartScreen-/StatusRail-Verbesserungen, beide im Browser verifiziert (Tests 104/104 gruen).

## #45 — Karten-Logo auf dem Startbildschirm
Zwei ueberlappende, gefaecherte Karten (Farbe + Wert, Gruen 9 / Rot 7) mit Neon-Glow als neue `CardLogo`-Komponente, unter dem Titel. Rein dekorativ (aria-hidden, pointer-events:none, statisch). Unter dem CRT-Skin verstaerkter Glow, im Default dezent.

Zusaetzlich der StartScreen-Grid auf `content-start`: die Zeilen wurden ueber die `min-h-screen`-Hoehe gestreckt und der Leerraum in die Abstaende verteilt (Titel->Karten 91px). Jetzt natuerliche Zeilenhoehe, Abstand 20px.

## #46 — StatusRail: kein Score-Mult-Pop mehr
Die kombinierte "Score xN"-Zeile poppte rein/raus, sobald der Wert die 1 kreuzte, und doppelte den Header-Chip (#37). Entfernt (Option A) und durch eine eigene "Tempo-Score xN"-Zeile ersetzt (monoton -> poppt nicht). Crit-Infos bleiben erhalten. Der Gesamt-Multiplikator steht weiterhin dauerhaft im Header-Chip.

Closes #45
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
