### PR TITLE
Cleanup-Aufwasch: Anleitung (#51), toter Import (#52), useEffect-Deps (#56), Modal-Schliessen (#58)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -91,7 +91,9 @@ export function Autostich() {
     if (state.phase !== "play" || paused || showOptions) return;
     const id = setTimeout(() => dispatch({ type: "RESOLVE_TRICK", rng: Math.random }), flipMs);
     return () => clearTimeout(id);
-  }, [state.phase, state.trickNo, paused, showOptions, state.speedPct, speedMult]);
+    // #56: flipMs direkt (statt seiner Einzel-Eingaben speedPct/speedMult) → Deps veralten nicht,
+    // falls flipMs künftig von weiteren Variablen abhängt.
+  }, [state.phase, state.trickNo, paused, showOptions, flipMs]);
 
   // Geist-Trajektorie des laufenden Runs mitschreiben.
   useEffect(() => {

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -1,5 +1,4 @@
 import * as C from "./constants.js";
-import { shuffledOrder } from "./deck.js";
 import { PERK_DEFS, buildOffer, critChanceFor, comboMultFor, tempoScoreMultFor, critMultiplierFor, streakBaseMult } from "./perks.js";
 import { xpToNext } from "./leveling.js";
 

--- a/src/ui/AnleitungModal.jsx
+++ b/src/ui/AnleitungModal.jsx
@@ -1,3 +1,5 @@
+import { useEscape } from "./useEscape.js";
+
 /* Schnellstart-Anleitung (#12): erklärt den grundsätzlichen Spielablauf.
    Erreichbar über den Startbildschirm; beim allerersten Start einmal automatisch. */
 const ITEMS = [
@@ -7,13 +9,14 @@ const ITEMS = [
   ["✨", "Perks bei Level-Up", "Siege geben XP. Bei jedem Level-Up pausiert das Spiel und du wählst einen Perk — dein Deck wird dauerhaft stärker."],
   ["🔁", "Deck-Durchlauf", "Nach 40 Stichen wird neu gemischt. Deine dauerhaften Kartenwert-Änderungen bleiben erhalten."],
   ["🎯", "Ansage", "Nach dem ersten Deck-Durchlauf schätzt du vor jeder neuen Runde, wie viele der 40 Stiche du gewinnst. Je genauer, desto größer der Score-Bonus — ein exakter Treffer verdreifacht den Rundenscore."],
-  ["⏯️", "Steuerung", "Auto-Play läuft von allein — oder Manuell Stich für Stich. Mit Pause hältst du an; das Tempo steigt über Tempo-Perks."],
+  ["⏯️", "Steuerung", "Auto-Play läuft von allein. Mit Pause hältst du an; das Tempo steigt über Tempo-Perks (und 2×/3× im Ablauf)."],
 ];
 
 export function AnleitungModal({ onClose }) {
+  useEscape(onClose); // #58: Escape schließt (Backdrop unten)
   return (
-    <div className="fixed inset-0 z-30 flex items-center justify-center p-4" style={{ background: "#0c0c10cc", backdropFilter: "blur(3px)" }}>
-      <div className="w-full max-w-lg rounded-2xl p-6 max-h-[90vh] overflow-y-auto" style={{ background: "#181820", border: "1px solid #33333e" }}>
+    <div onClick={onClose} className="fixed inset-0 z-30 flex items-center justify-center p-4" style={{ background: "#0c0c10cc", backdropFilter: "blur(3px)" }}>
+      <div onClick={(e) => e.stopPropagation()} className="w-full max-w-lg rounded-2xl p-6 max-h-[90vh] overflow-y-auto" style={{ background: "#181820", border: "1px solid #33333e" }}>
         <div className="text-center mb-4">
           <div className="text-xs uppercase tracking-widest" style={{ color: "#8a7de0" }}>Anleitung</div>
           <h2 className="text-xl font-bold mt-1">So funktioniert Autostich</h2>

--- a/src/ui/OptionsModal.jsx
+++ b/src/ui/OptionsModal.jsx
@@ -1,3 +1,5 @@
+import { useEscape } from "./useEscape.js";
+
 /* Optionen-Overlay (#41): erreichbar aus dem Menü UND im laufenden Run (dort pausiert
    der Lauf, solange offen). Bewusst erweiterbar — künftig Sound, Tempo-Default etc.
    Erste Option: der CRT-/Pixel-Skin-Toggle. */
@@ -43,9 +45,10 @@ function Row({ title, desc, children }) {
 
 export function OptionsModal({ options, onChange, onClose }) {
   const crtOn = options.skin === "crt";
+  useEscape(onClose); // #58: Escape schließt (Backdrop unten)
   return (
-    <div className="fixed inset-0 z-30 flex items-center justify-center p-4" style={{ background: "#0c0c10cc", backdropFilter: "blur(3px)" }}>
-      <div className="w-full max-w-lg rounded-2xl p-6 max-h-[90vh] overflow-y-auto" style={{ background: "#181820", border: "1px solid #33333e" }}>
+    <div onClick={onClose} className="fixed inset-0 z-30 flex items-center justify-center p-4" style={{ background: "#0c0c10cc", backdropFilter: "blur(3px)" }}>
+      <div onClick={(e) => e.stopPropagation()} className="w-full max-w-lg rounded-2xl p-6 max-h-[90vh] overflow-y-auto" style={{ background: "#181820", border: "1px solid #33333e" }}>
         <div className="text-center mb-4">
           <div className="text-xs uppercase tracking-widest" style={{ color: "#8a7de0" }}>Optionen</div>
           <h2 className="text-xl font-bold mt-1 font-pixel crt-title">Einstellungen</h2>

--- a/src/ui/UsernameModal.jsx
+++ b/src/ui/UsernameModal.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useEscape } from "./useEscape.js";
 
 /* Lokaler Nickname (#14): dient der Ersteinrichtung (beim ersten Start) und dem
    späteren Ändern. Minimal validiert — nur Trim + Länge 1–20; keine Eindeutigkeit,
@@ -9,6 +10,7 @@ export function UsernameModal({ initial = "", firstTime = false, onSave, onClose
   const [name, setName] = useState(initial);
   const trimmed = name.trim();
   const submit = () => { if (trimmed) onSave(trimmed.slice(0, MAX)); };
+  useEscape(onClose); // #58: Escape schließt (Backdrop existiert bereits)
 
   return (
     <div onClick={onClose} className="fixed inset-0 z-40 flex items-center justify-center p-4"

--- a/src/ui/useEscape.js
+++ b/src/ui/useEscape.js
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+
+/* #58: Escape schließt ein abweisbares Overlay — gemeinsam genutzt, damit Username/Optionen/
+   Anleitung einheitlich per Backdrop-Klick UND Escape schließen. (GameOver/PerkSelect/
+   PredictionSelect nutzen ihn bewusst NICHT — dort ist eine Auswahl erforderlich.) */
+export function useEscape(onClose) {
+  useEffect(() => {
+    if (!onClose) return;
+    const onKey = (e) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+}


### PR DESCRIPTION
Sammel-PR für die vier verbleibenden kleinen Issues.

- **#52** — ungenutzten Import `shuffledOrder` aus `engine.js` entfernt (seit dem #36-Umbau tot; Mischen liegt im Reducer).
- **#51** — Anleitung-Text „oder Manuell Stich für Stich" gestrichen (der Modus wurde in #2/#29 entfernt) → „Auto-Play läuft von allein. Mit Pause hältst du an; das Tempo steigt über Tempo-Perks (und 2×/3× im Ablauf)."
- **#56** — `flipMs` direkt in die RESOLVE_TRICK-Scheduler-Deps (statt seiner Einzel-Eingaben `speedPct`/`speedMult`) → Deps veralten nicht, falls `flipMs` künftig von mehr abhängt.
- **#58** — geteilter `useEscape`-Hook; `Username`/`Optionen`/`Anleitung` schließen jetzt einheitlich per **Backdrop-Klick UND Escape**. `GameOver`/`PerkSelect`/`PredictionSelect` bleiben bewusst nicht abweisbar (Auswahl erforderlich).

## Verifikation
- Build + **108 Tests** grün.
- #58 ist UI-Politur (Escape-Listener + Backdrop) — low-risk; Browser-Pane war für einen Live-Screenshot zu flaky, aber Build/Compile sauber.

Closes #51
Closes #52
Closes #56
Closes #58