### PR TITLE
Robustheit: flipMs-NaN im Menue (#55) + Mehrfach-Level-Up-Queue (#57)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,7 +54,7 @@ export function Autostich() {
   const active = state.phase === "play" && !paused && !showOptions;
   // Effektive Flip-Zeit: Basis / (1+Speed) / Turbo (1×/2×/3×). Beschleunigt nur Ablauf + Animation,
   // NICHT den Score (speedPct/tempoScoreMult bleiben unberührt → kein Cheesen).
-  const flipMs = (BASE_FLIP_MS / (1 + state.speedPct / 100)) / speedMult;
+  const flipMs = (BASE_FLIP_MS / (1 + (state.speedPct || 0) / 100)) / speedMult; // #55: speedPct fehlt im Menü → NaN vermeiden
 
   useEffect(() => {
     const g = loadGhost();

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -185,11 +185,15 @@ export function resolveTrick(state, rng = Math.random) {
   // nach der Perk-Wahl geht PICK_PERK bei predictionDue weiter in die Ansage-Phase (#36).
   let phase = "play";
   let newOffer = offer;
-  let leveled = false;
-  while (xp >= xpToNext(level)) { xp -= xpToNext(level); level += 1; leveled = true; }
-  if (leveled) {
+  // #57: mehrere Level-Ups in einem Stich als Queue — für den ERSTEN ein Angebot bauen, die
+  // restlichen bleiben als pendingLevelUps und werden nach jedem PICK_PERK nachgezogen (sonst
+  // würde bei künftigem Tuning ein übersprungenes Level still verschluckt).
+  let pendingLevelUps = 0;
+  while (xp >= xpToNext(level)) { xp -= xpToNext(level); level += 1; pendingLevelUps += 1; }
+  if (pendingLevelUps > 0) {
     const off = buildOffer(perks, rng, C.PERKS_OFFERED, level); // Level-Gate für Legendaries (#33)
-    if (off.length > 0) { phase = "levelup"; newOffer = off; } // Pool leer → keine Pause
+    if (off.length > 0) { phase = "levelup"; newOffer = off; pendingLevelUps -= 1; } // dieses Angebot zeigen
+    else pendingLevelUps = 0; // Pool leer → keine Pause; restliche Level-Ups verfallen (kein Angebot möglich)
   }
   if (phase === "play" && predictionDue) phase = "prediction"; // kein Level-Up → direkt Ansage
 
@@ -199,7 +203,7 @@ export function resolveTrick(state, rng = Math.random) {
     predictionBonusScore, exactPredictions, nearPredictions, largestPredictionBonus, predictionDue,
     life, maxLife, xp, level, score, winStreak, bestStreak, wins, losses, ties,
     crits, critBonusScore, bestTrickScore, legendaryCritBonus,
-    initiative, lastResult, perks, offer: newOffer, shield, tieArmed,
+    initiative, lastResult, perks, offer: newOffer, shield, tieArmed, pendingLevelUps,
     lastTrick, phase,
   };
 }

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -1,7 +1,7 @@
 import { buildDeck, shuffledOrder } from "./deck.js";
-import { PERK_DEFS } from "./perks.js";
+import { PERK_DEFS, buildOffer } from "./perks.js";
 import { resolveTrick } from "./engine.js";
-import { START_LIFE, PREDICTION_MIN, PREDICTION_MAX } from "./constants.js";
+import { START_LIFE, PREDICTION_MIN, PREDICTION_MAX, PERKS_OFFERED } from "./constants.js";
 
 /* Reiner Reducer — Determinismus-Invariante: kein Math.random / Date hier drin.
    Zufall kommt als Action-Payload (rng), siehe App.jsx. Phasen:
@@ -27,6 +27,7 @@ export function initialState(rng = Math.random) {
     initiative: "player",
     lastResult: null,
     perks: [], offer: null,
+    pendingLevelUps: 0, // #57: noch ausstehende Level-Up-Angebote (Mehrfach-Level-Up-Queue)
     speedPct: 0,
     shield: 0,
     tieArmed: false,
@@ -86,9 +87,18 @@ export function reducer(state, action) {
       // C5: Schild sofort gewähren (sonst erst beim nächsten Durchlauf-Start)
       const shieldGrant = perks.reduce((m, id) => Math.max(m, PERK_DEFS[id].shieldPerCycle || 0), 0);
       const shield = Math.max(state.shield || 0, shieldGrant);
+      // #57: noch ausstehende Level-Ups? → nächstes Angebot mit dem NEUEN Build zeigen (sonst würde
+      // ein Mehrfach-Level-Up bei künftigem Tuning ein Angebot still verschlucken).
+      let pending = state.pendingLevelUps || 0;
+      if (pending > 0) {
+        const off = buildOffer(perks, rng, PERKS_OFFERED, state.level);
+        if (off.length > 0)
+          return { ...state, deck, perks, speedPct, shield, phase: "levelup", offer: off, pendingLevelUps: pending - 1 };
+        // Pool leer → keine weiteren Angebote möglich; restliche Level-Ups verfallen.
+      }
       // Nach der Perk-Wahl: war ein Durchlauf-Ende fällig (#36), weiter in die Ansage-Phase, sonst play.
       const phase = state.predictionDue ? "prediction" : "play";
-      return { ...state, deck, perks, speedPct, shield, phase, offer: null };
+      return { ...state, deck, perks, speedPct, shield, phase, offer: null, pendingLevelUps: 0 };
     }
 
     default:

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -387,3 +387,20 @@ describe("resolveTrick — Zyklus & Level-Up", () => {
     expect(run(5)).toBe(run(5));
   });
 });
+
+describe("Level-Up-Queue (#57)", () => {
+  it("mehrere Level-Ups in einem Stich: erstes Angebot + Rest als pendingLevelUps", () => {
+    // xp 500 (+10 Sieg = 510) überspringt L1→L4 (100+120+150). Ein Angebot wird gezeigt, 2 bleiben in der Queue.
+    const s = resolveTrick(scenario(12, 0, { xp: 500, level: 1 }), rng);
+    expect(s.level).toBe(4);
+    expect(s.phase).toBe("levelup");
+    expect(s.offer.length).toBeGreaterThan(0);
+    expect(s.pendingLevelUps).toBe(2);
+  });
+  it("einzelnes Level-Up: pendingLevelUps bleibt 0", () => {
+    const s = resolveTrick(scenario(12, 0, { xp: 95, level: 1 }), rng);
+    expect(s.level).toBe(2);
+    expect(s.phase).toBe("levelup");
+    expect(s.pendingLevelUps).toBe(0);
+  });
+});

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -119,3 +119,21 @@ describe("LIFE_DRAIN — periodischer Zeit-Abzug (#59)", () => {
     expect(reducer(lvl, { type: "LIFE_DRAIN", amount: 20 }).life).toBe(100);
   });
 });
+
+describe("Level-Up-Queue — PICK_PERK (#57)", () => {
+  it("bei pendingLevelUps > 0 folgt ein weiteres Angebot mit dem neuen Build", () => {
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", level: 4, offer: ["A1", "C1", "E2"], pendingLevelUps: 2 };
+    const s1 = reducer(s0, { type: "PICK_PERK", perkId: "A1", rng });
+    expect(s1.perks).toEqual(["A1"]);
+    expect(s1.phase).toBe("levelup");
+    expect(s1.offer.length).toBeGreaterThan(0);
+    expect(s1.pendingLevelUps).toBe(1);
+  });
+  it("letztes Level-Up (pendingLevelUps 0) → zurück in play, offer null", () => {
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", level: 4, offer: ["A1", "C1", "E2"], pendingLevelUps: 0 };
+    const s1 = reducer(s0, { type: "PICK_PERK", perkId: "A1", rng });
+    expect(s1.phase).toBe("play");
+    expect(s1.offer).toBeNull();
+    expect(s1.pendingLevelUps).toBe(0);
+  });
+});


### PR DESCRIPTION
Zwei latente Robustheits-Bugs aus der „hand-gepflegte Zustände in App.jsx / engine.js"-Familie.

## #55 — flipMs NaN im Menü
Im Menü fehlt `state.speedPct` → `undefined/100 = NaN` → `flipMs = NaN`. Bisher harmlos (im Menü ungenutzt). Fix: `(state.speedPct || 0)`.

## #57 — Mehrfach-Level-Up-Queue
`resolveTrick` verarbeitete mehrere Level-Ups, baute aber **nur ein** Angebot → bei 2+ übersprungenen Schwellen ging ein Perk-Pick verloren. Latent (XP_PER_WIN=10 < kleinste Schwelle 100), aber bei künftigem Tuning (höheres XP_PER_WIN, XP-Perks) ein echter Bug.
- **engine:** `pendingLevelUps` zählt die Level-Ups; das erste Angebot wird gezeigt, der Rest bleibt in der Queue.
- **reducer `PICK_PERK`:** zieht nach jedem Pick das nächste Angebot (mit dem **neuen** Build) nach, bis die Queue leer ist — dann weiter nach `play`/`prediction`.
- Pool-leer-Fall abgedeckt (restliche Level-Ups verfallen ohne Angebot).

## Verifikation
- **108 Tests** grün (4 neu: Engine-Queue via injiziertem hohem XP, PICK_PERK-Nachzug, Einzel-Level-Up bleibt pending 0).

Closes #55
Closes #57