### PR TITLE
Anti-Infinity: periodischer eskalierender Leben-Abzug (ersetzt #32, #59)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useReducer, useEffect, useRef, useState } from "react";
 import { reducer, initialState, menuState } from "./game/reducer.js";
-import { BASE_FLIP_MS, GHOST_STEP, TRICKS_PER_CYCLE, lossCostFor, lossTierFor } from "./game/constants.js";
+import { BASE_FLIP_MS, GHOST_STEP, TRICKS_PER_CYCLE, LIFE_DRAIN_INTERVAL_MS, lifeDrainAt } from "./game/constants.js";
 import { baseScoreMultFor } from "./game/perks.js";
 import { loadGhost, saveGhost, loadHighscores, recordHighscore, loadOptions, saveOptions, loadUsername, saveUsername } from "./game/storage.js";
 import { leaderboardConfigured, publishRun } from "./game/leaderboard.js";
@@ -33,7 +33,7 @@ export function Autostich() {
   const [myEntry, setMyEntry] = useState(null);  // zuletzt gewerteter Lauf → Hervorhebung im Global-Board
   const [pubToken, setPubToken] = useState(0);    // bumpt nach erfolgreichem Submit → Board lädt neu
   function onSaveUsername(name) { saveUsername(name); setUsername(name); setShowUsername(false); }
-  const [lossNotice, setLossNotice] = useState(null); // kurzer Float beim Stufenwechsel der Niederlagenkosten (#32)
+  const [drainNotice, setDrainNotice] = useState(null); // kurzer Float beim periodischen Zeit-Abzug (#59)
   const [multPulse, setMultPulse] = useState(0);      // Zähler: bumpt bei Anstieg des Score-Mults → Puls (#37)
 
   // GEIST — Rekord-Trajektorie (Score je GHOST_STEP Stiche) + laufende Reihe
@@ -47,7 +47,7 @@ export function Autostich() {
   // RUN-TIMER (#10) — akkumulierte aktive Zeit; friert bei Pause / außerhalb „play" ein (#9)
   const timeBase = useRef(0);
   const segStart = useRef(null);
-  const lastLossTier = useRef(0); // zuletzt angezeigte Niederlagenkosten-Stufe (#32)
+  const lastDrainInterval = useRef(0); // zuletzt abgezogenes Zeit-Intervall (#59)
   const prevMult = useRef(1);     // vorheriger Score-Mult (Puls nur bei Anstieg, #37)
   // Offenes Optionen-Overlay friert den Lauf ein (wie andere Overlays) — ohne den
   // Nutzer-Pause-Toggle zu verändern: beim Schließen läuft es im vorherigen Zustand weiter.
@@ -87,14 +87,9 @@ export function Autostich() {
   }, [active]);
 
   // Auto-Play: nach jedem Stich (trickNo ändert sich) den nächsten planen. Pause hält alles an.
-  // Beim Auflösen die zeit-eskalierten Niederlagenkosten (#32) aus der LIVE aktiven Zeit berechnen
-  // und als Payload injizieren (Determinismus: der reine Layer sieht kein Date).
   useEffect(() => {
     if (state.phase !== "play" || paused || showOptions) return;
-    const id = setTimeout(() => {
-      const nowElapsed = timeBase.current + (segStart.current != null ? Date.now() - segStart.current : 0);
-      dispatch({ type: "RESOLVE_TRICK", rng: Math.random, lossCost: lossCostFor(nowElapsed) });
-    }, flipMs);
+    const id = setTimeout(() => dispatch({ type: "RESOLVE_TRICK", rng: Math.random }), flipMs);
     return () => clearTimeout(id);
   }, [state.phase, state.trickNo, paused, showOptions, state.speedPct, speedMult]);
 
@@ -140,8 +135,8 @@ export function Autostich() {
     runId.current = Date.now();
     timeBase.current = 0;
     segStart.current = null;
-    lastLossTier.current = 0;
-    setLossNotice(null);
+    lastDrainInterval.current = 0;
+    setDrainNotice(null);
     setPaused(false);
     setIsRecord(false);
     dispatch({ type: "START_RUN", rng: Math.random });
@@ -163,18 +158,22 @@ export function Autostich() {
 
   const best = Math.max(recordTotal.current, highscores[0]?.score || 0);
   const elapsedMs = timeBase.current + (segStart.current != null ? Date.now() - segStart.current : 0);
-  // Zeit-eskalierte Niederlagenkosten (#32) für die Anzeige (StatusRail-Indikator + Stufenwechsel-Float).
-  const lossCost = lossCostFor(elapsedMs);
-  const lossTier = lossTierFor(elapsedMs);
-  // Stufenwechsel → einmaliger, selbst-verschwindender Hinweis-Float (kein Modal, keine Pause).
-  // lossTier steigt nur mit aktiver Zeit (Pause friert ein) → kein Spam; Reset via startRun.
+  // Anti-Infinity (#59): periodischer, quadratisch eskalierender Leben-Abzug über die AKTIVE Zeit.
+  // drainInterval = Zahl der überschrittenen 2,5-Min-Schwellen; nextDrain = Betrag des nächsten Abzugs.
+  const drainInterval = Math.floor(elapsedMs / LIFE_DRAIN_INTERVAL_MS);
+  const nextDrain = lifeDrainAt(drainInterval + 1);
+  // Neue Schwelle(n) → für jede verpasste Stufe LIFE_DRAIN dispatchen (Payload: Betrag; Determinismus,
+  // der Reducer sieht kein Date) + kurzer, selbst-verschwindender Float. Reset via startRun.
   useEffect(() => {
-    if (state.phase !== "play" || lossTier <= lastLossTier.current) return;
-    lastLossTier.current = lossTier;
-    setLossNotice({ tier: lossTier, cost: lossCost });
-    const id = setTimeout(() => setLossNotice(null), 2000);
+    if (state.phase !== "play" || drainInterval <= lastDrainInterval.current) return;
+    for (let n = lastDrainInterval.current + 1; n <= drainInterval; n++) {
+      dispatch({ type: "LIFE_DRAIN", amount: lifeDrainAt(n) });
+    }
+    lastDrainInterval.current = drainInterval;
+    setDrainNotice({ interval: drainInterval, amount: lifeDrainAt(drainInterval) });
+    const id = setTimeout(() => setDrainNotice(null), 2000);
     return () => clearTimeout(id);
-  }, [lossTier, state.phase]);
+  }, [drainInterval, state.phase]);
 
   // Prominenter Score-Multiplikator-Chip (#37): geteilte Quelle mit der StatusRail (kein Drift).
   // perks || [] — im Menü (state = { phase:"menu" }) fehlen die Felder; Defaults greifen.
@@ -257,10 +256,10 @@ export function Autostich() {
 
           <div className="grid lg:grid-cols-[1fr_340px] gap-4 items-start">
             <div className="grid gap-4">
-              <Battlefield lastTrick={state.lastTrick} remaining={TRICKS_PER_CYCLE - state.pos} flipMs={flipMs} lossNotice={lossNotice} />
+              <Battlefield lastTrick={state.lastTrick} remaining={TRICKS_PER_CYCLE - state.pos} flipMs={flipMs} drainNotice={drainNotice} />
               <BuildPanel perks={state.perks} />
             </div>
-            <StatusRail state={state} speedPct={state.speedPct} lossCost={lossCost} currentTraj={currentTraj.current} recordTraj={recordTraj.current} />
+            <StatusRail state={state} speedPct={state.speedPct} nextDrain={nextDrain} currentTraj={currentTraj.current} recordTraj={recordTraj.current} />
           </div>
 
           {/* Chronik — Deck-Werte-Histogramm, volle Breite ganz unten (#28) */}

--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -2,11 +2,11 @@
    TUNING-BLOCK  — hier dreht der Dev im Playtest
    ============================================================ */
 export const START_LIFE       = 2000;   // Leben = Run-Timer [TUNING]
-export const DMG_PER_LOSS     = 10;     // Basis-Schaden je Niederlage (Stufe 0) [TUNING]
-// Anti-Infinity (#32): Niederlagenkosten eskalieren mit der AKTIVEN Laufzeit — Basis 10,
-// +5 je 5 Minuten, ungedeckelt (0–5min→10, 5–10→15, 10–15→20, 15–20→25 …). Beide tunbar.
-export const LOSS_COST_STEP     = 5;               // +Schaden je Stufe [TUNING]
-export const LOSS_COST_STEP_MS  = 5 * 60 * 1000;   // Stufenlänge: 5 Min aktiver Spielzeit [TUNING]
+export const DMG_PER_LOSS     = 10;     // Schaden je Niederlage (flat) [TUNING]
+// Anti-Infinity (#59, ersetzt #32): periodischer, quadratisch eskalierender Leben-Abzug über die
+// AKTIVE Laufzeit — alle 2,5 Min −LIFE_DRAIN_BASE·n² (n = Intervall-Index): −5, −20, −45, −80 … kein Cap.
+export const LIFE_DRAIN_INTERVAL_MS = 2.5 * 60 * 1000; // 2,5 Min aktiver Spielzeit je Abzug [TUNING]
+export const LIFE_DRAIN_BASE        = 5;               // Abzug = LIFE_DRAIN_BASE · n² [TUNING]
 export const XP_PER_WIN       = 10;     // XP je gewonnenem Stich [TUNING]
 export const SCORE_PER_WIN    = 100;    // Basispunkte je Sieg (Perks/Tempo skalieren darauf) [TUNING]
 export const TEMPO_SCORE_FACTOR = 0.005; // je %-Punkt speedPct +0,5 % Stichscore [TUNING]
@@ -44,11 +44,10 @@ export const VALUE_CAP = null;
 // speedPct), kein manueller Regler (#2, Design-Doc §5.3).
 export const BASE_FLIP_MS = 1750;   // ms je Stich bei 0 % Speed (Basis-Tempo, etwas flotter; Turbo/Perks oben drauf) [TUNING]
 
-// Anti-Infinity (#32): Stufe & Schaden für eine gegebene AKTIVE Laufzeit. Pure Funktionen im
-// game/-Layer (Determinismus-Invariante: kein Date/Wall-Clock hier — elapsedMs wird injiziert,
-// analog zum rng-Payload). App.jsx reicht lossCostFor(elapsedMs) in die RESOLVE_TRICK-Action.
-export const lossTierFor = (elapsedMs) => Math.floor(Math.max(0, elapsedMs) / LOSS_COST_STEP_MS);
-export const lossCostFor = (elapsedMs) => DMG_PER_LOSS + LOSS_COST_STEP * lossTierFor(elapsedMs);
+// Anti-Infinity (#59): Abzug im n-ten 2,5-Min-Intervall (n≥1) — quadratisch, kein Cap. Rein.
+// App.jsx erkennt aus elapsedMs das Überschreiten einer Intervall-Schwelle und dispatcht LIFE_DRAIN
+// mit lifeDrainAt(n) (Determinismus: der game/-Layer sieht kein Date, nur den Betrag als Payload).
+export const lifeDrainAt = (n) => LIFE_DRAIN_BASE * n * n;
 
 /* ============================================================
    DECK / FARBEN

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -40,7 +40,7 @@ export function effectivePlayerValue(baseValue, perks, ctx) {
 /* Einen Stich auflösen → neuer State (pure). rng wird nur bei Durchlauf-Ende
    (Neu-Mischen) und Level-Up (Perk-Angebot) gebraucht — als Abhängigkeit injiziert,
    damit die Schicht deterministisch/seedbar bleibt (kein Math.random hier drin). */
-export function resolveTrick(state, rng = Math.random, lossCost = C.DMG_PER_LOSS) {
+export function resolveTrick(state, rng = Math.random) {
   if (state.phase !== "play") return state;
 
   let {
@@ -109,9 +109,10 @@ export function resolveTrick(state, rng = Math.random, lossCost = C.DMG_PER_LOSS
     lastResult = "win";
   } else if (lost) {
     losses += 1; winStreak = 0;
-    // lossCost = zeit-eskalierter Grundwert (#32). Legendär-Zusatzschaden (L1 +3 / L6 +2, summiert)
-    // addiert darauf; dmgReduce (C3) zieht ab, Schild (C5) absorbiert danach (s. u.).
-    dmg = Math.max(0, lossCost + sumHook(perks, "extraDamageTaken", {}) - sumHook(perks, "dmgReduce", {}));
+    // Flat-Grundschaden (#59: die #32-Zeiteskalation ist raus; Zeit-Pressure läuft jetzt über den
+    // periodischen LIFE_DRAIN). Legendär-Zusatzschaden (L1 +3 / L6 +2) addiert; dmgReduce (C3) zieht
+    // ab, Schild (C5) absorbiert danach (s. u.).
+    dmg = Math.max(0, C.DMG_PER_LOSS + sumHook(perks, "extraDamageTaken", {}) - sumHook(perks, "dmgReduce", {}));
     // Schild (C5) absorbiert NACH der Schadensberechnung, vor dem Leben.
     if (shield > 0 && dmg > 0) { const absorbed = Math.min(shield, dmg); shield -= absorbed; dmg -= absorbed; }
     life -= dmg;

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -49,9 +49,16 @@ export function reducer(state, action) {
       return menuState();
 
     case "RESOLVE_TRICK":
-      // action.lossCost: zeit-eskalierte Niederlagenkosten (#32), von App.jsx aus elapsedMs injiziert.
-      // Fehlt sie, greift der Engine-Default (DMG_PER_LOSS) → Reducer bleibt rein/deterministisch.
-      return resolveTrick(state, action.rng, action.lossCost);
+      return resolveTrick(state, action.rng);
+
+    case "LIFE_DRAIN": {
+      // Anti-Infinity (#59): periodischer, quadratisch eskalierender Leben-Abzug. Betrag kommt als
+      // Payload aus App.jsx (Determinismus: kein Date im Reducer). Nur im Spiel; ≤0 → Game Over.
+      if (state.phase !== "play") return state;
+      const life = state.life - (action.amount || 0);
+      if (life <= 0) return { ...state, life: 0, phase: "gameover" };
+      return { ...state, life };
+    }
 
     case "SUBMIT_PREDICTION": {
       // Ansage bestätigen (#36): erst JETZT neu mischen, pos/Zyklus-Akkus zurücksetzen, nächster Durchlauf.

--- a/src/ui/Battlefield.jsx
+++ b/src/ui/Battlefield.jsx
@@ -48,7 +48,7 @@ function Side({ label, remaining, dealFrom, children }) {
   );
 }
 
-export function Battlefield({ lastTrick, remaining = TRICKS_PER_CYCLE, flipMs = 1000, lossNotice = null }) {
+export function Battlefield({ lastTrick, remaining = TRICKS_PER_CYCLE, flipMs = 1000, drainNotice = null }) {
   const reduced = usePrefersReducedMotion();
   const t = lastTrick;
   const win = t && (t.result === "win" || t.result === "win_tie");
@@ -104,14 +104,14 @@ export function Battlefield({ lastTrick, remaining = TRICKS_PER_CYCLE, flipMs = 
           </div>
         )}
 
-        {/* Anti-Infinity (#32): einmaliger Hinweis beim Stufenwechsel der Niederlagenkosten —
+        {/* Anti-Infinity (#59): einmaliger Hinweis beim periodischen Zeit-Abzug —
             non-blocking, selbst-verschwindend; reduced-motion → statisch (App räumt nach 2 s ab). */}
-        {lossNotice && (
-          <div key={`lossnotice-${lossNotice.tier}`} className="pointer-events-none absolute left-1/2 top-0 font-bold whitespace-nowrap z-20"
+        {drainNotice && (
+          <div key={`drainnotice-${drainNotice.interval}`} className="pointer-events-none absolute left-1/2 top-0 font-bold whitespace-nowrap z-20"
             style={{ fontSize: 14, color: "#e0605a", textShadow: "0 0 10px #e0605a99",
                      transform: reduced ? "translateX(-50%)" : undefined,
                      animation: fx("as-notice 2000ms ease-out forwards") }}>
-            ⚠ Niederlagen kosten jetzt {lossNotice.cost}♥
+            ⏳ Zeit-Abzug −{drainNotice.amount}♥
           </div>
         )}
 

--- a/src/ui/StatusRail.jsx
+++ b/src/ui/StatusRail.jsx
@@ -21,7 +21,7 @@ function Stat({ label, value, tone }) {
   );
 }
 
-export function StatusRail({ state, speedPct, lossCost = 10, currentTraj = [], recordTraj = [] }) {
+export function StatusRail({ state, speedPct, nextDrain = 0, currentTraj = [], recordTraj = [] }) {
   const { life, maxLife, xp, level, score, wins, losses, ties, cycle, trickNo, winStreak, bestStreak, pos, lastTrick, perks, crits, shield, legendaryCritBonus = 0, prediction = null, cycleWins = 0 } = state;
   const need = xpToNext(level);
   const remaining = TRICKS_PER_CYCLE - pos; // Karten bis zum nächsten Mischen (#6)
@@ -43,8 +43,8 @@ export function StatusRail({ state, speedPct, lossCost = 10, currentTraj = [], r
   const lowLifeRally = perks.includes("L3") && maxLife > 0 && life / maxLife <= 0.25;
   // Leben-Balken bei Schaden/Heilung kurz aufblitzen (#15).
   const lifeFlash = lastTrick ? (lastTrick.result === "loss" && lastTrick.dmg > 0 ? "#e0605a" : lastTrick.healed > 0 ? "#5ab87a" : null) : null;
-  // Passiver Indikator der zeit-eskalierten Niederlagenkosten (#32): grün → gelb → rot je Stufe.
-  const lossColor = lossCost <= 10 ? "#5ab87a" : lossCost <= 20 ? "#d4a63a" : "#e0605a";
+  // Passiver Indikator des nächsten periodischen Zeit-Abzugs (#59): grün → gelb → rot je Härte.
+  const drainColor = nextDrain <= 20 ? "#5ab87a" : nextDrain <= 80 ? "#d4a63a" : "#e0605a";
   return (
     <div className="rounded-xl p-4 grid gap-3 as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
       {/* Leben */}
@@ -58,11 +58,11 @@ export function StatusRail({ state, speedPct, lossCost = 10, currentTraj = [], r
           {lifeFlash && <div key={trickNo} className="absolute inset-0 rounded-full pointer-events-none"
             style={{ animation: "as-flash 400ms ease-out", "--flash": lifeFlash }} />}
         </div>
-        {/* Niederlagenkosten — passiver Dauer-Indikator, eskaliert zeitbasiert (#32). */}
+        {/* Zeit-Abzug — passiver Indikator des NÄCHSTEN periodischen Abzugs (#59). */}
         <div className="flex justify-end mt-1">
-          <span className="text-[10px]" style={{ color: lossColor }}
-            title="Schaden je Niederlage — steigt +5 je 5 Min aktiver Spielzeit">
-            Niederlage −{lossCost}♥
+          <span className="text-[10px]" style={{ color: drainColor }}
+            title="Periodischer Zeit-Abzug — alle 2,5 Min, quadratisch eskalierend (5·n²)">
+            Zeit-Abzug (nächster) −{nextDrain}♥
           </span>
         </div>
         {/* L3 „Letztes Aufbäumen" aktiv (#33): deutlicher, aber statischer Status (kein Blinken). */}

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { makeRng, shuffledOrder } from "../src/game/deck.js";
 import { initialState } from "../src/game/reducer.js";
 import { resolveTrick, rollCrit } from "../src/game/engine.js";
-import { lossCostFor, lossTierFor, TRICKS_PER_CYCLE, PREDICTION_MAX } from "../src/game/constants.js";
+import { lifeDrainAt, TRICKS_PER_CYCLE, PREDICTION_MAX } from "../src/game/constants.js";
 
 // Ansage-Phase (#36) im resolveTrick-Direktloop überspringen (mimt SUBMIT_PREDICTION: mischen + Reset).
 const passPrediction = (s, seed) => ({
@@ -128,32 +128,16 @@ describe("resolveTrick — Verteidigungs-Perks", () => {
   });
 });
 
-describe("Anti-Infinity — zeitbasierte Niederlagenkosten (#32)", () => {
-  const MIN = 60 * 1000;
-  it("Rampe: Basis 10, +5 je 5 Min aktiver Zeit, ungedeckelt", () => {
-    expect(lossCostFor(0)).toBe(10);
-    expect(lossCostFor(4.9 * MIN)).toBe(10);   // 0–5 min
-    expect(lossCostFor(5 * MIN)).toBe(15);     // Stufe 1 beginnt bei exakt 5:00
-    expect(lossCostFor(9.9 * MIN)).toBe(15);
-    expect(lossCostFor(10 * MIN)).toBe(20);
-    expect(lossCostFor(15 * MIN)).toBe(25);
-    expect(lossCostFor(60 * MIN)).toBe(70);    // kein Cap: 10 + 5×12
+describe("Anti-Infinity — periodischer Leben-Abzug (#59, ersetzt #32)", () => {
+  it("lifeDrainAt: quadratische Kurve 5·n² (−5, −20, −45, −80, …, 500)", () => {
+    expect(lifeDrainAt(1)).toBe(5);
+    expect(lifeDrainAt(2)).toBe(20);
+    expect(lifeDrainAt(3)).toBe(45);
+    expect(lifeDrainAt(4)).toBe(80);
+    expect(lifeDrainAt(10)).toBe(500);
   });
-  it("lossTierFor zählt die 5-Minuten-Stufe; negative/0 Zeit ist sicher", () => {
-    expect(lossTierFor(0)).toBe(0);
-    expect(lossTierFor(5 * MIN)).toBe(1);
-    expect(lossTierFor(12 * MIN)).toBe(2);
-    expect(lossCostFor(-100)).toBe(10);
-  });
-  it("resolveTrick nutzt die injizierte lossCost statt der Konstante", () => {
-    expect(resolveTrick(scenario(0, 12, { life: 100 }), rng, 15).life).toBe(85);
-    expect(resolveTrick(scenario(0, 12, { life: 100 }), rng).life).toBe(90); // Default = DMG_PER_LOSS
-  });
-  it("dmgReduce (C3) und Schild (C5) wirken auf den eskalierten Wert", () => {
-    expect(resolveTrick(scenario(0, 12, { life: 100, perks: ["C3"] }), rng, 20).life).toBe(82); // 20−2
-    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C5"], shield: 50 }), rng, 20);
-    expect(s.life).toBe(100);   // 20 vom Schild absorbiert
-    expect(s.shield).toBe(30);
+  it("Niederlagenschaden ist wieder flat (keine Zeit-Eskalation)", () => {
+    expect(resolveTrick(scenario(0, 12, { life: 100 }), rng).life).toBe(90); // DMG_PER_LOSS = 10
   });
 });
 
@@ -241,14 +225,14 @@ describe("resolveTrick — Tempo-Score & Crit (#19)", () => {
 });
 
 describe("Legendäre Perks (#33) — Engine-Integration", () => {
-  it("L1 Überladung: +3 Zusatzschaden je Niederlage (auf lossCost)", () => {
-    expect(resolveTrick(scenario(0, 12, { life: 100, perks: ["L1"] }), rng, 10).life).toBe(87); // 10+3
+  it("L1 Überladung: +3 Zusatzschaden je Niederlage (auf den flat Grundschaden)", () => {
+    expect(resolveTrick(scenario(0, 12, { life: 100, perks: ["L1"] }), rng).life).toBe(87); // 10+3
   });
   it("L1+L6: extraDamageTaken summiert korrekt (+5)", () => {
-    expect(resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "L6"] }), rng, 10).life).toBe(85); // 10+3+2
+    expect(resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "L6"] }), rng).life).toBe(85); // 10+3+2
   });
   it("C5 Schild verhindert den ersten Verlust je Durchlauf voll — auch mit L1-Zusatzschaden", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "C5"], shield: 50 }), rng, 10);
+    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "C5"], shield: 50 }), rng);
     expect(s.life).toBe(100);   // 13 Schaden komplett vom Schild absorbiert
     expect(s.shield).toBe(37);  // 50 − 13
   });

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -58,15 +58,6 @@ describe("Reducer", () => {
   it("TO_MENU verlässt den Lauf zurück ins Menü", () => {
     expect(reducer(initialState(makeRng(1)), { type: "TO_MENU" }).phase).toBe("menu");
   });
-
-  it("RESOLVE_TRICK reicht action.lossCost an die Engine durch (#32)", () => {
-    const constDeck = (v) => Array.from({ length: 40 }, (_, i) => ({ id: `X${i}`, suit: "R", baseRank: v, value: v }));
-    const id40 = Array.from({ length: 40 }, (_, i) => i);
-    // Erzwungene Niederlage (Spieler 0 vs. Gegner 12).
-    const losing = { ...initialState(makeRng(1)), deck: constDeck(0), oppDeck: constDeck(12), playerOrder: id40, oppOrder: id40, life: 100 };
-    expect(reducer(losing, { type: "RESOLVE_TRICK", rng, lossCost: 25 }).life).toBe(75);
-    expect(reducer(losing, { type: "RESOLVE_TRICK", rng }).life).toBe(90); // ohne Payload → Default 10
-  });
 });
 
 describe("Reducer — Ansage-System (#36)", () => {
@@ -105,5 +96,26 @@ describe("Reducer — Ansage-System (#36)", () => {
   it("Ansage bleibt den ganzen Durchlauf unverändert (RESOLVE_TRICK ändert sie nicht)", () => {
     const play = { ...initialState(makeRng(1)), prediction: 25 };
     expect(reducer(play, { type: "RESOLVE_TRICK", rng }).prediction).toBe(25);
+  });
+});
+
+describe("LIFE_DRAIN — periodischer Zeit-Abzug (#59)", () => {
+  it("zieht den Betrag vom Leben ab (bleibt in play)", () => {
+    const s = { ...initialState(makeRng(1)), life: 100 };
+    const r = reducer(s, { type: "LIFE_DRAIN", amount: 20 });
+    expect(r.life).toBe(80);
+    expect(r.phase).toBe("play");
+  });
+  it("life ≤ 0 durch den Abzug → Game Over", () => {
+    const s = { ...initialState(makeRng(1)), life: 15 };
+    const r = reducer(s, { type: "LIFE_DRAIN", amount: 20 });
+    expect(r.life).toBe(0);
+    expect(r.phase).toBe("gameover");
+  });
+  it("greift nur in der play-Phase (Menü/Overlay unberührt)", () => {
+    const menu = menuState();
+    expect(reducer(menu, { type: "LIFE_DRAIN", amount: 20 })).toBe(menu);
+    const lvl = { ...initialState(makeRng(1)), phase: "levelup", life: 100 };
+    expect(reducer(lvl, { type: "LIFE_DRAIN", amount: 20 }).life).toBe(100);
   });
 });


### PR DESCRIPTION
Setzt #59 um: der periodische, quadratisch eskalierende Leben-Abzug **ersetzt** die zeitbasierten Niederlagenkosten aus #32.

## Was
- **Neu (#59):** alle **2,5 Min** aktiver Spielzeit ein Abzug `5·n²` (n = Intervall-Index): −5, −20, −45, −80, −125 … **kein Cap**. `life ≤ 0` dadurch → Game Over. Decay-Tod allein bei ~27 Min.
- **Ersetzt #32:** `lossCostFor`/`lossTierFor` + „Niederlage −X♥"-Anzeige raus; **Verlustschaden wieder flat** (`DMG_PER_LOSS`).

## Umsetzung
- `constants.js`: `LIFE_DRAIN_INTERVAL_MS`, `LIFE_DRAIN_BASE`, `lifeDrainAt(n) = 5·n²`.
- `reducer.js`: neue `LIFE_DRAIN`-Action — Betrag als Payload (Determinismus: kein `Date` im `game/`-Layer), `≤0` → `gameover`, Phase-Guard.
- `engine.js`: `resolveTrick` ohne `lossCost`-Param; Verlustschaden flat (L1/L6-Zusatzschaden + C3/C5 wirken weiter).
- `App.jsx`: erkennt aus `elapsedMs` das Überschreiten der 2,5-Min-Schwellen → `LIFE_DRAIN` dispatch (holt verpasste Intervalle nach); non-blocking Drain-Float; #32-Wiring entfernt.
- `StatusRail`/`Battlefield`: „Zeit-Abzug (nächster) −N♥"-Indikator + „⏳ Zeit-Abzug −N♥"-Float.

## Tests
- Alle **104** grün. Neu: `lifeDrainAt`-Kurve, flat Verlustschaden, `LIFE_DRAIN` (Abzug / Game-Over / Phase-Guard). #32-Tests entfernt.
- Live-Browser-Check ausgelassen (Port 5173 belegt; Effekt ist zeit-gated 2,5 Min) — Logik über Tests + Build abgedeckt.

Closes #59