### PR TITLE
#71 Phase 2c: Crit-Historie-Rares (Crit-Folge / Fehlzündung / Schwachstellenanalyse)

### DIFF
--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -47,6 +47,7 @@ export function resolveTrick(state, rng = Math.random) {
     life, maxLife, xp, level, score, winStreak, bestStreak, wins, losses, ties,
     initiative, lastResult, perks, offer, shield, tieArmed, sinceWin = 0,
     lossStreak = 0, lastWinValue = null, altLen = 0, // #71 Rares: Revanche / Präzision / Wechselspiel
+    critFollowArmed = false, misfireBonus = 0, weaknessArmed = false, // #71 Crit-Historie: Crit-Folge / Fehlzündung / Schwachstellenanalyse
     crits, critBonusScore, bestTrickScore, legendaryCritBonus = 0,
     // Ansage-System (#36)
     cycleWins = 0, cycleBaseScore = 0, prediction = null, lastPrediction = null,
@@ -91,7 +92,8 @@ export function resolveTrick(state, rng = Math.random) {
     if (winStreak > bestStreak) bestStreak = winStreak; // längste Serie des Runs (#8)
     // winStreak/wins enthalten hier bereits den gerade gewonnenen Stich.
     const wctx = { winValue: pValue, margin: pValue - oValue, winStreak, wins, trickNo, posInCycle: pos, speedPct: state.speedPct || 0,
-                   lastWinValue, altLen }; // #71: Präzision (Vergleich mit letztem Siegwert) / Wechselspiel
+                   lastWinValue, altLen, // #71: Präzision (Vergleich mit letztem Siegwert) / Wechselspiel
+                   critFollowArmed, misfireBonus, weaknessArmed }; // #71 Crit-Historie: Stand VOR diesem Sieg (feed critChance-Hooks)
     // Score: Basis-Serien-Mult (#39, immer) × Perk-Multiplikatoren × Tempo, DANN additive Boni (D3/D5), DANN Crit.
     const tempoScoreMult = tempoScoreMultFor(perks, state.speedPct); // L6 „Raserei": Tempo-Faktor ×2
     scoreBeforeCrit = C.SCORE_PER_WIN * streakBaseMult(winStreak) * prodHook(perks, "scoreMult", wctx) * tempoScoreMult
@@ -99,6 +101,10 @@ export function resolveTrick(state, rng = Math.random) {
     critChance = critChanceFor(perks, wctx, legendaryCritBonus); // inkl. L4-Bonus & L5-Halbierung
     critMultiplier = critMultiplierFor(perks, wctx);             // L5 „Jackpot": ×4 überschreibt Basis ×2
     isCrit = rollCrit(critChance, ownsGuaranteedCrit(perks, wctx), rng);
+    // #71 Crit-Historie: Update NACH dem Wurf (wctx trug den Stand davor).
+    critFollowArmed = isCrit;                                        // Crit-Folge: nur ein Crit rüstet den nächsten Sieg
+    misfireBonus = isCrit ? 0 : Math.min(misfireBonus + 0.03, 0.30); // Fehlzündung: +3 pp je Sieg ohne Crit, Crit setzt zurück
+    weaknessArmed = false;                                           // Schwachstellenanalyse: durch diesen Sieg verbraucht
     gained = scoreBeforeCrit * (isCrit ? critMultiplier : 1);
     critBonus = gained - scoreBeforeCrit;
     score += gained;
@@ -131,6 +137,7 @@ export function resolveTrick(state, rng = Math.random) {
     if (ownsFlag(perks, "winTieAfterLoss")) tieArmed = true;
     sinceWin += 1; // #71 Durchbruch: kein Sieg → Zähler hoch
     lossStreak += 1; // #71 Revanche: aufeinanderfolgende Niederlagen
+    if (oValue - pValue >= 5) weaknessArmed = true; // #71 Schwachstellenanalyse: klare Niederlage rüstet nächsten Sieg
     lastResult = "loss";
   } else {
     ties += 1;
@@ -161,6 +168,7 @@ export function resolveTrick(state, rng = Math.random) {
       cycleWins, cycleBaseScore, prediction, lastPrediction, lastPredictionResult,
       predictionBonusScore, exactPredictions, nearPredictions, largestPredictionBonus,
       initiative, lastResult, offer, shield, tieArmed, sinceWin, lossStreak, lastWinValue, altLen,
+      critFollowArmed, misfireBonus, weaknessArmed,
       lastTrick, phase: "gameover",
     };
   }
@@ -219,6 +227,7 @@ export function resolveTrick(state, rng = Math.random) {
     life, maxLife, xp, level, score, winStreak, bestStreak, wins, losses, ties,
     crits, critBonusScore, bestTrickScore, legendaryCritBonus,
     initiative, lastResult, perks, offer: newOffer, shield, tieArmed, pendingLevelUps, sinceWin, lossStreak, lastWinValue, altLen,
+    critFollowArmed, misfireBonus, weaknessArmed,
     lastTrick, phase,
   };
 }

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -145,6 +145,17 @@ export const PERK_DEFS = {
         desc: "Sobald sich Sieg und Niederlage abwechseln, gibt jeder weitere Sieg im Wechselmuster +100 Score.",
         scoreFlat: (ctx) => ((ctx.altLen || 0) >= 3 ? 100 : 0) },
 
+  // ---- Seltene Perks (#71, Phase 2c) — Crit-Historie (neue Engine-State-Felder) ----
+  D14: { id: "D14", cat: "D", rarity: "rare", label: "Crit-Folge",
+        desc: "Nach einem Crit erhält der nächste gewonnene Stich +20 % Crit-Chance (beim nächsten Sieg verbraucht).",
+        critChance: (ctx) => (ctx.critFollowArmed ? 0.20 : 0) },
+  D15: { id: "D15", cat: "D", rarity: "rare", label: "Fehlzündung",
+        desc: "Jeder Sieg ohne Crit gibt +3 % Crit-Chance (max +30 %); ein Crit setzt den Bonus zurück.",
+        critChance: (ctx) => (ctx.misfireBonus || 0) },
+  D16: { id: "D16", cat: "D", rarity: "rare", label: "Schwachstellenanalyse",
+        desc: "Verlierst du mit mindestens 5 Wertpunkten Abstand, erhält der nächste gewonnene Stich +40 % Crit-Chance.",
+        critChance: (ctx) => (ctx.weaknessArmed ? 0.40 : 0) },
+
   // ---- B: Stich-Effekte (Wert-Bonus auf die aktuelle Karte) ----
   B1: { id: "B1", cat: "B", label: "Gegenangriff",
         desc: "Nach einem verlorenen Stich erhält die nächste Karte +2 Wert.",

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -28,6 +28,7 @@ export function initialState(rng = Math.random) {
     lastResult: null,
     sinceWin: 0, // #71 Durchbruch: aufeinanderfolgende Stiche ohne Sieg
     lossStreak: 0, lastWinValue: null, altLen: 0, // #71 Rares: Revanche / Präzision / Wechselspiel
+    critFollowArmed: false, misfireBonus: 0, weaknessArmed: false, // #71 Crit-Historie: Crit-Folge / Fehlzündung / Schwachstellenanalyse
     perks: [], offer: null,
     pendingLevelUps: 0, // #57: noch ausstehende Level-Up-Angebote (Mehrfach-Level-Up-Queue)
     speedPct: 0,

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -432,3 +432,33 @@ describe("Historie-Rares — Engine (#71 Phase 2b)", () => {
     expect(resolveTrick(scenario(12, 0, { perks: ["D13"], lastResult: "win", altLen: 5 }), rng).lastTrick.gained).toBeCloseTo(102);
   });
 });
+
+describe("Crit-Historie-Rares — Engine (#71 Phase 2c)", () => {
+  const never = () => 0.99; // Crit-Wurf schlägt nie an → Zustandsübergänge isoliert testbar
+
+  it("D14 Crit-Folge: +20 % Crit-Chance nur wenn gerüstet", () => {
+    expect(resolveTrick(scenario(12, 0, { perks: ["D14"], critFollowArmed: true }), never).lastTrick.critChance).toBeCloseTo(0.20);
+    expect(resolveTrick(scenario(12, 0, { perks: ["D14"], critFollowArmed: false }), never).lastTrick.critChance).toBeCloseTo(0);
+  });
+  it("D14: ein Crit rüstet, ein Sieg ohne Crit entrüstet", () => {
+    expect(resolveTrick(scenario(12, 0, { perks: ["D9"], wins: 9 }), rng).critFollowArmed).toBe(true);  // D9-Garantie-Crit
+    expect(resolveTrick(scenario(12, 0, { critFollowArmed: true }), never).critFollowArmed).toBe(false); // Sieg ohne Crit
+  });
+
+  it("D15 Fehlzündung: misfireBonus speist die Crit-Chance", () => {
+    expect(resolveTrick(scenario(12, 0, { perks: ["D15"], misfireBonus: 0.09 }), never).lastTrick.critChance).toBeCloseTo(0.09);
+  });
+  it("D15: +3 pp je Sieg ohne Crit, gedeckelt bei +30 pp, Crit setzt zurück", () => {
+    expect(resolveTrick(scenario(12, 0, { misfireBonus: 0 }), never).misfireBonus).toBeCloseTo(0.03);
+    expect(resolveTrick(scenario(12, 0, { misfireBonus: 0.29 }), never).misfireBonus).toBeCloseTo(0.30); // Deckel
+    expect(resolveTrick(scenario(12, 0, { perks: ["D9"], wins: 9, misfireBonus: 0.20 }), rng).misfireBonus).toBe(0); // Crit → reset
+  });
+
+  it("D16 Schwachstellenanalyse: klare Niederlage rüstet, Sieg verbraucht (+40 %)", () => {
+    expect(resolveTrick(scenario(0, 12, { perks: ["D16"], life: 100 }), never).weaknessArmed).toBe(true);   // Abstand 12 ≥5
+    expect(resolveTrick(scenario(10, 12, { perks: ["D16"], life: 100 }), never).weaknessArmed).toBe(false); // Abstand 2 <5
+    const win = resolveTrick(scenario(12, 0, { perks: ["D16"], weaknessArmed: true }), never);
+    expect(win.lastTrick.critChance).toBeCloseTo(0.40);
+    expect(win.weaknessArmed).toBe(false); // Sieg verbraucht
+  });
+});

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -290,3 +290,18 @@ describe("Seltene Perks (#71, Phase 2b — Historie-Hooks)", () => {
     expect(PERK_DEFS.D13.scoreFlat({ altLen: 2 })).toBe(0);
   });
 });
