### PR TITLE
Tuning: Legendary-Gewicht 5 -> 7

### DIFF
--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -27,7 +27,7 @@ export const D4_MULT      = 3;    // D4  Score-Faktor
 export const D5_BONUS     = 300;  // D5  jeder 10. Sieg: Flat-Bonus
 
 // Legendäre Perks & Raritäts-System (#33) [TUNING]
-export const RARITY_WEIGHTS            = { common: 100, legendary: 5 }; // Ziehgewichte je Seltenheit (#38: 8→5)
+export const RARITY_WEIGHTS            = { common: 100, legendary: 7 }; // Ziehgewichte je Seltenheit (#38: 8→5→7)
 export const LEGENDARY_MIN_LEVEL       = 2;    // Legendaries erst ab diesem Level im Angebot (#38: 5→2)
 export const MAX_LEGENDARIES_PER_OFFER = 1;    // höchstens so viele Legendaries je Angebot
 export const L4_CRIT_STEP = 0.01;  // L4 Kritische Masse: +1 pp Crit-Chance je Crit


### PR DESCRIPTION
Legendaries etwas häufiger: `RARITY_WEIGHTS.legendary` 5 → 7.

- Angebots-Rate (ab Level 2, frischer Pool): ~3,1 % → **~4,2 %** pro Level-Up; steigt im Lauf weiter, wenn Commons aus dem Pool fallen.
- Reines Tuning (eine Konstante). Build + 110 Tests grün.