### PR TITLE
Beenden fuehrt zum Endscreen (statt direkt ins Menue)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -148,6 +148,7 @@ export function Autostich() {
     dispatch({ type: "START_RUN", rng: Math.random });
   }
   const toMenu = () => { saveRun(); dispatch({ type: "TO_MENU" }); }; // Lauf verlassen (#5)
+  const endRun = () => dispatch({ type: "END_RUN" }); // Beenden → Endscreen; saveRun läuft über den gameover-Effekt
   const pick = (id) => dispatch({ type: "PICK_PERK", perkId: id, rng: Math.random });
   const submitPrediction = (n) => dispatch({ type: "SUBMIT_PREDICTION", prediction: n, rng: Math.random }); // #36
 
@@ -257,7 +258,7 @@ export function Autostich() {
           <Controls
             paused={paused} onTogglePause={() => setPaused((p) => !p)}
             speedMult={speedMult} onSpeed={(m) => setSpeedMult((cur) => (cur === m ? 1 : m))}
-            onRestart={startRun} onAbort={toMenu} onOptions={() => setShowOptions(true)}
+            onRestart={startRun} onAbort={endRun} onOptions={() => setShowOptions(true)}
           />
 
           <div className="grid lg:grid-cols-[1fr_340px] gap-4 items-start">

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -49,6 +49,10 @@ export function reducer(state, action) {
     case "TO_MENU":     // laufenden Run verlassen (#5)
       return menuState();
 
+    case "END_RUN":     // Lauf freiwillig beenden → Endscreen (GameOver) statt direkt ins Menü.
+      // Highscore/Geist sichert der gameover-Effekt in App.jsx (saveRun). Menü/Gameover ignorieren.
+      return (state.phase === "menu" || state.phase === "gameover") ? state : { ...state, phase: "gameover" };
+
     case "RESOLVE_TRICK":
       return resolveTrick(state, action.rng);
 

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -137,3 +137,19 @@ describe("Level-Up-Queue — PICK_PERK (#57)", () => {
     expect(s1.pendingLevelUps).toBe(0);
   });
 });
+
+describe("END_RUN — Beenden → Endscreen", () => {
+  it("aus dem laufenden Spiel → gameover (Score/State bleiben für den Endscreen erhalten)", () => {
+    const play = { ...initialState(makeRng(1)), score: 1234, trickNo: 50 };
+    const r = reducer(play, { type: "END_RUN" });
+    expect(r.phase).toBe("gameover");
+    expect(r.score).toBe(1234);
+    expect(r.trickNo).toBe(50);
+  });
+  it("aus Menü/gameover unberührt (kein Effekt)", () => {
+    const menu = menuState();
+    expect(reducer(menu, { type: "END_RUN" })).toBe(menu);
+    const over = { ...initialState(makeRng(1)), phase: "gameover" };
+    expect(reducer(over, { type: "END_RUN" })).toBe(over);
+  });
+});


### PR DESCRIPTION
Analog zu TrickLadder: „Beenden" beendet den Lauf, zeigt aber den GameOver-/Endscreen und speichert den Highscore — statt direkt ins Hauptmenü zu springen. Vom Endscreen aus: Neuer Lauf / Menü.

- **Reducer:** neue `END_RUN`-Action → `phase: "gameover"` (Menü/Gameover bleiben unberührt).
- **App:** `endRun()` dispatcht `END_RUN`; der bestehende `phase==="gameover"`-Effekt ruft `saveRun` (Highscore + Geist, idempotent via Ref-Guard). Controls „Beenden" → `endRun` statt `toMenu`; `toMenu` bleibt für „Menü" auf dem Endscreen.
- **Test:** `END_RUN` aus `play` → `gameover` (Score/State bleiben); aus Menü/gameover ohne Effekt.

Build + 110 Tests grün.