### PR TITLE
Perk-Overhaul Phase 1 (#71): 3-Stufen-Raritaet + 6 neue Normal-Perks

### DIFF
--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -27,8 +27,9 @@ export const D4_MULT      = 3;    // D4  Score-Faktor
 export const D5_BONUS     = 300;  // D5  jeder 10. Sieg: Flat-Bonus
 
 // Legendäre Perks & Raritäts-System (#33) [TUNING]
-export const RARITY_WEIGHTS            = { common: 100, legendary: 7 }; // Ziehgewichte je Seltenheit (#38: 8→5→7)
-export const LEGENDARY_MIN_LEVEL       = 2;    // Legendaries erst ab diesem Level im Angebot (#38: 5→2)
+export const RARITY_WEIGHTS            = { common: 100, rare: 25, legendary: 4 }; // 3-Stufen-Rarität (#71); „common" = normal
+export const RARE_MIN_LEVEL            = 2;    // Seltene Perks erst ab diesem Level im Angebot (#71)
+export const LEGENDARY_MIN_LEVEL       = 5;    // Legendaries erst ab diesem Level im Angebot (#71)
 export const MAX_LEGENDARIES_PER_OFFER = 1;    // höchstens so viele Legendaries je Angebot
 export const L4_CRIT_STEP = 0.01;  // L4 Kritische Masse: +1 pp Crit-Chance je Crit
 export const L4_CRIT_CAP  = 0.30;  // L4  … dauerhaft gedeckelt bei +30 pp

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -45,7 +45,7 @@ export function resolveTrick(state, rng = Math.random) {
   let {
     deck, oppDeck, playerOrder, oppOrder, pos, cycle, trickNo,
     life, maxLife, xp, level, score, winStreak, bestStreak, wins, losses, ties,
-    initiative, lastResult, perks, offer, shield, tieArmed,
+    initiative, lastResult, perks, offer, shield, tieArmed, sinceWin = 0,
     crits, critBonusScore, bestTrickScore, legendaryCritBonus = 0,
     // Ansage-System (#36)
     cycleWins = 0, cycleBaseScore = 0, prediction = null, lastPrediction = null,
@@ -63,6 +63,7 @@ export function resolveTrick(state, rng = Math.random) {
     lastResult,
     lostLastTrick: lastResult === "loss",
     winStreak,
+    sinceWin, // #71 Durchbruch: Stiche ohne Sieg (Stand VOR diesem Stich)
     life, maxLife, // L3 „Letztes Aufbäumen": cardBonus prüft das Leben-Verhältnis VOR der Auflösung
   };
   const pValue = effectivePlayerValue(pCard.value, perks, ctx);
@@ -82,7 +83,7 @@ export function resolveTrick(state, rng = Math.random) {
     winStreak += 1; wins += 1; cycleWins += 1; // cycleWins: Siege im laufenden Durchlauf (#36)
     if (winStreak > bestStreak) bestStreak = winStreak; // längste Serie des Runs (#8)
     // winStreak/wins enthalten hier bereits den gerade gewonnenen Stich.
-    const wctx = { winValue: pValue, winStreak, wins, trickNo, posInCycle: pos, speedPct: state.speedPct || 0 };
+    const wctx = { winValue: pValue, margin: pValue - oValue, winStreak, wins, trickNo, posInCycle: pos, speedPct: state.speedPct || 0 };
     // Score: Basis-Serien-Mult (#39, immer) × Perk-Multiplikatoren × Tempo, DANN additive Boni (D3/D5), DANN Crit.
     const tempoScoreMult = tempoScoreMultFor(perks, state.speedPct); // L6 „Raserei": Tempo-Faktor ×2
     scoreBeforeCrit = C.SCORE_PER_WIN * streakBaseMult(winStreak) * prodHook(perks, "scoreMult", wctx) * tempoScoreMult
@@ -105,21 +106,24 @@ export function resolveTrick(state, rng = Math.random) {
     life = Math.min(maxLife, life + healed);
     initiative = "player";
     if (tieConverted) tieArmed = false;
+    sinceWin = 0; // #71 Durchbruch: Sieg setzt den Zähler zurück
     lastResult = "win";
   } else if (lost) {
     losses += 1; winStreak = 0;
     // Flat-Grundschaden (#59: die #32-Zeiteskalation ist raus; Zeit-Pressure läuft jetzt über den
     // periodischen LIFE_DRAIN). Legendär-Zusatzschaden (L1 +3 / L6 +2) addiert; dmgReduce (C3) zieht
     // ab, Schild (C5) absorbiert danach (s. u.).
-    dmg = Math.max(0, C.DMG_PER_LOSS + sumHook(perks, "extraDamageTaken", {}) - sumHook(perks, "dmgReduce", {}));
+    dmg = Math.max(0, C.DMG_PER_LOSS + sumHook(perks, "extraDamageTaken", {}) - sumHook(perks, "dmgReduce", { life, maxLife }));
     // Schild (C5) absorbiert NACH der Schadensberechnung, vor dem Leben.
     if (shield > 0 && dmg > 0) { const absorbed = Math.min(shield, dmg); shield -= absorbed; dmg -= absorbed; }
     life -= dmg;
     initiative = "opp";
     if (ownsFlag(perks, "winTieAfterLoss")) tieArmed = true;
+    sinceWin += 1; // #71 Durchbruch: kein Sieg → Zähler hoch
     lastResult = "loss";
   } else {
     ties += 1;
+    sinceWin += 1; // #71 Durchbruch: Gleichstand zählt als „kein Sieg" weiter
     lastResult = "tie";
     // Serie & Initiative unverändert
   }
@@ -144,7 +148,7 @@ export function resolveTrick(state, rng = Math.random) {
       crits, critBonusScore, bestTrickScore, legendaryCritBonus,
       cycleWins, cycleBaseScore, prediction, lastPrediction, lastPredictionResult,
       predictionBonusScore, exactPredictions, nearPredictions, largestPredictionBonus,
-      initiative, lastResult, offer, shield, tieArmed,
+      initiative, lastResult, offer, shield, tieArmed, sinceWin,
       lastTrick, phase: "gameover",
     };
   }
@@ -202,7 +206,7 @@ export function resolveTrick(state, rng = Math.random) {
     predictionBonusScore, exactPredictions, nearPredictions, largestPredictionBonus, predictionDue,
     life, maxLife, xp, level, score, winStreak, bestStreak, wins, losses, ties,
     crits, critBonusScore, bestTrickScore, legendaryCritBonus,
-    initiative, lastResult, perks, offer: newOffer, shield, tieArmed, pendingLevelUps,
+    initiative, lastResult, perks, offer: newOffer, shield, tieArmed, pendingLevelUps, sinceWin,
     lastTrick, phase,
   };
 }

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -32,6 +32,15 @@ import { shuffle } from "./deck.js";
 const bumpWhere = (deck, pred, delta) =>
   deck.map((c) => (pred(c) ? { ...c, value: c.value + delta } : c));
 
+// #71: die n Karten mit dem höchsten (dir="desc") bzw. niedrigsten (dir="asc") aktuellen Wert
+// um delta anheben. Stabiler Sort (Ties nach ursprünglichem Index) → deterministisch, kein rng.
+const bumpTopN = (deck, n, delta, dir) => {
+  const order = deck.map((_, i) => i).sort((a, b) =>
+    dir === "desc" ? deck[b].value - deck[a].value : deck[a].value - deck[b].value);
+  const pick = new Set(order.slice(0, n));
+  return deck.map((c, i) => (pick.has(i) ? { ...c, value: c.value + delta } : c));
+};
+
 // D2-Kombo: eskalierender Siegesserien-Multiplikator (+D2_STEP je Serienstufe, KEIN Cap, #31).
 // EINE Formel als geteilte Quelle für Score-Berechnung (D2-Hook) UND Anzeige (comboMultFor →
 // Battlefield-Float) → kein Drift, analog zum Muster von scoreMultFor/critChanceFor (#23/#25).
@@ -73,6 +82,26 @@ export const PERK_DEFS = {
           const chosen = new Set(shuffle(idx, rng).slice(0, 4)); // bis zu 4 unterschiedliche Karten
           return d.map((c, i) => (chosen.has(i) ? { ...c, value: c.value + 6 } : c));
         } },
+
+  // ---- Neue Normal-Perks (#71) — Anzeige-Gruppe über `cat` (A Deck / B Stich / C Leben) ----
+  A6: { id: "A6", cat: "A", label: "Mittelklasse",
+        desc: "Alle Karten mit aktuellem Wert 4–7 erhalten dauerhaft +2 Wert.",
+        onPick: (d) => bumpWhere(d, (c) => c.value >= 4 && c.value <= 7, 2) },
+  A7: { id: "A7", cat: "A", label: "Spitzenförderung",
+        desc: "Die vier aktuell höchsten Karten erhalten dauerhaft je +6 Wert.",
+        onPick: (d) => bumpTopN(d, 4, 6, "desc") },
+  A8: { id: "A8", cat: "A", label: "Nachzügler",
+        desc: "Die vier aktuell niedrigsten Karten erhalten dauerhaft je +6 Wert.",
+        onPick: (d) => bumpTopN(d, 4, 6, "asc") },
+  B6: { id: "B6", cat: "B", label: "Knappe Kiste",
+        desc: "Gewinnst du mit exakt 1 Wertpunkt Vorsprung, +100 Score.",
+        scoreFlat: (ctx) => (ctx.margin === 1 ? 100 : 0) },
+  B7: { id: "B7", cat: "B", label: "Durchbruch",
+        desc: "Nach fünf Stichen ohne Sieg erhält die nächste Karte +10 Wert (Sieg setzt zurück, Gleichstand zählt weiter).",
+        cardBonus: (ctx) => ((ctx.sinceWin || 0) >= 5 ? 10 : 0) },
+  C6: { id: "C6", cat: "C", label: "Trotz",
+        desc: "Unter 50 % Leben −1 Schaden bei Niederlagen; bei 25 % oder weniger insgesamt −2.",
+        dmgReduce: ({ life, maxLife }) => (maxLife > 0 && life / maxLife <= 0.25 ? 2 : maxLife > 0 && life / maxLife < 0.5 ? 1 : 0) },
 
   // ---- B: Stich-Effekte (Wert-Bonus auf die aktuelle Karte) ----
   B1: { id: "B1", cat: "B", label: "Gegenangriff",
@@ -156,8 +185,8 @@ export const PERK_DEFS = {
         desc: "Ab 3 Siegen in Folge gewinnst du alle Gleichstände, bis die Serie endet.",
         winTie: ({ winStreak }) => winStreak >= 3 },
   L3: { id: "L3", cat: "C", rarity: "legendary", label: "Letztes Aufbäumen",
-        desc: "Bei 25 % Leben oder weniger erhalten alle Karten +6 Wert für den aktuellen Stich.",
-        cardBonus: ({ life, maxLife }) => (maxLife > 0 && life / maxLife <= 0.25 ? 6 : 0) },
+        desc: "Bei 25 % Leben oder weniger erhalten alle Karten +3 Wert für den aktuellen Stich.",
+        cardBonus: ({ life, maxLife }) => (maxLife > 0 && life / maxLife <= 0.25 ? 3 : 0) }, // #71: +6→+3
   L4: { id: "L4", cat: "D", rarity: "legendary", label: "Kritische Masse",
         desc: "Jeder Crit erhöht deine Crit-Chance dauerhaft um 1 Prozentpunkt (max +30 pp).",
         legendaryCritGain: true }, // Engine führt legendaryCritBonus (Erhöhung NACH dem Crit-Wurf)
@@ -179,8 +208,11 @@ export const isLegendary = (id) => rarityOf(id) === "legendary";
 // Deterministisch über den injizierten rng (ein rng()-Zug je Auswahl). Pool leer → weniger Perks.
 export function buildOffer(owned, rng, count, level = 1) {
   const legendaryOK = level >= C.LEGENDARY_MIN_LEVEL;
-  let pool = PERK_LIST.filter((p) =>
-    !owned.includes(p.id) && (legendaryOK || (p.rarity || "common") !== "legendary"));
+  const rareOK = level >= C.RARE_MIN_LEVEL; // #71: 3-Stufen-Gate — Seltene ab RARE_MIN_LEVEL
+  let pool = PERK_LIST.filter((p) => {
+    const r = p.rarity || "common";
+    return !owned.includes(p.id) && (r !== "legendary" || legendaryOK) && (r !== "rare" || rareOK);
+  });
   const chosen = [];
   let legendaries = 0;
   while (chosen.length < count && pool.length > 0) {

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -26,6 +26,7 @@ export function initialState(rng = Math.random) {
     nearPredictions: 0, largestPredictionBonus: 0, predictionDue: false,
     initiative: "player",
     lastResult: null,
+    sinceWin: 0, // #71 Durchbruch: aufeinanderfolgende Stiche ohne Sieg
     perks: [], offer: null,
     pendingLevelUps: 0, // #57: noch ausstehende Level-Up-Angebote (Mehrfach-Level-Up-Queue)
     speedPct: 0,

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -247,12 +247,12 @@ describe("Legendäre Perks (#33) — Engine-Integration", () => {
     expect(s.lastTrick.result).toBe("tie");
     expect(s.winStreak).toBe(2);
   });
-  it("L3 Letztes Aufbäumen: +6 Kartenwert bei ≤25 % Leben kippt den Stich, > 25 % nicht", () => {
-    const low = resolveTrick(scenario(4, 8, { perks: ["L3"], life: 500, maxLife: 2000 }), rng);
-    expect(low.lastTrick.pValue).toBe(10); // 4 + 6
+  it("L3 Letztes Aufbäumen: +3 Kartenwert bei ≤25 % Leben kippt den Stich, > 25 % nicht (#71)", () => {
+    const low = resolveTrick(scenario(6, 8, { perks: ["L3"], life: 500, maxLife: 2000 }), rng);
+    expect(low.lastTrick.pValue).toBe(9); // 6 + 3
     expect(low.wins).toBe(1);
-    const high = resolveTrick(scenario(4, 8, { perks: ["L3"], life: 501, maxLife: 2000 }), rng);
-    expect(high.lastTrick.pValue).toBe(4);
+    const high = resolveTrick(scenario(6, 8, { perks: ["L3"], life: 501, maxLife: 2000 }), rng);
+    expect(high.lastTrick.pValue).toBe(6);
     expect(high.losses).toBe(1);
   });
   it("L4 Kritische Masse: Bonus erst NACH einem Crit, gedeckelt bei +30 pp", () => {

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -74,16 +74,16 @@ describe("buildOffer", () => {
     expect(buildOffer(owned, makeRng(1), 3, 9)).toHaveLength(2); // nur A1/A2 übrig (Commons)
   });
 
-  // ---- Legendär / Rarität (#33, Gate ab Level 2 seit #38) ----
-  it("bietet unter Level 2 KEINE Legendaries (Level-Gate)", () => {
+  // ---- Legendär / Rarität (3-Stufen seit #71: Legendaries ab Level 5) ----
+  it("bietet unter Level 5 KEINE Legendaries (Level-Gate)", () => {
     for (let s = 0; s < 20; s++) {
-      expect(buildOffer([], makeRng(s), 3, 1).some(isLegendary)).toBe(false);
+      expect(buildOffer([], makeRng(s), 3, 4).some(isLegendary)).toBe(false);
     }
   });
-  it("ab Level 2 erscheinen Legendaries — höchstens EINER je Angebot", () => {
+  it("ab Level 5 erscheinen Legendaries — höchstens EINER je Angebot", () => {
     // Nur Legendaries übrig → das Angebot enthält genau 1 (max 1 pro Angebot), und der ist legendär.
     const owned = PERK_LIST.filter((p) => !isLegendary(p.id)).map((p) => p.id);
-    const off = buildOffer(owned, makeRng(3), 3, 2);
+    const off = buildOffer(owned, makeRng(3), 3, 5);
     expect(off).toHaveLength(1);
     expect(isLegendary(off[0])).toBe(true);
   });
@@ -134,9 +134,9 @@ describe("Legendäre Perks — reine Hooks (#33)", () => {
     expect(PERK_DEFS.L2.winTie({ winStreak: 3 })).toBe(true);
     expect(PERK_DEFS.L2.winTie({ winStreak: 2 })).toBe(false);
   });
-  it("L3 Letztes Aufbäumen: +6 bei ≤ 25 % Leben (auch exakt 25 %), sonst 0", () => {
-    expect(PERK_DEFS.L3.cardBonus({ life: 500, maxLife: 2000 })).toBe(6); // 25 %
-    expect(PERK_DEFS.L3.cardBonus({ life: 400, maxLife: 2000 })).toBe(6); // < 25 %
+  it("L3 Letztes Aufbäumen: +3 bei ≤ 25 % Leben (auch exakt 25 %), sonst 0 (#71)", () => {
+    expect(PERK_DEFS.L3.cardBonus({ life: 500, maxLife: 2000 })).toBe(3); // 25 %
+    expect(PERK_DEFS.L3.cardBonus({ life: 400, maxLife: 2000 })).toBe(3); // < 25 %
     expect(PERK_DEFS.L3.cardBonus({ life: 501, maxLife: 2000 })).toBe(0); // > 25 %
   });
   it("L6 Raserei: verdoppelt NUR den Tempo-Faktor (via tempoScoreMultFor)", () => {
@@ -195,5 +195,43 @@ describe("comboMultFor (D2-Kombo, geteilte Anzeige-Quelle #31)", () => {
   it("neutral (1) ohne D2 — die Kombo IST der D2-Effekt", () => {
     expect(comboMultFor(["D1", "D4"], 20)).toBe(1);
     expect(comboMultFor([], 20)).toBe(1);
+  });
+});
+
+describe("Neue Normal-Perks (#71)", () => {
+  const sumV = (d) => d.reduce((s, c) => s + c.value, 0);
+  it("A6 Mittelklasse: Werte 4–7 je +2 (Startdeck 16 Karten → +32)", () => {
+    expect(sumV(PERK_DEFS.A6.onPick(buildDeck())) - sumV(buildDeck())).toBe(32);
+  });
+  it("A7 Spitzenförderung: die vier höchsten Karten je +6 (+24; vier 10er → 16)", () => {
+    expect(sumV(PERK_DEFS.A7.onPick(buildDeck())) - sumV(buildDeck())).toBe(24);
+    expect(PERK_DEFS.A7.onPick(buildDeck()).filter((c) => c.value === 16)).toHaveLength(4);
+  });
+  it("A8 Nachzügler: die vier niedrigsten Karten je +6 (+24; vier 1er → 7)", () => {
+    expect(sumV(PERK_DEFS.A8.onPick(buildDeck())) - sumV(buildDeck())).toBe(24);
+    expect(PERK_DEFS.A8.onPick(buildDeck()).filter((c) => c.value === 7 && c.baseRank === 1)).toHaveLength(4);
+  });
+  it("B6 Knappe Kiste: +100 nur bei genau 1 Wertpunkt Vorsprung", () => {
+    expect(PERK_DEFS.B6.scoreFlat({ margin: 1 })).toBe(100);
+    expect(PERK_DEFS.B6.scoreFlat({ margin: 2 })).toBe(0);
+    expect(PERK_DEFS.B6.scoreFlat({ margin: 0 })).toBe(0);
+  });
+  it("B7 Durchbruch: +10 ab 5 Stichen ohne Sieg", () => {
+    expect(PERK_DEFS.B7.cardBonus({ sinceWin: 4 })).toBe(0);
+    expect(PERK_DEFS.B7.cardBonus({ sinceWin: 5 })).toBe(10);
+    expect(PERK_DEFS.B7.cardBonus({ sinceWin: 8 })).toBe(10);
+  });
+  it("C6 Trotz: −1 unter 50 %, −2 bei ≤ 25 % Leben", () => {
+    expect(PERK_DEFS.C6.dmgReduce({ life: 1500, maxLife: 2000 })).toBe(0); // 75 %
+    expect(PERK_DEFS.C6.dmgReduce({ life: 900, maxLife: 2000 })).toBe(1);  // 45 %
+    expect(PERK_DEFS.C6.dmgReduce({ life: 500, maxLife: 2000 })).toBe(2);  // 25 %
+  });
+});
+
+describe("Durchbruch (B7) — sinceWin-Zähler in der Engine (#71)", () => {
+  it("+10 auf die Karte nach 5 Stichen ohne Sieg", () => {
+    // sinceWin=5 im State → Durchbruch-cardBonus greift für DIESEN Stich (Karte 3 → 13).
+    expect(effectivePlayerValue(3, ["B7"], { sinceWin: 5 })).toBe(13);
+    expect(effectivePlayerValue(3, ["B7"], { sinceWin: 4 })).toBe(3);
   });
 });


### PR DESCRIPTION
**Phase 1** von #71 — die kohärente, testbare Basis. Rares + neue Legendaries folgen in eigenen PRs.

## Rarität (3 Stufen)
- `RARITY_WEIGHTS = { common: 100, rare: 25, legendary: 4 }` (legendary 7→4, per #71).
- Neue `RARE_MIN_LEVEL = 2`; `LEGENDARY_MIN_LEVEL` 2→**5**.
- `buildOffer` erweitert: `rare`/`legendary` gewichtet ohne Zurücklegen, Level-Gates je Stufe, Legendary-Cap bleibt. Die `rare`-Stufe ist **Infrastruktur** — noch ohne rare Perks (Phase 2).

## Neue Normal-Perks (35er-Ziel: 29 → 35)
- **A6 Mittelklasse** — Wert 4–7 dauerhaft +2
- **A7 Spitzenförderung** — die vier höchsten Karten je +6
- **A8 Nachzügler** — die vier niedrigsten Karten je +6
- **B6 Knappe Kiste** — +100 Score bei genau 1 Wertpunkt Vorsprung
- **B7 Durchbruch** — +10 Kartenwert nach 5 Stichen ohne Sieg
- **C6 Trotz** — −1 Schaden unter 50 %, −2 bei ≤ 25 % Leben

## Engine-Hooks dafür
- `sinceWin`-Zähler (Durchbruch; Sieg→0, Niederlage/Gleichstand→+1), im State + cardBonus-ctx.
- `margin` (pValue−oValue) im win-ctx (Knappe Kiste).
- `dmgReduce`-ctx `{life,maxLife}` (Trotz).
- **L3 Letztes Aufbäumen +6→+3** (Rebalance).

## Verifikation
- Build + **117 Tests** grün (7 neu). Legendary-Gate-/L3-Tests auf die neuen Werte gezogen.
- Determinismus gewahrt (Sort ohne rng, keine neuen Date/Math.random).

Teil von #71 (Phase 1).