### PR TITLE
Perk-Overhaul Phase 2b (#71): 3 Historie-Rares

### DIFF
--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -46,6 +46,7 @@ export function resolveTrick(state, rng = Math.random) {
     deck, oppDeck, playerOrder, oppOrder, pos, cycle, trickNo,
     life, maxLife, xp, level, score, winStreak, bestStreak, wins, losses, ties,
     initiative, lastResult, perks, offer, shield, tieArmed, sinceWin = 0,
+    lossStreak = 0, lastWinValue = null, altLen = 0, // #71 Rares: Revanche / Präzision / Wechselspiel
     crits, critBonusScore, bestTrickScore, legendaryCritBonus = 0,
     // Ansage-System (#36)
     cycleWins = 0, cycleBaseScore = 0, prediction = null, lastPrediction = null,
@@ -64,6 +65,7 @@ export function resolveTrick(state, rng = Math.random) {
     lostLastTrick: lastResult === "loss",
     winStreak,
     sinceWin, // #71 Durchbruch: Stiche ohne Sieg (Stand VOR diesem Stich)
+    lossStreak, // #71 Revanche: aufeinanderfolgende Niederlagen (Stand VOR diesem Stich)
     life, maxLife, // L3 „Letztes Aufbäumen": cardBonus prüft das Leben-Verhältnis VOR der Auflösung
   };
   const pValue = effectivePlayerValue(pCard.value, perks, ctx);
@@ -76,6 +78,11 @@ export function resolveTrick(state, rng = Math.random) {
   else if (tieArmed || anyHookTrue(perks, "winTie", ctx)) { won = true; tieConverted = true; }
   // sonst echter Gleichstand: kein Effekt (§4.1)
 
+  // #71 Wechselspiel: Länge der aktuellen strikten Sieg/Niederlage-Alternation (Gleichstand bricht sie).
+  const curRes = won ? "win" : lost ? "loss" : "tie";
+  altLen = curRes === "tie" ? 0
+    : (curRes !== lastResult && (lastResult === "win" || lastResult === "loss")) ? altLen + 1 : 1;
+
   let gained = 0, dmg = 0, healed = 0;
   let isCrit = false, critChance = 0, critMultiplier = C.CRIT_BASE_MULT, scoreBeforeCrit = 0, critBonus = 0;
 
@@ -83,7 +90,8 @@ export function resolveTrick(state, rng = Math.random) {
     winStreak += 1; wins += 1; cycleWins += 1; // cycleWins: Siege im laufenden Durchlauf (#36)
     if (winStreak > bestStreak) bestStreak = winStreak; // längste Serie des Runs (#8)
     // winStreak/wins enthalten hier bereits den gerade gewonnenen Stich.
-    const wctx = { winValue: pValue, margin: pValue - oValue, winStreak, wins, trickNo, posInCycle: pos, speedPct: state.speedPct || 0 };
+    const wctx = { winValue: pValue, margin: pValue - oValue, winStreak, wins, trickNo, posInCycle: pos, speedPct: state.speedPct || 0,
+                   lastWinValue, altLen }; // #71: Präzision (Vergleich mit letztem Siegwert) / Wechselspiel
     // Score: Basis-Serien-Mult (#39, immer) × Perk-Multiplikatoren × Tempo, DANN additive Boni (D3/D5), DANN Crit.
     const tempoScoreMult = tempoScoreMultFor(perks, state.speedPct); // L6 „Raserei": Tempo-Faktor ×2
     scoreBeforeCrit = C.SCORE_PER_WIN * streakBaseMult(winStreak) * prodHook(perks, "scoreMult", wctx) * tempoScoreMult
@@ -107,6 +115,8 @@ export function resolveTrick(state, rng = Math.random) {
     initiative = "player";
     if (tieConverted) tieArmed = false;
     sinceWin = 0; // #71 Durchbruch: Sieg setzt den Zähler zurück
+    lossStreak = 0; // #71 Revanche: Sieg beendet die Niederlagenserie
+    lastWinValue = pValue; // #71 Präzision: letzten Siegwert merken (NACH dem Vergleich in wctx)
     lastResult = "win";
   } else if (lost) {
     losses += 1; winStreak = 0;
@@ -120,10 +130,12 @@ export function resolveTrick(state, rng = Math.random) {
     initiative = "opp";
     if (ownsFlag(perks, "winTieAfterLoss")) tieArmed = true;
     sinceWin += 1; // #71 Durchbruch: kein Sieg → Zähler hoch
+    lossStreak += 1; // #71 Revanche: aufeinanderfolgende Niederlagen
     lastResult = "loss";
   } else {
     ties += 1;
     sinceWin += 1; // #71 Durchbruch: Gleichstand zählt als „kein Sieg" weiter
+    lossStreak = 0; // #71 Revanche: Gleichstand ist keine Niederlage → Serie bricht
     lastResult = "tie";
     // Serie & Initiative unverändert
   }
@@ -148,7 +160,7 @@ export function resolveTrick(state, rng = Math.random) {
       crits, critBonusScore, bestTrickScore, legendaryCritBonus,
       cycleWins, cycleBaseScore, prediction, lastPrediction, lastPredictionResult,
       predictionBonusScore, exactPredictions, nearPredictions, largestPredictionBonus,
-      initiative, lastResult, offer, shield, tieArmed, sinceWin,
+      initiative, lastResult, offer, shield, tieArmed, sinceWin, lossStreak, lastWinValue, altLen,
       lastTrick, phase: "gameover",
     };
   }
@@ -206,7 +218,7 @@ export function resolveTrick(state, rng = Math.random) {
     predictionBonusScore, exactPredictions, nearPredictions, largestPredictionBonus, predictionDue,
     life, maxLife, xp, level, score, winStreak, bestStreak, wins, losses, ties,
     crits, critBonusScore, bestTrickScore, legendaryCritBonus,
-    initiative, lastResult, perks, offer: newOffer, shield, tieArmed, pendingLevelUps, sinceWin,
+    initiative, lastResult, perks, offer: newOffer, shield, tieArmed, pendingLevelUps, sinceWin, lossStreak, lastWinValue, altLen,
     lastTrick, phase,
   };
 }

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -134,6 +134,17 @@ export const PERK_DEFS = {
         desc: "Jeder zehnte Stich gibt bei einem Sieg +150 Score.",
         scoreFlat: (ctx) => (ctx.trickNo % 10 === 0 ? 150 : 0) },
 
+  // ---- Seltene Perks (#71, Phase 2b) — Ergebnis-/Wert-Historie (neue State-Felder) ----
+  B8: { id: "B8", cat: "B", rarity: "rare", label: "Revanche",
+        desc: "Nach zwei aufeinanderfolgenden Niederlagen erhält die nächste Karte +7 Wert.",
+        cardBonus: (ctx) => ((ctx.lossStreak || 0) >= 2 ? 7 : 0) },
+  D12: { id: "D12", cat: "D", rarity: "rare", label: "Präzision",
+        desc: "Gewinnst du mit demselben aktuellen Kartenwert wie beim vorherigen Sieg, ×3 Score.",
+        scoreMult: (ctx) => (ctx.lastWinValue != null && ctx.winValue === ctx.lastWinValue ? 3 : 1) },
+  D13: { id: "D13", cat: "D", rarity: "rare", label: "Wechselspiel",
+        desc: "Sobald sich Sieg und Niederlage abwechseln, gibt jeder weitere Sieg im Wechselmuster +100 Score.",
+        scoreFlat: (ctx) => ((ctx.altLen || 0) >= 3 ? 100 : 0) },
+
   // ---- B: Stich-Effekte (Wert-Bonus auf die aktuelle Karte) ----
   B1: { id: "B1", cat: "B", label: "Gegenangriff",
         desc: "Nach einem verlorenen Stich erhält die nächste Karte +2 Wert.",

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -27,6 +27,7 @@ export function initialState(rng = Math.random) {
     initiative: "player",
     lastResult: null,
     sinceWin: 0, // #71 Durchbruch: aufeinanderfolgende Stiche ohne Sieg
+    lossStreak: 0, lastWinValue: null, altLen: 0, // #71 Rares: Revanche / Präzision / Wechselspiel
     perks: [], offer: null,
     pendingLevelUps: 0, // #57: noch ausstehende Level-Up-Angebote (Mehrfach-Level-Up-Queue)
     speedPct: 0,

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -416,3 +416,19 @@ describe("Seltene Perks — Engine (#71)", () => {
     expect(resolveTrick(scenario(0, 12, { perks: ["E7"], life: 100 }), rng).life).toBe(89); // 10+1
   });
 });
+
+describe("Historie-Rares — Engine (#71 Phase 2b)", () => {
+  it("B8 Revanche: nach 2 Niederlagen +7 auf die nächste Karte", () => {
+    expect(resolveTrick(scenario(3, 8, { perks: ["B8"], lossStreak: 2, life: 1000 }), rng).lastTrick.pValue).toBe(10);
+    expect(resolveTrick(scenario(3, 8, { perks: ["B8"], lossStreak: 1, life: 1000 }), rng).lastTrick.pValue).toBe(3);
+  });
+  it("D12 Präzision: ×3 bei Übereinstimmung mit dem letzten Siegwert; lastWinValue wird gesetzt", () => {
+    expect(resolveTrick(scenario(12, 0, { perks: ["D12"], lastWinValue: 12 }), rng).score).toBeCloseTo(306); // 100×1,02×3
+    expect(resolveTrick(scenario(12, 0, { perks: ["D12"], lastWinValue: 11 }), rng).score).toBeCloseTo(102);
+    expect(resolveTrick(scenario(9, 0, { perks: ["D12"] }), rng).lastWinValue).toBe(9);
+  });
+  it("D13 Wechselspiel: +100, wenn ein Sieg das W/L-Muster fortsetzt (altLen ≥3)", () => {
+    expect(resolveTrick(scenario(12, 0, { perks: ["D13"], lastResult: "loss", altLen: 2 }), rng).lastTrick.gained).toBeCloseTo(202);
+    expect(resolveTrick(scenario(12, 0, { perks: ["D13"], lastResult: "win", altLen: 5 }), rng).lastTrick.gained).toBeCloseTo(102);
+  });
+});

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -274,3 +274,19 @@ describe("Seltene Perks (#71, Phase 2a)", () => {
     expect(off.every((id) => PERK_DEFS[id].rarity === "rare")).toBe(true);
   });
 });
+
+describe("Seltene Perks (#71, Phase 2b — Historie-Hooks)", () => {
+  it("B8 Revanche: +7 ab 2 Niederlagen in Folge", () => {
+    expect(PERK_DEFS.B8.cardBonus({ lossStreak: 2 })).toBe(7);
+    expect(PERK_DEFS.B8.cardBonus({ lossStreak: 1 })).toBe(0);
+  });
+  it("D12 Präzision: ×3 bei gleichem Wert wie letzter Sieg (erster Sieg ×1)", () => {
+    expect(PERK_DEFS.D12.scoreMult({ winValue: 8, lastWinValue: 8 })).toBe(3);
+    expect(PERK_DEFS.D12.scoreMult({ winValue: 8, lastWinValue: 7 })).toBe(1);
+    expect(PERK_DEFS.D12.scoreMult({ winValue: 8, lastWinValue: null })).toBe(1);
+  });
+  it("D13 Wechselspiel: +100 ab Alternations-Länge 3", () => {
+    expect(PERK_DEFS.D13.scoreFlat({ altLen: 3 })).toBe(100);
+    expect(PERK_DEFS.D13.scoreFlat({ altLen: 2 })).toBe(0);
+  });
+});


### PR DESCRIPTION
Erste **stateful Seltene** von #71 — Ergebnis-/Wert-Historie.

- **B8 Revanche** — +7 auf die nächste Karte nach 2 Niederlagen in Folge (`lossStreak`)
- **D12 Präzision** — ×3 Score bei gleichem Siegwert wie beim vorherigen Sieg (`lastWinValue`)
- **D13 Wechselspiel** — +100 je Sieg, der das W/L-Wechselmuster fortsetzt, ab Alternations-Länge 3 (`altLen`)

Engine: drei neue Run-State-Felder + ctx-Threading (`lossStreak` in cardBonus-ctx, `lastWinValue`/`altLen` im win-ctx; `altLen` aus dem Ergebnis VOR den Branches berechnet, Gleichstand bricht die Alternation).

Build + **133 Tests** grün (+6, Hooks + Engine-Integration). `game/` deterministisch.

Teil von #71 (Phase 2b). Restliche Rares (Crit-Historie, per-Durchlauf, Tempo, Super-Crit) folgen.