### PR TITLE
#71 Phase 2f: Historie-Rares (Perfekte Folge / Farbserie / Volles Haus)

### DIFF
--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -49,6 +49,9 @@ export function resolveTrick(state, rng = Math.random) {
     lossStreak = 0, lastWinValue = null, altLen = 0, // #71 Rares: Revanche / Präzision / Wechselspiel
     critFollowArmed = false, misfireBonus = 0, weaknessArmed = false, // #71 Crit-Historie: Crit-Folge / Fehlzündung / Schwachstellenanalyse
     cleanStreak = 0, notfallUsed = false, // #71 Per-Durchlauf: Sauberer Durchlauf (Zähler) / Notfallration (1×/Durchlauf)
+    ascRun = 0, lastPlayedValue = null, // #71 Perfekte Folge: aufsteigende Wertfolge
+    winSuit = null, winSuitStreak = 0, // #71 Farbserie: gleicher-Farbe-Siegesserie
+    recentResults = [], // #71 Volles Haus: die letzten (bis zu 4) Ergebnisse VOR diesem Stich
     crits, critBonusScore, bestTrickScore, legendaryCritBonus = 0,
     // Ansage-System (#36)
     cycleWins = 0, cycleBaseScore = 0, prediction = null, lastPrediction = null,
@@ -60,6 +63,13 @@ export function resolveTrick(state, rng = Math.random) {
   const oCard = oppDeck[oppOrder[pos]];
 
   trickNo += 1;
+  // #71 Perfekte Folge: Länge der aktuell streng ansteigenden Wertfolge INKL. dieser Karte (Basiswert).
+  // Gleicher/niedrigerer Wert beginnt die Folge neu. State für den nächsten Stich sofort fortschreiben.
+  const ascChain = (lastPlayedValue != null && pCard.value > lastPlayedValue) ? (ascRun || 0) + 1 : 1;
+  ascRun = ascChain;
+  lastPlayedValue = pCard.value;
+  // #71 Volles Haus: Siege in den (bis zu 4) Stichen VOR diesem — inkl. aktuellem Sieg = Fenster 5.
+  const recentWinCount = recentResults.filter((r) => r === "win").length;
   const ctx = {
     posInCycle: pos,
     trickNo,
@@ -68,6 +78,7 @@ export function resolveTrick(state, rng = Math.random) {
     winStreak,
     sinceWin, // #71 Durchbruch: Stiche ohne Sieg (Stand VOR diesem Stich)
     lossStreak, // #71 Revanche: aufeinanderfolgende Niederlagen (Stand VOR diesem Stich)
+    ascChain, // #71 Perfekte Folge
     life, maxLife, // L3 „Letztes Aufbäumen": cardBonus prüft das Leben-Verhältnis VOR der Auflösung
   };
   const pValue = effectivePlayerValue(pCard.value, perks, ctx);
@@ -92,9 +103,13 @@ export function resolveTrick(state, rng = Math.random) {
     winStreak += 1; wins += 1; cycleWins += 1; // cycleWins: Siege im laufenden Durchlauf (#36)
     if (winStreak > bestStreak) bestStreak = winStreak; // längste Serie des Runs (#8)
     // winStreak/wins enthalten hier bereits den gerade gewonnenen Stich.
+    // #71 Farbserie: Länge der Serie gewonnener Stiche gleicher Farbe INKL. dieses Siegs.
+    const suitStreak = pCard.suit === winSuit ? winSuitStreak + 1 : 1;
     const wctx = { winValue: pValue, margin: pValue - oValue, winStreak, wins, trickNo, posInCycle: pos, speedPct: state.speedPct || 0,
                    lastWinValue, altLen, // #71: Präzision (Vergleich mit letztem Siegwert) / Wechselspiel
-                   critFollowArmed, misfireBonus, weaknessArmed }; // #71 Crit-Historie: Stand VOR diesem Sieg (feed critChance-Hooks)
+                   critFollowArmed, misfireBonus, weaknessArmed, // #71 Crit-Historie: Stand VOR diesem Sieg (feed critChance-Hooks)
+                   suitStreak, recentWinCount }; // #71 Farbserie / Volles Haus
+    winSuit = pCard.suit; winSuitStreak = suitStreak; // Farbserie fortschreiben
     // Score: Basis-Serien-Mult (#39, immer) × Perk-Multiplikatoren × Tempo, DANN additive Boni (D3/D5), DANN Crit.
     const tempoScoreMult = tempoScoreMultFor(perks, state.speedPct); // L6 „Raserei": Tempo-Faktor ×2
     scoreBeforeCrit = C.SCORE_PER_WIN * streakBaseMult(winStreak) * prodHook(perks, "scoreMult", wctx) * tempoScoreMult
@@ -139,14 +154,19 @@ export function resolveTrick(state, rng = Math.random) {
     sinceWin += 1; // #71 Durchbruch: kein Sieg → Zähler hoch
     lossStreak += 1; // #71 Revanche: aufeinanderfolgende Niederlagen
     if (oValue - pValue >= 5) weaknessArmed = true; // #71 Schwachstellenanalyse: klare Niederlage rüstet nächsten Sieg
+    winSuit = null; winSuitStreak = 0; // #71 Farbserie: Niederlage beendet die Farbserie
     lastResult = "loss";
   } else {
     ties += 1;
     sinceWin += 1; // #71 Durchbruch: Gleichstand zählt als „kein Sieg" weiter
     lossStreak = 0; // #71 Revanche: Gleichstand ist keine Niederlage → Serie bricht
+    winSuit = null; winSuitStreak = 0; // #71 Farbserie: Gleichstand ist kein Sieg → Serie bricht
     lastResult = "tie";
     // Serie & Initiative unverändert
   }
+
+  // #71 Volles Haus: Ergebnis-Fenster fortschreiben (letzte 4 Ergebnisse für den nächsten Stich).
+  recentResults = [...recentResults, lastResult].slice(-4);
 
   // #71 Sauberer Durchlauf (C8): Stiche in Folge OHNE echten Lebensverlust (voll vom Schild absorbiert
   // zählt nicht als Verlust). Erreicht der Zähler die Schwelle → heilen und zurücksetzen.
@@ -184,6 +204,7 @@ export function resolveTrick(state, rng = Math.random) {
       predictionBonusScore, exactPredictions, nearPredictions, largestPredictionBonus,
       initiative, lastResult, offer, shield, tieArmed, sinceWin, lossStreak, lastWinValue, altLen,
       critFollowArmed, misfireBonus, weaknessArmed, cleanStreak, notfallUsed,
+      ascRun, lastPlayedValue, winSuit, winSuitStreak, recentResults,
       lastTrick, phase: "gameover",
     };
   }
@@ -246,6 +267,7 @@ export function resolveTrick(state, rng = Math.random) {
     crits, critBonusScore, bestTrickScore, legendaryCritBonus,
     initiative, lastResult, perks, offer: newOffer, shield, tieArmed, pendingLevelUps, sinceWin, lossStreak, lastWinValue, altLen,
     critFollowArmed, misfireBonus, weaknessArmed, cleanStreak, notfallUsed,
+    ascRun, lastPlayedValue, winSuit, winSuitStreak, recentResults,
     lastTrick, phase,
   };
 }

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -170,6 +170,17 @@ export const PERK_DEFS = {
         desc: "Erstes Mal je Durchlauf bei 25 % Leben oder weniger: sofort +40 Leben.",
         emergencyHeal: true }, // Engine führt notfallUsed
 
+  // ---- Seltene Perks (#71, Phase 2f) — Ergebnis-/Wert-Historie (neue State-Felder) ----
+  B9: { id: "B9", cat: "B", rarity: "rare", label: "Perfekte Folge",
+        desc: "Bei streng ansteigenden Kartenwerten je weitere Karte der Folge mehr Wert: 2.→+1, 3.→+2 … max +5. Eine gleiche/niedrigere Karte beginnt neu.",
+        cardBonus: (ctx) => Math.min((ctx.ascChain || 1) - 1, 5) },
+  D17: { id: "D17", cat: "D", rarity: "rare", label: "Farbserie",
+        desc: "Mehrere Siege in Folge mit derselben Farbe: 2.→+75, 3.→+100, je weiterer +25 (max +200). Andere Farbe/Niederlage beendet die Serie.",
+        scoreFlat: (ctx) => (ctx.suitStreak >= 2 ? Math.min(75 + (ctx.suitStreak - 2) * 25, 200) : 0) },
+  D18: { id: "D18", cat: "D", rarity: "rare", label: "Volles Haus",
+        desc: "Enthalten die letzten fünf Stiche (inkl. aktuellem) mindestens 4 Siege, gibt der aktuelle Sieg +250 Score.",
+        scoreFlat: (ctx) => ((ctx.recentWinCount || 0) >= 3 ? 250 : 0) },
+
   // ---- B: Stich-Effekte (Wert-Bonus auf die aktuelle Karte) ----
   B1: { id: "B1", cat: "B", label: "Gegenangriff",
         desc: "Nach einem verlorenen Stich erhält die nächste Karte +2 Wert.",

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -30,6 +30,7 @@ export function initialState(rng = Math.random) {
     lossStreak: 0, lastWinValue: null, altLen: 0, // #71 Rares: Revanche / Präzision / Wechselspiel
     critFollowArmed: false, misfireBonus: 0, weaknessArmed: false, // #71 Crit-Historie: Crit-Folge / Fehlzündung / Schwachstellenanalyse
     cleanStreak: 0, notfallUsed: false, // #71 Per-Durchlauf: Sauberer Durchlauf / Notfallration
+    ascRun: 0, lastPlayedValue: null, winSuit: null, winSuitStreak: 0, recentResults: [], // #71 Historie: Perfekte Folge / Farbserie / Volles Haus
     perks: [], offer: null,
     pendingLevelUps: 0, // #57: noch ausstehende Level-Up-Angebote (Mehrfach-Level-Up-Queue)
     speedPct: 0,

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -499,3 +499,40 @@ describe("Per-Durchlauf-Rares — Engine (#71 Phase 2d)", () => {
     expect(resolveTrick(scenario(13, 0, { pos: 39, perks: ["C10"], notfallUsed: true, life: 1000, maxLife: 2000 }), rng).notfallUsed).toBe(false);
   });
 });
+
+describe("Historie-Rares — Engine (#71 Phase 2f)", () => {
+  const mk = (arr, suit = "R") => arr.map((v, i) => ({ id: `${suit}${i}`, suit, baseRank: v, value: v }));
+
+  it("B9 Perfekte Folge: aufsteigende Werte geben 0/+1/+2, Rückschritt beginnt neu", () => {
+    const deck = mk([3, 5, 7, 4]);
+    const opp = mk([0, 0, 0, 0]);
+    let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: [0, 1, 2, 3], oppOrder: [0, 1, 2, 3], perks: ["B9"], life: 1000 };
+    const pv = [];
+    for (let i = 0; i < 4; i++) { s = resolveTrick(s, rng); pv.push(s.lastTrick.pValue); }
+    expect(pv).toEqual([3, 6, 9, 4]); // Bonus 0,1,2 dann Reset 0
+  });
+
+  it("D17 Farbserie: gleiche Farbe zählt, Farbwechsel beginnt bei 1, Niederlage bricht", () => {
+    const deck = [{ id: "a", suit: "R", baseRank: 12, value: 12 }, { id: "b", suit: "R", baseRank: 12, value: 12 }, { id: "c", suit: "B", baseRank: 12, value: 12 }];
+    const opp = mk([0, 0, 0]);
+    let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: [0, 1, 2], oppOrder: [0, 1, 2], perks: ["D17"], life: 1000 };
+    s = resolveTrick(s, rng); expect(s.winSuitStreak).toBe(1); // R
+    s = resolveTrick(s, rng); expect(s.winSuitStreak).toBe(2); // R
+    s = resolveTrick(s, rng); expect(s.winSuitStreak).toBe(1); expect(s.winSuit).toBe("B"); // Farbwechsel
+    expect(resolveTrick(scenario(0, 12, { perks: ["D17"], winSuit: "R", winSuitStreak: 3, life: 1000 }), rng).winSuitStreak).toBe(0); // Niederlage bricht
+  });
+  it("D17: 2. Sieg gleicher Farbe gibt +75 Flat", () => {
+    let s = scenario(12, 0, { perks: ["D17"] }); // constDeck: alles Farbe R
+    s = resolveTrick(s, rng); // Serie 1 → +0
+    s = resolveTrick(s, rng); // Serie 2 → +75
+    expect(s.lastTrick.gained).toBeCloseTo(100 * 1.04 + 75); // 179
+  });
+
+  it("D18 Volles Haus: ≥4 Siege im 5er-Fenster → +250", () => {
+    expect(resolveTrick(scenario(12, 0, { perks: ["D18"], recentResults: ["win", "win", "win", "loss"] }), rng).lastTrick.gained).toBeCloseTo(352); // 3 Vorsiege + aktueller = 4
+    expect(resolveTrick(scenario(12, 0, { perks: ["D18"], recentResults: ["win", "win", "loss", "loss"] }), rng).lastTrick.gained).toBeCloseTo(102); // nur 3 im Fenster
+  });
+  it("Volles-Haus-Fenster: recentResults hält die letzten 4 Ergebnisse", () => {
+    expect(resolveTrick(scenario(12, 0, { recentResults: ["loss", "win", "tie", "win"] }), rng).recentResults).toEqual(["win", "tie", "win", "win"]);
+  });
+});

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -317,3 +317,25 @@ describe("Seltene Perks (#71, Phase 2d — Per-Durchlauf)", () => {
     expect(PERK_DEFS.C9.scoreMult()).toBeCloseTo(1.2);
   });
 });
