### PR TITLE
Globales Leaderboard (Supabase) + lokaler Username (#14)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,5 @@
+# Öffentliche Supabase-Config für lokales `npm run dev` (siehe .env.production).
+# Kein Secret — RLS schützt; nur select + insert erlaubt (#14). Gleiches Projekt
+# wie Prototyp 1 (TrickLadder), aber eigene Tabelle `autostich_scores`.
+VITE_SUPABASE_URL=https://gswanqcigrbjxpdasrum.supabase.co
+VITE_SUPABASE_KEY=sb_publishable_fjEtIGO3JJltkTNLW3S4aA_DkHFVHCD

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,6 @@
+# Öffentliche Supabase-Config (Publishable Key + Project URL) für den globalen
+# Highscore (#14). Bewusst committet: kein Secret — RLS erlaubt nur select + insert,
+# der Key ist explizit "safe to share publicly". Der service_role/secret Key gehört
+# NIEMALS hierher. Gleiches Projekt wie Prototyp 1, eigene Tabelle `autostich_scores`.
+VITE_SUPABASE_URL=https://gswanqcigrbjxpdasrum.supabase.co
+VITE_SUPABASE_KEY=sb_publishable_fjEtIGO3JJltkTNLW3S4aA_DkHFVHCD

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,8 @@ import { useReducer, useEffect, useRef, useState } from "react";
 import { reducer, initialState, menuState } from "./game/reducer.js";
 import { BASE_FLIP_MS, GHOST_STEP, TRICKS_PER_CYCLE, lossCostFor, lossTierFor } from "./game/constants.js";
 import { baseScoreMultFor } from "./game/perks.js";
-import { loadGhost, saveGhost, loadHighscores, recordHighscore, loadOptions, saveOptions } from "./game/storage.js";
+import { loadGhost, saveGhost, loadHighscores, recordHighscore, loadOptions, saveOptions, loadUsername, saveUsername } from "./game/storage.js";
+import { leaderboardConfigured, publishRun } from "./game/leaderboard.js";
 import { fmtDuration } from "./game/deck.js";
 import { StatusRail } from "./ui/StatusRail.jsx";
 import { Battlefield } from "./ui/Battlefield.jsx";
@@ -13,6 +14,7 @@ import { PredictionSelect } from "./ui/PredictionSelect.jsx";
 import { GameOver } from "./ui/GameOver.jsx";
 import { StartScreen } from "./ui/StartScreen.jsx";
 import { OptionsModal } from "./ui/OptionsModal.jsx";
+import { UsernameModal } from "./ui/UsernameModal.jsx";
 import { CrtParticles } from "./ui/CrtParticles.jsx";
 import { DeckHistogram } from "./ui/BuildSummary.jsx";
 
@@ -25,6 +27,12 @@ export function Autostich() {
   const [, setClock] = useState(0); // erzwingt Re-Render fürs Ticken des Timers
   const [highscores, setHighscores] = useState(() => loadHighscores());
   const [isRecord, setIsRecord] = useState(false);
+  // Globaler Highscore (#14): lokaler Nickname + Ersteinrichtungs-Modal.
+  const [username, setUsername] = useState(loadUsername);
+  const [showUsername, setShowUsername] = useState(() => !loadUsername());
+  const [myEntry, setMyEntry] = useState(null);  // zuletzt gewerteter Lauf → Hervorhebung im Global-Board
+  const [pubToken, setPubToken] = useState(0);    // bumpt nach erfolgreichem Submit → Board lädt neu
+  function onSaveUsername(name) { saveUsername(name); setUsername(name); setShowUsername(false); }
   const [lossNotice, setLossNotice] = useState(null); // kurzer Float beim Stufenwechsel der Niederlagenkosten (#32)
   const [multPulse, setMultPulse] = useState(0);      // Zähler: bumpt bei Anstieg des Score-Mults → Puls (#37)
 
@@ -105,6 +113,14 @@ export function Autostich() {
     setHighscores(recordHighscore({
       score: finalScore, level: state.level, tricks: state.trickNo, cycles: state.cycle, ts: runId.current,
     }));
+    // Globalen Lauf posten (#14) — additiv, fehlertolerant. myEntry hebt ihn im Board hervor;
+    // pubToken lädt das Board nach dem Submit neu (damit der eigene Lauf drin ist).
+    const name = (username || "").trim().slice(0, 20);
+    const gEntry = { name, score: finalScore, level: state.level, tricks: state.trickNo, cycles: state.cycle };
+    setMyEntry(gEntry);
+    if (leaderboardConfigured && name) {
+      publishRun(gEntry).then(() => setPubToken((t) => t + 1)).catch(() => {});
+    }
     if (finalScore > recordTotal.current) {
       recordTraj.current = currentTraj.current.slice();
       recordTotal.current = finalScore;
@@ -184,7 +200,8 @@ export function Autostich() {
       {options.skin === "crt" && state.phase === "menu" && <CrtParticles />}
       <div className="w-full max-w-5xl grid gap-4">
         {state.phase === "menu" ? (
-          <StartScreen onStart={startRun} highscores={highscores} best={best} onOptions={() => setShowOptions(true)} />
+          <StartScreen onStart={startRun} highscores={highscores} best={best} onOptions={() => setShowOptions(true)}
+            username={username} onEditName={() => setShowUsername(true)} myEntry={myEntry} pubToken={pubToken} />
         ) : (<>
           <header className="flex items-end justify-between flex-wrap gap-2">
             <div>
@@ -262,11 +279,17 @@ export function Autostich() {
       )}
       {state.phase === "gameover" && (
         <GameOver state={{ ...state, runId: runId.current }} highscores={highscores} isRecord={isRecord} timeStr={fmtDuration(elapsedMs)}
-          currentTraj={currentTraj.current} recordTraj={runStartRecordTraj.current} onRestart={startRun} onMenu={toMenu} />
+          currentTraj={currentTraj.current} recordTraj={runStartRecordTraj.current} onRestart={startRun} onMenu={toMenu}
+          myEntry={myEntry} pubToken={pubToken} hasUsername={!!(username || "").trim()} onEditName={() => setShowUsername(true)} />
       )}
 
       {showOptions && (
         <OptionsModal options={options} onChange={changeOptions} onClose={() => setShowOptions(false)} />
+      )}
+
+      {showUsername && (
+        <UsernameModal initial={username} firstTime={!username}
+          onSave={onSaveUsername} onClose={() => setShowUsername(false)} />
       )}
     </div>
   );

--- a/src/game/leaderboard.js
+++ b/src/game/leaderboard.js
@@ -1,0 +1,27 @@
+// Globaler Highscore via Supabase Data API (PostgREST) — dependency-frei per fetch,
+// self-contained für Pages/CSP. Publishable Key + URL sind öffentlich; RLS erlaubt
+// nur select + insert. Alle Aufrufer fangen Fehler ab (graceful degradation). (#14)
+const BASE = import.meta.env.VITE_SUPABASE_URL;
+const KEY  = import.meta.env.VITE_SUPABASE_KEY;
+export const leaderboardConfigured = !!(BASE && KEY);
+
+const REST = `${BASE}/rest/v1/autostich_scores`;
+const headers = { apikey: KEY, Authorization: `Bearer ${KEY}` };
+
+// Top-N global: Score↓, bei Gleichstand mehr Stiche, dann jünger.
+export async function fetchGlobalTop(limit = 10) {
+  const url = `${REST}?select=name,score,level,tricks,cycles,created_at&order=score.desc,tricks.desc,created_at.desc&limit=${limit}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`fetchGlobalTop ${res.status}`);
+  return res.json();
+}
+
+// Lauf veröffentlichen. entry: { name, score, level, tricks, cycles }.
+export async function publishRun(entry) {
+  const res = await fetch(REST, {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "application/json", Prefer: "return=minimal" },
+    body: JSON.stringify(entry),
+  });
+  if (!res.ok) throw new Error(`publishRun ${res.status}`);
+}

--- a/src/game/storage.js
+++ b/src/game/storage.js
@@ -21,6 +21,14 @@ export function saveGhost(traj, total) {
   try { localStorage.setItem("as_ghost", JSON.stringify({ traj, total, step: GHOST_STEP })); } catch (e) {}
 }
 
+/* Lokaler Nickname (#14) — hängt an globalen Highscore-Einträgen. Leer ⇒ „erster Start". */
+export function loadUsername() {
+  try { return localStorage.getItem("as_username") || ""; } catch (e) { return ""; }
+}
+export function saveUsername(name) {
+  try { localStorage.setItem("as_username", name); } catch (e) {}
+}
+
 /* Lokale Highscore-Liste (Top 5) — getrennt vom Geist.
    Eintrag: { score, level, tricks, cycles, ts }. */
 export function loadHighscores() {

--- a/src/ui/GameOver.jsx
+++ b/src/ui/GameOver.jsx
@@ -1,7 +1,9 @@
 import { PERK_DEFS, CATEGORIES } from "../game/perks.js";
 import { Sparkline } from "./Sparkline.jsx";
+import { GlobalLeaderboard } from "./GlobalLeaderboard.jsx";
 
-export function GameOver({ state, highscores, isRecord, timeStr, onRestart, onMenu, currentTraj = [], recordTraj = [] }) {
+export function GameOver({ state, highscores, isRecord, timeStr, onRestart, onMenu, currentTraj = [], recordTraj = [],
+  myEntry = null, pubToken = 0, hasUsername = false, onEditName }) {
   const score = Math.floor(state.score);
   return (
     <div className="fixed inset-0 z-20 flex items-center justify-center p-4" style={{ background: "#0c0c10cc", backdropFilter: "blur(3px)" }}>
@@ -67,7 +69,7 @@ export function GameOver({ state, highscores, isRecord, timeStr, onRestart, onMe
 
         {highscores.length > 0 && (
           <div className="mt-5">
-            <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">Beste Läufe</div>
+            <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">Deine Läufe</div>
             <div className="grid gap-1">
               {highscores.map((h, i) => (
                 <div key={i} className="flex justify-between text-sm px-2 py-1 rounded"
@@ -79,6 +81,15 @@ export function GameOver({ state, highscores, isRecord, timeStr, onRestart, onMe
               ))}
             </div>
           </div>
+        )}
+
+        {/* Globaler Highscore (#14) — nach dem Submit (pubToken) neu geladen, damit der
+            eigene Lauf enthalten und hervorgehoben ist. Ohne Config/offline entfällt er. */}
+        <GlobalLeaderboard mine={myEntry} reloadToken={pubToken} />
+        {!hasUsername && onEditName && (
+          <button onClick={onEditName} className="mt-2 text-xs opacity-60 hover:opacity-100 transition-opacity">
+            Namen festlegen, um im globalen Highscore zu erscheinen
+          </button>
         )}
 
         <div className="flex gap-2 mt-6">

--- a/src/ui/GlobalLeaderboard.jsx
+++ b/src/ui/GlobalLeaderboard.jsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { leaderboardConfigured, fetchGlobalTop } from "../game/leaderboard.js";
+
+/* Globaler Highscore (#14): additiv UNTER dem lokalen Block. Holt Top-N selbst und
+   degradiert lautlos — fehlende Config blendet den Block ganz aus, offline/Fehler zeigt
+   einen dezenten Hinweis. Der lokale Block (beim Aufrufer) bleibt immer unberührt.
+
+   mine        — der eigene, gerade gepostete Lauf → wird in der Liste hervorgehoben.
+   reloadToken — neu laden, sobald er sich ändert (nach dem Submit, damit der eigene
+                 Lauf enthalten ist).
+   framed      — eigener Panel-Rahmen (StartScreen). Ohne: schlichte Sektion (Game-Over). */
+export function GlobalLeaderboard({ limit = 10, mine = null, reloadToken = 0, framed = false }) {
+  const [rows, setRows] = useState(null);   // null = lädt · [] = leer · [...] = Daten
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!leaderboardConfigured) return;
+    let alive = true;
+    setError(false);
+    setRows(null);
+    fetchGlobalTop(limit)
+      .then((data) => { if (alive) setRows(Array.isArray(data) ? data : []); })
+      .catch(() => { if (alive) setError(true); });
+    return () => { alive = false; };
+  }, [limit, reloadToken]);
+
+  if (!leaderboardConfigured) return null; // ohne Config: Block entfällt komplett
+
+  // Eigenen Lauf genau einmal hervorheben (erste Übereinstimmung).
+  let flagged = false;
+  const isMine = (r) => {
+    if (flagged || !mine || !mine.name) return false;
+    const hit = r.name === mine.name && r.score === mine.score && r.level === mine.level
+      && r.tricks === mine.tricks && r.cycles === mine.cycles;
+    if (hit) flagged = true;
+    return hit;
+  };
+
+  const body = (
+    <>
+      <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">Global — Top {limit}</div>
+      {error ? (
+        <div className="text-xs opacity-40 text-center py-3">Global nicht verfügbar.</div>
+      ) : rows === null ? (
+        <div className="text-xs opacity-40 text-center py-3">Lädt globale Bestenliste …</div>
+      ) : rows.length === 0 ? (
+        <div className="text-xs opacity-40 text-center py-3">Noch keine globalen Einträge — sei die/der Erste.</div>
+      ) : (
+        <div className="grid gap-1">
+          {rows.map((r, i) => {
+            const mineRow = isMine(r);
+            return (
+              <div key={i} className="flex items-center gap-2 text-sm px-2 py-1 rounded"
+                style={{ background: mineRow ? "#5ab87a22" : "#20202a",
+                  border: `1px solid ${mineRow ? "#5ab87a66" : "transparent"}` }}>
+                <span className="opacity-50 w-6 shrink-0">#{i + 1}</span>
+                <span className="flex-1 truncate" style={{ color: mineRow ? "#5ab87a" : "#e8e8ea" }}>
+                  {r.name || "—"}{mineRow && <span className="opacity-60 text-xs"> · du</span>}
+                </span>
+                <span className="font-bold shrink-0" style={{ color: "#d4a63a" }}>{r.score.toLocaleString("de-DE")}</span>
+                <span className="opacity-40 text-xs shrink-0">Lvl {r.level} · {r.tricks}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+
+  return framed ? (
+    <div className="w-full max-w-sm rounded-xl p-4 as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
+      {body}
+    </div>
+  ) : (
+    <div className="mt-5">{body}</div>
+  );
+}

--- a/src/ui/StartScreen.jsx
+++ b/src/ui/StartScreen.jsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from "react";
 import { AnleitungModal } from "./AnleitungModal.jsx";
 import { CardLogo } from "./CardLogo.jsx";
+import { GlobalLeaderboard } from "./GlobalLeaderboard.jsx";
 
 /* Startbildschirm (#4): Einstieg mit „Neuer Run", Anleitung (#12) und lokaler Bestenliste. */
-export function StartScreen({ onStart, highscores, best, onOptions }) {
+export function StartScreen({ onStart, highscores, best, onOptions, username = "", onEditName, myEntry = null, pubToken = 0 }) {
   const [showGuide, setShowGuide] = useState(false);
 
   // Beim allerersten Start die Anleitung einmal automatisch zeigen (#12).
@@ -54,9 +55,18 @@ export function StartScreen({ onStart, highscores, best, onOptions }) {
         )}
       </div>
 
+      {/* Lokaler Nickname (#14) — jederzeit editierbar; hängt an globalen Einträgen. */}
+      {onEditName && (
+        <button onClick={onEditName} className="text-xs opacity-60 hover:opacity-100 transition-opacity">
+          {username
+            ? <>Angemeldet als <b style={{ color: "#5ab87a" }}>{username}</b> · Name ändern</>
+            : <>Namen festlegen für den globalen Highscore</>}
+        </button>
+      )}
+
       <div className="w-full max-w-sm rounded-xl p-4 as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
         <div className="flex items-center justify-between mb-2">
-          <span className="text-[11px] uppercase tracking-wide opacity-50">Highscore</span>
+          <span className="text-[11px] uppercase tracking-wide opacity-50">Deine Läufe</span>
           <span className="text-sm font-bold" style={{ color: "#d4a63a" }}>
             Rekord {best.toLocaleString("de-DE")}
           </span>
@@ -75,6 +85,10 @@ export function StartScreen({ onStart, highscores, best, onOptions }) {
           </div>
         )}
       </div>
+
+      {/* Globaler Highscore (#14) — additiv unter dem lokalen Block; blendet sich ohne
+          Config/offline lautlos aus. Der lokale Block oben bleibt immer sichtbar. */}
+      <GlobalLeaderboard framed mine={myEntry} reloadToken={pubToken} />
 
       {showGuide && <AnleitungModal onClose={closeGuide} />}
     </div>

--- a/src/ui/UsernameModal.jsx
+++ b/src/ui/UsernameModal.jsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+/* Lokaler Nickname (#14): dient der Ersteinrichtung (beim ersten Start) und dem
+   späteren Ändern. Minimal validiert — nur Trim + Länge 1–20; keine Eindeutigkeit,
+   kein Filter. Der Name erscheint an den globalen Highscore-Einträgen. */
+const MAX = 20;
+
+export function UsernameModal({ initial = "", firstTime = false, onSave, onClose }) {
+  const [name, setName] = useState(initial);
+  const trimmed = name.trim();
+  const submit = () => { if (trimmed) onSave(trimmed.slice(0, MAX)); };
+
+  return (
+    <div onClick={onClose} className="fixed inset-0 z-40 flex items-center justify-center p-4"
+      style={{ background: "#0c0c10cc", backdropFilter: "blur(3px)" }}>
+      <div onClick={(e) => e.stopPropagation()} className="w-full max-w-xs rounded-2xl p-6"
+        style={{ background: "#181820", border: "1px solid #33333e" }}>
+        <div className="text-center mb-4">
+          <div className="text-xs uppercase tracking-widest" style={{ color: "#8a7de0" }}>
+            {firstTime ? "Willkommen" : "Name ändern"}
+          </div>
+          <h2 className="text-xl font-bold mt-1 font-pixel crt-title">
+            {firstTime ? "Wähle deinen Namen" : "Dein Name"}
+          </h2>
+        </div>
+
+        <input autoFocus value={name} maxLength={MAX}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
+          placeholder="Dein Name"
+          className="w-full px-3 py-2.5 rounded-lg text-sm outline-none"
+          style={{ background: "#12121a", border: "1px solid #2a2a33", color: "#e8e8ea" }} />
+        <div className="text-[11px] opacity-45 mt-2 leading-snug">
+          1–20 Zeichen · erscheint im globalen Highscore. Jederzeit im Menü änderbar.
+        </div>
+
+        <div className="flex gap-2 mt-4">
+          {!firstTime && (
+            <button onClick={onClose} className="py-2.5 px-4 rounded-lg font-bold transition-all"
+              style={{ background: "#20202a", color: "#e8e8ea", border: "1px solid #30303a" }}>
+              Abbrechen
+            </button>
+          )}
+          <button onClick={submit} disabled={!trimmed}
+            className="flex-1 py-2.5 rounded-lg font-bold transition-all"
+            style={{ background: trimmed ? "#5ab87a" : "#26262c", color: trimmed ? "#141419" : "#666",
+              cursor: trimmed ? "pointer" : "not-allowed" }}>
+            Speichern
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Globales Leaderboard über Supabase mit lokalem Username — analog Prototyp 1, im bestehenden Projekt, eigene Tabelle `autostich_scores`. Der lokale Highscore bleibt vollständig erhalten; das globale Board kommt additiv darunter. End-to-end live verifiziert.

## Teil A — Username (lokal)
`loadUsername`/`saveUsername` (localStorage `as_username`). `UsernameModal` für die Ersteinrichtung beim ersten Start und späteres Ändern; im StartScreen jederzeit editierbar. Hängt an jedem globalen Eintrag.

## Teil B — Supabase (dependency-frei)
`leaderboard.js`: `fetchGlobalTop(10)` + `publishRun` per REST-Fetch auf PostgREST (`/rest/v1/autostich_scores`). Öffentliche Config (publishable Key + URL) committet in `.env.development`/`.env.production` — kein Secret, Schutz via RLS (nur `select` + `insert`). Auto-Submit bei Game-Over UND vorzeitigem Beenden (`App.saveRun`), fehlertolerant.

## Teil C — Anzeige
Lokaler Block "Deine Läufe" (Top 5) unverändert und immer sichtbar; darunter `GlobalLeaderboard` "Global — Top 10" mit Namen, eigener Lauf hervorgehoben (`· du`). Lade-/Leer-/Fehlerzustände nur global; ohne Config/offline entfällt der globale Block lautlos. In StartScreen (gerahmt) und Game-Over (nach dem Submit neu geladen).

## Verifiziert
- Username setzen/anzeigen/ändern, persistiert.
- Lauf → Publish → eigener Eintrag erscheint hervorgehoben; Zeile serverseitig persistiert.
- RLS: anon `insert`+`select` ok, `update`/`delete` blockiert (0 Zeilen betroffen).
- Ohne Tabelle: lokaler Block voll funktionsfähig, global "nicht verfügbar" (graceful).
- Tests 104/104, `npm run build` grün, Env im Prod-Bundle gebacken.

**Setup-Hinweis:** Die Tabelle `autostich_scores` + RLS-Policies wurden im Supabase-Projekt bereits per SQL angelegt (nötig, da der anon-Key keine DDL darf).

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
