### PR TITLE
Fix #50: Neustart fror Timer & Anti-Infinity (Leben-Abzug) bei 0:00 ein

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -134,7 +134,11 @@ export function Autostich() {
     recorded.current = false;
     runId.current = Date.now();
     timeBase.current = 0;
-    segStart.current = null;
+    // Segment SOFORT starten (nicht nullen): bei „Neustart" aus einem bereits aktiven Lauf
+    // wechselt `active` true→true, der [active]-Timer-Effekt läuft NICHT erneut → segStart bliebe
+    // null → elapsedMs=0 → Timer/Anti-Infinity (#59) fröre ein (#50). Der ==null-Guard im Effekt
+    // verhindert Doppel-Setzen bei echten false→true-Einstiegen (Menü→Play, GameOver→Neu).
+    segStart.current = Date.now();
     lastDrainInterval.current = 0;
     setDrainNotice(null);
     setPaused(false);


### PR DESCRIPTION
Behebt #50 — und damit den Grund, warum der periodische Leben-Abzug (#59) sich „nicht live" anfühlte.

## Ursache
`startRun()` setzte `segStart.current = null`. Bei **„Neustart" aus einem aktiven Lauf** wechselt `active` true→true → der `[active]`-Timer-Segment-Effekt läuft **nicht** erneut → `segStart` bleibt null → `elapsedMs = 0` dauerhaft. Folge: Run-Timer friert bei `0:00`, und der zeitbasierte **Leben-Abzug (#59)** feuert nie (`drainInterval` bleibt 0).

## Fix
In `startRun()` das Segment **sofort starten** (`segStart.current = Date.now()`) statt nullen. Der `==null`-Guard im Effekt verhindert Doppel-Setzen bei den echten `false→true`-Einstiegen (Menü→Play, GameOver→Neuer Lauf) — für alle Pfade sicher.

## Verifikation
- Build + **104 Tests** grün.
- Hinweis: der Timer-/Segment-Code (React-Wiring) hat weiterhin keine Testabdeckung (nur der `game/`-Layer ist getestet). Ein Integrations-Regressionstest wäre separat sinnvoll.

Closes #50