+
+describe("Seltene Perks (#71, Phase 2f — Historie-Hooks)", () => {
+  it("B9 Perfekte Folge: 0/+1/+2 … gedeckelt bei +5", () => {
+    expect(PERK_DEFS.B9.cardBonus({ ascChain: 1 })).toBe(0);
+    expect(PERK_DEFS.B9.cardBonus({ ascChain: 2 })).toBe(1);
+    expect(PERK_DEFS.B9.cardBonus({ ascChain: 4 })).toBe(3);
+    expect(PERK_DEFS.B9.cardBonus({ ascChain: 6 })).toBe(5); // Deckel
+    expect(PERK_DEFS.B9.cardBonus({ ascChain: 9 })).toBe(5);
+  });
+  it("D17 Farbserie: 75/100/… gedeckelt bei 200, unter Serie 2 nichts", () => {
+    expect(PERK_DEFS.D17.scoreFlat({ suitStreak: 1 })).toBe(0);
+    expect(PERK_DEFS.D17.scoreFlat({ suitStreak: 2 })).toBe(75);
+    expect(PERK_DEFS.D17.scoreFlat({ suitStreak: 3 })).toBe(100);
+    expect(PERK_DEFS.D17.scoreFlat({ suitStreak: 7 })).toBe(200); // 75+5×25=200
+    expect(PERK_DEFS.D17.scoreFlat({ suitStreak: 9 })).toBe(200); // Deckel
+  });
+  it("D18 Volles Haus: +250 ab 3 Vorsiegen im 4er-Fenster", () => {
+    expect(PERK_DEFS.D18.scoreFlat({ recentWinCount: 3 })).toBe(250);
+    expect(PERK_DEFS.D18.scoreFlat({ recentWinCount: 4 })).toBe(250);
+    expect(PERK_DEFS.D18.scoreFlat({ recentWinCount: 2 })).toBe(0);
+  });
+});


