### PR TITLE
#71 Phase 2d: Per-Durchlauf-Rares (Überlebensvorteil / Sauberer Durchlauf / Opfergabe / Notfallration)

### DIFF
--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -26,6 +26,16 @@ export const D4_LOW_MAX   = 3;    // D4  „Außenseiter" bis zu diesem Wert
 export const D4_MULT      = 3;    // D4  Score-Faktor
 export const D5_BONUS     = 300;  // D5  jeder 10. Sieg: Flat-Bonus
 
+// Seltene Per-Durchlauf-Perks (#71 Phase 2d) [TUNING]
+export const SURVIVAL_PER_CARD  = 4;   // C7 Überlebensvorteil: Heilung je eigener Karte mit hohem Wert …
+export const SURVIVAL_MIN_VALUE = 13;  // …          … ab diesem Kartenwert
+export const SURVIVAL_CAP       = 60;  // …          … gedeckelt je Durchlauf
+export const CLEAN_RUN_HEAL     = 15;  // C8 Sauberer Durchlauf: Heilung nach …
+export const CLEAN_RUN_TRICKS   = 10;  // …          … so vielen Stichen in Folge ohne echten Lebensverlust
+export const SACRIFICE_LIFE     = 30;  // C9 Opfergabe: Leben-Kosten je Durchlauf-Beginn (kann nicht töten)
+export const SACRIFICE_SCORE_MULT = 1.20; // C9 …    … dafür +20 % Score, solange gehalten
+export const EMERGENCY_HEAL     = 40;  // C10 Notfallration: Sofortheilung, 1× je Durchlauf bei ≤25 % Leben
+
 // Legendäre Perks & Raritäts-System (#33) [TUNING]
 export const RARITY_WEIGHTS            = { common: 100, rare: 25, legendary: 4 }; // 3-Stufen-Rarität (#71); „common" = normal
 export const RARE_MIN_LEVEL            = 2;    // Seltene Perks erst ab diesem Level im Angebot (#71)

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -48,6 +48,7 @@ export function resolveTrick(state, rng = Math.random) {
     initiative, lastResult, perks, offer, shield, tieArmed, sinceWin = 0,
     lossStreak = 0, lastWinValue = null, altLen = 0, // #71 Rares: Revanche / Präzision / Wechselspiel
     critFollowArmed = false, misfireBonus = 0, weaknessArmed = false, // #71 Crit-Historie: Crit-Folge / Fehlzündung / Schwachstellenanalyse
+    cleanStreak = 0, notfallUsed = false, // #71 Per-Durchlauf: Sauberer Durchlauf (Zähler) / Notfallration (1×/Durchlauf)
     crits, critBonusScore, bestTrickScore, legendaryCritBonus = 0,
     // Ansage-System (#36)
     cycleWins = 0, cycleBaseScore = 0, prediction = null, lastPrediction = null,
@@ -147,6 +148,20 @@ export function resolveTrick(state, rng = Math.random) {
     // Serie & Initiative unverändert
   }
 
+  // #71 Sauberer Durchlauf (C8): Stiche in Folge OHNE echten Lebensverlust (voll vom Schild absorbiert
+  // zählt nicht als Verlust). Erreicht der Zähler die Schwelle → heilen und zurücksetzen.
+  const lostLife = dmg > 0;
+  cleanStreak = lostLife ? 0 : cleanStreak + 1;
+  if (ownsFlag(perks, "cleanRunHeal") && cleanStreak >= C.CLEAN_RUN_TRICKS && life > 0) {
+    const add = Math.min(maxLife - life, C.CLEAN_RUN_HEAL);
+    life += add; healed += add; cleanStreak = 0;
+  }
+  // #71 Notfallration (C10): erstes Mal je Durchlauf bei ≤25 % Leben sofort heilen (rettet nicht vor Tod).
+  if (ownsFlag(perks, "emergencyHeal") && !notfallUsed && life > 0 && maxLife > 0 && life / maxLife <= 0.25) {
+    const add = Math.min(maxLife - life, C.EMERGENCY_HEAL);
+    life += add; healed += add; notfallUsed = true;
+  }
+
   const lastTrick = {
     pCard, oCard, pValue, oValue,
     result: tieConverted ? "win_tie" : won ? "win" : lost ? "loss" : "tie",
@@ -168,7 +183,7 @@ export function resolveTrick(state, rng = Math.random) {
       cycleWins, cycleBaseScore, prediction, lastPrediction, lastPredictionResult,
       predictionBonusScore, exactPredictions, nearPredictions, largestPredictionBonus,
       initiative, lastResult, offer, shield, tieArmed, sinceWin, lossStreak, lastWinValue, altLen,
-      critFollowArmed, misfireBonus, weaknessArmed,
+      critFollowArmed, misfireBonus, weaknessArmed, cleanStreak, notfallUsed,
       lastTrick, phase: "gameover",
     };
   }
@@ -179,8 +194,11 @@ export function resolveTrick(state, rng = Math.random) {
   let predictionDue = false;
   if (pos >= C.TRICKS_PER_CYCLE) {
     cycle += 1;
-    const ch = sumHook(perks, "healOnCycle", {});
+    const ch = sumHook(perks, "healOnCycle", { deck }); // C7 Überlebensvorteil liest das Deck (Karten ≥13)
     if (ch > 0) life = Math.min(maxLife, life + ch);
+    // #71 Opfergabe (C9): zu Beginn jedes Durchlaufs −30 Leben (kann nicht töten → min 1); +20 % Score via scoreMult.
+    if (ownsFlag(perks, "sacrificeCycle")) life = Math.max(1, life - C.SACRIFICE_LIFE);
+    notfallUsed = false; // #71 Notfallration (C10): 1× je Durchlauf → beim Durchlauf-Wechsel zurücksetzen
     shield = perks.reduce((m, id) => Math.max(m, PERK_DEFS[id].shieldPerCycle || 0), 0); // C5: Schild je Durchlauf (kein Stapeln)
     if (prediction != null) { // ab dem 2. Durchlauf: Ansage auswerten
       const difference = Math.abs(prediction - cycleWins);
@@ -227,7 +245,7 @@ export function resolveTrick(state, rng = Math.random) {
     life, maxLife, xp, level, score, winStreak, bestStreak, wins, losses, ties,
     crits, critBonusScore, bestTrickScore, legendaryCritBonus,
     initiative, lastResult, perks, offer: newOffer, shield, tieArmed, pendingLevelUps, sinceWin, lossStreak, lastWinValue, altLen,
-    critFollowArmed, misfireBonus, weaknessArmed,
+    critFollowArmed, misfireBonus, weaknessArmed, cleanStreak, notfallUsed,
     lastTrick, phase,
   };
 }

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -156,6 +156,20 @@ export const PERK_DEFS = {
         desc: "Verlierst du mit mindestens 5 Wertpunkten Abstand, erhält der nächste gewonnene Stich +40 % Crit-Chance.",
         critChance: (ctx) => (ctx.weaknessArmed ? 0.40 : 0) },
 
+  // ---- Seltene Perks (#71, Phase 2d) — Per-Durchlauf Leben/Score (Engine-Flags + Zyklus-Hooks) ----
+  C7: { id: "C7", cat: "C", rarity: "rare", label: "Überlebensvorteil",
+        desc: "Nach jedem Durchlauf 4 Leben je eigener Karte mit Wert 13 oder höher (max 60).",
+        healOnCycle: ({ deck }) => Math.min(C.SURVIVAL_CAP, C.SURVIVAL_PER_CARD * (deck || []).filter((c) => c.value >= C.SURVIVAL_MIN_VALUE).length) },
+  C8: { id: "C8", cat: "C", rarity: "rare", label: "Sauberer Durchlauf",
+        desc: "Nach 10 Stichen in Folge ohne echten Lebensverlust +15 Leben (voll vom Schild absorbierter Schaden zählt nicht).",
+        cleanRunHeal: true }, // Engine führt cleanStreak
+  C9: { id: "C9", cat: "C", rarity: "rare", label: "Opfergabe",
+        desc: "Zu Beginn jedes Durchlaufs −30 Leben (kann nicht töten); dafür dauerhaft +20 % Score.",
+        sacrificeCycle: true, scoreMult: () => C.SACRIFICE_SCORE_MULT },
+  C10: { id: "C10", cat: "C", rarity: "rare", label: "Notfallration",
+        desc: "Erstes Mal je Durchlauf bei 25 % Leben oder weniger: sofort +40 Leben.",
+        emergencyHeal: true }, // Engine führt notfallUsed
+
   // ---- B: Stich-Effekte (Wert-Bonus auf die aktuelle Karte) ----
   B1: { id: "B1", cat: "B", label: "Gegenangriff",
         desc: "Nach einem verlorenen Stich erhält die nächste Karte +2 Wert.",

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -29,6 +29,7 @@ export function initialState(rng = Math.random) {
     sinceWin: 0, // #71 Durchbruch: aufeinanderfolgende Stiche ohne Sieg
     lossStreak: 0, lastWinValue: null, altLen: 0, // #71 Rares: Revanche / Präzision / Wechselspiel
     critFollowArmed: false, misfireBonus: 0, weaknessArmed: false, // #71 Crit-Historie: Crit-Folge / Fehlzündung / Schwachstellenanalyse
+    cleanStreak: 0, notfallUsed: false, // #71 Per-Durchlauf: Sauberer Durchlauf / Notfallration
     perks: [], offer: null,
     pendingLevelUps: 0, // #57: noch ausstehende Level-Up-Angebote (Mehrfach-Level-Up-Queue)
     speedPct: 0,

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -462,3 +462,40 @@ describe("Crit-Historie-Rares — Engine (#71 Phase 2c)", () => {
     expect(win.weaknessArmed).toBe(false); // Sieg verbraucht
   });
 });
+
+describe("Per-Durchlauf-Rares — Engine (#71 Phase 2d)", () => {
+  it("C7 Überlebensvorteil: Durchlauf-Ende heilt 4 je Karte ≥13 (Deck 13er → Deckel 60)", () => {
+    const s = resolveTrick(scenario(13, 0, { pos: 39, perks: ["C7"], life: 1000, maxLife: 2000 }), rng);
+    expect(s.cycle).toBe(1);
+    expect(s.life).toBe(1060); // 40 Karten ≥13 → 160, gedeckelt 60
+  });
+
+  it("C8 Sauberer Durchlauf: 10. Stich ohne echten Verlust → +15, Zähler zurück", () => {
+    const s = resolveTrick(scenario(12, 0, { perks: ["C8"], cleanStreak: 9, life: 1000, maxLife: 2000 }), rng);
+    expect(s.lastTrick.healed).toBe(15);
+    expect(s.life).toBe(1015);
+    expect(s.cleanStreak).toBe(0);
+  });
+  it("C8: echter Lebensverlust setzt den Zähler zurück; Schild-Absorption zählt als sauber", () => {
+    expect(resolveTrick(scenario(0, 12, { perks: ["C8"], cleanStreak: 9, life: 1000 }), rng).cleanStreak).toBe(0); // Verlust
+    const shielded = resolveTrick(scenario(0, 12, { perks: ["C8", "C5"], cleanStreak: 9, shield: 50, life: 1000, maxLife: 2000 }), rng);
+    expect(shielded.life).toBe(1015); // Schaden voll vom Schild → sauber → 10. Stich heilt
+    expect(shielded.shield).toBe(40);
+  });
+
+  it("C9 Opfergabe: +20 % Score dauerhaft; Durchlauf-Beginn −30 Leben (kann nicht töten)", () => {
+    expect(resolveTrick(scenario(12, 0, { perks: ["C9"] }), rng).score).toBeCloseTo(122.4); // 100×1,02×1,2
+    expect(resolveTrick(scenario(12, 0, { pos: 39, perks: ["C9"], life: 1000, maxLife: 2000 }), rng).life).toBe(970); // −30
+    expect(resolveTrick(scenario(12, 0, { pos: 39, perks: ["C9"], life: 20, maxLife: 2000 }), rng).life).toBe(1);     // clamp 1
+  });
+
+  it("C10 Notfallration: 1× je Durchlauf bei ≤25 % Leben +40, dann verbraucht", () => {
+    const hit = resolveTrick(scenario(0, 12, { perks: ["C10"], life: 400, maxLife: 2000 }), rng);
+    expect(hit.life).toBe(430); // 400 −10 Verlust +40 Notfall
+    expect(hit.notfallUsed).toBe(true);
+    expect(resolveTrick(scenario(0, 12, { perks: ["C10"], life: 400, maxLife: 2000, notfallUsed: true }), rng).life).toBe(390); // schon genutzt
+  });
+  it("C10: notfallUsed wird beim Durchlauf-Wechsel zurückgesetzt", () => {
+    expect(resolveTrick(scenario(13, 0, { pos: 39, perks: ["C10"], notfallUsed: true, life: 1000, maxLife: 2000 }), rng).notfallUsed).toBe(false);
+  });
+});

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -305,3 +305,15 @@ describe("Seltene Perks (#71, Phase 2c — Crit-Historie-Hooks)", () => {
     expect(PERK_DEFS.D16.critChance({ weaknessArmed: false })).toBe(0);
   });
 });
+
+describe("Seltene Perks (#71, Phase 2d — Per-Durchlauf)", () => {
+  const mkDeck = (vals) => vals.map((v, i) => ({ id: `c${i}`, suit: "R", baseRank: i, value: v }));
+  it("C7 Überlebensvorteil: 4 je Karte ≥13, gedeckelt bei 60", () => {
+    expect(PERK_DEFS.C7.healOnCycle({ deck: mkDeck([13, 14, 5, 12, 20]) })).toBe(12); // 3 Karten ≥13 → 12
+    expect(PERK_DEFS.C7.healOnCycle({ deck: mkDeck(Array(20).fill(13)) })).toBe(60);  // 80 → Deckel 60
+    expect(PERK_DEFS.C7.healOnCycle({ deck: mkDeck([1, 2, 3]) })).toBe(0);
+  });
+  it("C9 Opfergabe: scoreMult +20 %", () => {
+    expect(PERK_DEFS.C9.scoreMult()).toBeCloseTo(1.2);
+  });
+});


### PR DESCRIPTION
Teil von #71 — vierte Rare-Charge: **Per-Durchlauf Leben & Score** (Kategorie Leben).

## Neue Perks (selten, Kat. C)
- **C7 Überlebensvorteil** — nach jedem Durchlauf 4 Leben je eigener Karte mit Wert ≥ 13 (max 60). `healOnCycle` liest jetzt das Deck.
- **C8 Sauberer Durchlauf** — 10 Stiche in Folge ohne echten Lebensverlust → +15. Voll vom Schild absorbierter Schaden zählt als sauber.
- **C9 Opfergabe** — Durchlauf-Beginn −30 Leben (kann nicht töten → min 1), dafür dauerhaft +20 % Score.
- **C10 Notfallration** — 1× je Durchlauf bei ≤ 25 % Leben sofort +40.

## Engine
- `healOnCycle`-Hook bekommt `{ deck }` (C7).
- Zwei neue State-Felder: `cleanStreak` (C8), `notfallUsed` (C10, Reset am Durchlauf-Wechsel).
- Clean-/Notfall-Heilung nach den Ergebnis-Zweigen, mit `life > 0`-Guards (heilt nie einen toten Spieler); beide Heilungen fließen in `lastTrick.healed` (Float).
- Opfergabe-Kosten im Durchlauf-Ende-Block, `Math.max(1, …)`.

Rein/deterministisch. +8 Tests → **149 gesamt grün**, Build ok.

Fortschritt #71: Rares 17/24 · Legendaries 6/11.