+
+describe("Seltene Perks (#71, Phase 2c — Crit-Historie-Hooks)", () => {
+  it("D14 Crit-Folge: +20 % nur wenn gerüstet", () => {
+    expect(PERK_DEFS.D14.critChance({ critFollowArmed: true })).toBe(0.20);
+    expect(PERK_DEFS.D14.critChance({ critFollowArmed: false })).toBe(0);
+  });
+  it("D15 Fehlzündung: gibt den akkumulierten misfireBonus zurück", () => {
+    expect(PERK_DEFS.D15.critChance({ misfireBonus: 0.12 })).toBe(0.12);
+    expect(PERK_DEFS.D15.critChance({})).toBe(0);
+  });
+  it("D16 Schwachstellenanalyse: +40 % nur wenn gerüstet", () => {
+    expect(PERK_DEFS.D16.critChance({ weaknessArmed: true })).toBe(0.40);
+    expect(PERK_DEFS.D16.critChance({ weaknessArmed: false })).toBe(0);
+  });
+});


### PR DESCRIPTION
Teil des Perk-Overhauls #71 — dritte Rare-Charge: **Crit-Historie**.

## Neue Perks (selten, Kat. D)
- **D14 Crit-Folge** — nach einem Crit erhält der nächste gewonnene Stich +20 % Crit-Chance (beim nächsten Sieg verbraucht).
- **D15 Fehlzündung** — jeder Sieg ohne Crit +3 pp Crit-Chance (max +30 pp); ein Crit setzt zurück.
- **D16 Schwachstellenanalyse** — Niederlage mit ≥5 Wertpunkten Abstand → nächster gewonnener Stich +40 % Crit-Chance.

## Engine
Drei neue State-Felder (`critFollowArmed`, `misfireBonus`, `weaknessArmed`), in `initialState` + beiden `resolveTrick`-Returns geführt. Update **nach** dem Crit-Wurf — `wctx` trägt den Stand davor, sodass die `critChance`-Hooks den korrekten Vorher-Wert sehen. Rein/deterministisch, kein neuer rng-Zug.

## Tests
+8 (5 Engine-Übergänge, 3 Hook-Unit) → **141 gesamt grün**, Build ok.

Fortschritt #71: Rares 13/24 · Legendaries 6/11.