### PR DESCRIPTION
Teil von #71 — fünfte Rare-Charge: **Ergebnis-/Wert-Historie**.

## Neue Perks (selten)
- **B9 Perfekte Folge** (Stich) — bei streng ansteigenden Kartenwerten je weitere Karte +1/+2/… (max +5); gleicher/niedrigerer Wert beginnt neu.
- **D17 Farbserie** (Score) — Siege in Folge mit derselben Farbe: 2.→+75, 3.→+100, je weiterer +25 (max +200). Farbwechsel/Niederlage/Gleichstand bricht.
- **D18 Volles Haus** (Score) — ≥4 Siege in den letzten fünf Stichen (inkl. aktuellem) → +250.

## Engine — 5 neue State-Felder
- `ascRun` + `lastPlayedValue` (Perfekte Folge; `ascChain` in `ctx`, jeden Stich fortgeschrieben)
- `winSuit` + `winSuitStreak` (Farbserie; `suitStreak` in `wctx`; Reset bei Niederlage/Gleichstand)
- `recentResults` (Volles Haus; 4er-Ergebnisfenster; `recentWinCount` in `wctx`)

Alle Felder in `initialState` + beiden `resolveTrick`-Returns geführt. Rein/deterministisch. +8 Tests → **157 gesamt grün**, Build ok.

Fortschritt #71: Rares **20/24** · Legendaries 6/11. Rest: Überzahl · Hochlauf · Ruhe vor dem Sturm · Überschusskrit (Phase 2e), dann 5 Legendaries.