### PR TITLE
#71 Phase 2e: Serien-/Tempo-/Crit-Rares (Überzahl / Hochlauf / Ruhe vor dem Sturm / Überschusskrit)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,8 +53,10 @@ export function Autostich() {
   // Nutzer-Pause-Toggle zu verändern: beim Schließen läuft es im vorherigen Zustand weiter.
   const active = state.phase === "play" && !paused && !showOptions;
   // Effektive Flip-Zeit: Basis / (1+Speed) / Turbo (1×/2×/3×). Beschleunigt nur Ablauf + Animation,
-  // NICHT den Score (speedPct/tempoScoreMult bleiben unberührt → kein Cheesen).
-  const flipMs = (BASE_FLIP_MS / (1 + (state.speedPct || 0) / 100)) / speedMult; // #55: speedPct fehlt im Menü → NaN vermeiden
+  // NICHT den Basis-Score (permanenter speedPct → Tempo-Score bleibt separat). #71: temporäres Tempo
+  // (Hochlauf/Ruhe, state.tempTempo) beschleunigt hier zusätzlich die reale Anzeige.
+  const effSpeedPct = (state.speedPct || 0) + (state.tempTempo || 0);
+  const flipMs = (BASE_FLIP_MS / (1 + effSpeedPct / 100)) / speedMult; // #55: speedPct fehlt im Menü → NaN vermeiden
 
   useEffect(() => {
     const g = loadGhost();

--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -36,6 +36,14 @@ export const SACRIFICE_LIFE     = 30;  // C9 Opfergabe: Leben-Kosten je Durchlau
 export const SACRIFICE_SCORE_MULT = 1.20; // C9 …    … dafür +20 % Score, solange gehalten
 export const EMERGENCY_HEAL     = 40;  // C10 Notfallration: Sofortheilung, 1× je Durchlauf bei ≤25 % Leben
 
+// Seltene Tempo/Crit-Perks (#71 Phase 2e) [TUNING]
+export const RAMP_TEMPO_STEP = 2;   // E9 Hochlauf: +% temporäres Tempo je Sieg …
+export const RAMP_TEMPO_CAP  = 40;  // …          … gedeckelt
+export const RAMP_TEMPO_LOSS = 10;  // …          … Abzug je Niederlage
+export const CALM_TRICKS     = 5;   // E10 Ruhe vor dem Sturm: so viele Stiche nach einem Gleichstand …
+export const CALM_TEMPO_PCT  = 50;  // …          … um so viel % schneller (zählt auch für Tempo-Score)
+export const SUPERCRIT_MULT_FACTOR = 1.5; // D19 Überschusskrit: Faktor auf den Crit-Multiplikator (×2→×3, ×4→×6)
+
 // Legendäre Perks & Raritäts-System (#33) [TUNING]
 export const RARITY_WEIGHTS            = { common: 100, rare: 25, legendary: 4 }; // 3-Stufen-Rarität (#71); „common" = normal
 export const RARE_MIN_LEVEL            = 2;    // Seltene Perks erst ab diesem Level im Angebot (#71)

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -1,5 +1,5 @@
 import * as C from "./constants.js";
-import { PERK_DEFS, buildOffer, critChanceFor, comboMultFor, tempoScoreMultFor, critMultiplierFor, streakBaseMult } from "./perks.js";
+import { PERK_DEFS, buildOffer, critChanceRawFor, comboMultFor, tempoScoreMultFor, critMultiplierFor, streakBaseMult } from "./perks.js";
 import { xpToNext } from "./leveling.js";
 
 function sumHook(perks, name, ctx) {
@@ -52,6 +52,8 @@ export function resolveTrick(state, rng = Math.random) {
     ascRun = 0, lastPlayedValue = null, // #71 Perfekte Folge: aufsteigende Wertfolge
     winSuit = null, winSuitStreak = 0, // #71 Farbserie: gleicher-Farbe-Siegesserie
     recentResults = [], // #71 Volles Haus: die letzten (bis zu 4) Ergebnisse VOR diesem Stich
+    overStreak = 0, // #71 Überzahl: effektive Serie für Serien-Effekte (klare Siege zählen doppelt)
+    rampTempo = 0, calmTricks = 0, tempTempo = 0, // #71 Tempo: Hochlauf (Rampe) / Ruhe vor dem Sturm (Burst) / effektives Temp-Tempo
     crits, critBonusScore, bestTrickScore, legendaryCritBonus = 0,
     // Ansage-System (#36)
     cycleWins = 0, cycleBaseScore = 0, prediction = null, lastPrediction = null,
@@ -70,12 +72,20 @@ export function resolveTrick(state, rng = Math.random) {
   lastPlayedValue = pCard.value;
   // #71 Volles Haus: Siege in den (bis zu 4) Stichen VOR diesem — inkl. aktuellem Sieg = Fenster 5.
   const recentWinCount = recentResults.filter((r) => r === "win").length;
+  // #71 Phase-2e-Flags einmal auflösen (Überzahl / Hochlauf / Ruhe vor dem Sturm).
+  const ownsUeberzahl = ownsFlag(perks, "ueberzahl");
+  const ownsHochlauf = ownsFlag(perks, "hochlauf");
+  const ownsRuhe = ownsFlag(perks, "ruheVorDemSturm");
+  // #71 Überzahl: effektive Serie für Serien-Effekte (Stand VOR dem Stich). Ohne Perk == winStreak.
+  let serieStreak = ownsUeberzahl ? (overStreak || 0) : winStreak;
+  // #71 Temp-Tempo dieses Stichs (Stand aus dem letzten Stich — identisch zu dem Wert, den App für flipMs nutzte).
+  const curTempTempo = tempTempo || 0;
   const ctx = {
     posInCycle: pos,
     trickNo,
     lastResult,
     lostLastTrick: lastResult === "loss",
-    winStreak,
+    winStreak: serieStreak, // #71 Überzahl: Serien-Effekte (B2 Momentum) sehen die effektive Serie
     sinceWin, // #71 Durchbruch: Stiche ohne Sieg (Stand VOR diesem Stich)
     lossStreak, // #71 Revanche: aufeinanderfolgende Niederlagen (Stand VOR diesem Stich)
     ascChain, // #71 Perfekte Folge
@@ -97,26 +107,36 @@ export function resolveTrick(state, rng = Math.random) {
     : (curRes !== lastResult && (lastResult === "win" || lastResult === "loss")) ? altLen + 1 : 1;
 
   let gained = 0, dmg = 0, healed = 0;
-  let isCrit = false, critChance = 0, critMultiplier = C.CRIT_BASE_MULT, scoreBeforeCrit = 0, critBonus = 0;
+  let isCrit = false, superCrit = false, critChance = 0, critMultiplier = C.CRIT_BASE_MULT, scoreBeforeCrit = 0, critBonus = 0;
 
   if (won) {
     winStreak += 1; wins += 1; cycleWins += 1; // cycleWins: Siege im laufenden Durchlauf (#36)
     if (winStreak > bestStreak) bestStreak = winStreak; // längste Serie des Runs (#8)
+    // #71 Überzahl: klarer Sieg (Vorsprung ≥5) zählt für Serien-Effekte als zwei Stufen (nicht für wins/XP/Heilung).
+    overStreak = (overStreak || 0) + (ownsUeberzahl && pValue - oValue >= 5 ? 2 : 1);
+    serieStreak = ownsUeberzahl ? overStreak : winStreak; // effektive Serie NACH diesem Sieg
     // winStreak/wins enthalten hier bereits den gerade gewonnenen Stich.
     // #71 Farbserie: Länge der Serie gewonnener Stiche gleicher Farbe INKL. dieses Siegs.
     const suitStreak = pCard.suit === winSuit ? winSuitStreak + 1 : 1;
-    const wctx = { winValue: pValue, margin: pValue - oValue, winStreak, wins, trickNo, posInCycle: pos, speedPct: state.speedPct || 0,
+    const wctx = { winValue: pValue, margin: pValue - oValue, winStreak: serieStreak, wins, trickNo, posInCycle: pos, speedPct: state.speedPct || 0,
                    lastWinValue, altLen, // #71: Präzision (Vergleich mit letztem Siegwert) / Wechselspiel
                    critFollowArmed, misfireBonus, weaknessArmed, // #71 Crit-Historie: Stand VOR diesem Sieg (feed critChance-Hooks)
                    suitStreak, recentWinCount }; // #71 Farbserie / Volles Haus
     winSuit = pCard.suit; winSuitStreak = suitStreak; // Farbserie fortschreiben
     // Score: Basis-Serien-Mult (#39, immer) × Perk-Multiplikatoren × Tempo, DANN additive Boni (D3/D5), DANN Crit.
-    const tempoScoreMult = tempoScoreMultFor(perks, state.speedPct); // L6 „Raserei": Tempo-Faktor ×2
-    scoreBeforeCrit = C.SCORE_PER_WIN * streakBaseMult(winStreak) * prodHook(perks, "scoreMult", wctx) * tempoScoreMult
+    // #71 Hochlauf/Ruhe: temporäres Tempo zählt zusätzlich zum permanenten speedPct für den Tempo-Score.
+    const tempoScoreMult = tempoScoreMultFor(perks, (state.speedPct || 0) + curTempTempo); // L6 „Raserei": Tempo-Faktor ×2
+    scoreBeforeCrit = C.SCORE_PER_WIN * streakBaseMult(serieStreak) * prodHook(perks, "scoreMult", wctx) * tempoScoreMult
                       + sumHook(perks, "scoreFlat", wctx);
-    critChance = critChanceFor(perks, wctx, legendaryCritBonus); // inkl. L4-Bonus & L5-Halbierung
+    const rawCrit = critChanceRawFor(perks, wctx, legendaryCritBonus); // ungeklemmt (für Überschusskrit)
+    critChance = Math.min(1, Math.max(0, rawCrit));             // Anzeige/normaler Wurf (geklemmt), inkl. L4/L5
     critMultiplier = critMultiplierFor(perks, wctx);             // L5 „Jackpot": ×4 überschreibt Basis ×2
     isCrit = rollCrit(critChance, ownsGuaranteedCrit(perks, wctx), rng);
+    // #71 Überschusskrit: Crit-Chance über 100 % → Chance (= Überschuss) auf einen Super-Crit (×1,5 auf den Crit-Faktor).
+    if (isCrit && ownsFlag(perks, "superCrit") && rawCrit > 1) {
+      const excess = Math.min(rawCrit - 1, 1);
+      if (rng() < excess) { superCrit = true; critMultiplier *= C.SUPERCRIT_MULT_FACTOR; }
+    }
     // #71 Crit-Historie: Update NACH dem Wurf (wctx trug den Stand davor).
     critFollowArmed = isCrit;                                        // Crit-Folge: nur ein Crit rüstet den nächsten Sieg
     misfireBonus = isCrit ? 0 : Math.min(misfireBonus + 0.03, 0.30); // Fehlzündung: +3 pp je Sieg ohne Crit, Crit setzt zurück
@@ -155,6 +175,7 @@ export function resolveTrick(state, rng = Math.random) {
     lossStreak += 1; // #71 Revanche: aufeinanderfolgende Niederlagen
     if (oValue - pValue >= 5) weaknessArmed = true; // #71 Schwachstellenanalyse: klare Niederlage rüstet nächsten Sieg
     winSuit = null; winSuitStreak = 0; // #71 Farbserie: Niederlage beendet die Farbserie
+    overStreak = 0; serieStreak = 0; // #71 Überzahl: Niederlage beendet die (effektive) Serie
     lastResult = "loss";
   } else {
     ties += 1;
@@ -167,6 +188,13 @@ export function resolveTrick(state, rng = Math.random) {
 
   // #71 Volles Haus: Ergebnis-Fenster fortschreiben (letzte 4 Ergebnisse für den nächsten Stich).
   recentResults = [...recentResults, lastResult].slice(-4);
+
+  // #71 Temp-Tempo fortschreiben (Hochlauf-Rampe / Ruhe-Burst) → in tempTempo für App-Flip + nächsten Tempo-Score.
+  if (ownsHochlauf) rampTempo = won ? Math.min(rampTempo + C.RAMP_TEMPO_STEP, C.RAMP_TEMPO_CAP)
+                                : lost ? Math.max(rampTempo - C.RAMP_TEMPO_LOSS, 0) : rampTempo;
+  if (ownsRuhe && curRes === "tie") calmTricks = C.CALM_TRICKS; // Gleichstand startet/erneuert den Burst
+  else if (calmTricks > 0) calmTricks -= 1;                     // sonst einen schnellen Stich verbrauchen
+  tempTempo = (ownsHochlauf ? rampTempo : 0) + (ownsRuhe && calmTricks > 0 ? C.CALM_TEMPO_PCT : 0);
 
   // #71 Sauberer Durchlauf (C8): Stiche in Folge OHNE echten Lebensverlust (voll vom Schild absorbiert
   // zählt nicht als Verlust). Erreicht der Zähler die Schwelle → heilen und zurücksetzen.
@@ -186,11 +214,12 @@ export function resolveTrick(state, rng = Math.random) {
     pCard, oCard, pValue, oValue,
     result: tieConverted ? "win_tie" : won ? "win" : lost ? "loss" : "tie",
     gained, dmg, healed, trickNo,
-    isCrit, critChance, critMultiplier, scoreBeforeCrit, scoreGain: gained, critBonus,
-    jackpot: isCrit && critMultiplier > C.CRIT_BASE_MULT, // L5 „Jackpot": Crit ×4 → verstärkter Float
+    isCrit, superCrit, critChance, critMultiplier, scoreBeforeCrit, scoreGain: gained, critBonus,
+    jackpot: isCrit && critMultiplier > C.CRIT_BASE_MULT, // L5 „Jackpot" / Super-Crit → verstärkter Float
     // D2-Kombo-Wert der resultierenden Serie (geteilte Quelle → kein Drift zur Score-Berechnung, #31).
     // 1 ohne D2; bei Niederlage/Gleichstand irrelevant (Anzeige nur bei Sieg ab ×1,5).
-    comboMult: comboMultFor(perks, winStreak),
+    // Überzahl: die effektive Serie (serieStreak) speist auch die Anzeige → kein Drift zum Score.
+    comboMult: comboMultFor(perks, serieStreak),
   };
 
   // Tod? — sofort beenden (kein Weiterziehen / Level-Up / KEINE Ansage-Auswertung, #36).
@@ -205,6 +234,7 @@ export function resolveTrick(state, rng = Math.random) {
       initiative, lastResult, offer, shield, tieArmed, sinceWin, lossStreak, lastWinValue, altLen,
       critFollowArmed, misfireBonus, weaknessArmed, cleanStreak, notfallUsed,
       ascRun, lastPlayedValue, winSuit, winSuitStreak, recentResults,
+      overStreak, rampTempo, calmTricks, tempTempo,
       lastTrick, phase: "gameover",
     };
   }
@@ -268,6 +298,7 @@ export function resolveTrick(state, rng = Math.random) {
     initiative, lastResult, perks, offer: newOffer, shield, tieArmed, pendingLevelUps, sinceWin, lossStreak, lastWinValue, altLen,
     critFollowArmed, misfireBonus, weaknessArmed, cleanStreak, notfallUsed,
     ascRun, lastPlayedValue, winSuit, winSuitStreak, recentResults,
+    overStreak, rampTempo, calmTricks, tempTempo,
     lastTrick, phase,
   };
 }

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -181,6 +181,20 @@ export const PERK_DEFS = {
         desc: "Enthalten die letzten fünf Stiche (inkl. aktuellem) mindestens 4 Siege, gibt der aktuelle Sieg +250 Score.",
         scoreFlat: (ctx) => ((ctx.recentWinCount || 0) >= 3 ? 250 : 0) },
 
+  // ---- Seltene Perks (#71, Phase 2e) — Serien-/Tempo-/Crit-Mechanik (Engine-Flags + State) ----
+  B10: { id: "B10", cat: "B", rarity: "rare", label: "Überzahl",
+        desc: "Ein Sieg mit mindestens 5 Wertpunkten Vorsprung zählt für Siegesserien-Effekte als zwei Stufen (Statistik/XP/Heilung bleiben ein Sieg).",
+        ueberzahl: true }, // Engine führt overStreak
+  E9: { id: "E9", cat: "E", rarity: "rare", label: "Hochlauf",
+        desc: "Jeder Sieg gibt +2 % temporäres Tempo (max +40 %); eine Niederlage −10 pp. Zählt für Geschwindigkeit und Tempo-Score.",
+        hochlauf: true }, // Engine führt rampTempo/tempTempo
+  E10: { id: "E10", cat: "E", rarity: "rare", label: "Ruhe vor dem Sturm",
+        desc: "Nach einem Gleichstand laufen die nächsten fünf Stiche 50 % schneller; das temporäre Tempo zählt auch für den Tempo-Score.",
+        ruheVorDemSturm: true }, // Engine führt calmTricks/tempTempo
+  D19: { id: "D19", cat: "D", rarity: "rare", label: "Überschusskrit",
+        desc: "Crit-Chance über 100 % kann einen Super-Crit auslösen (z. B. 130 % → +30 % Chance auf ×3 statt ×2; mit Jackpot ×6).",
+        superCrit: true }, // Engine wertet die Überschuss-Chance aus
+
   // ---- B: Stich-Effekte (Wert-Bonus auf die aktuelle Karte) ----
   B1: { id: "B1", cat: "B", label: "Gegenangriff",
         desc: "Nach einem verlorenen Stich erhält die nächste Karte +2 Wert.",
@@ -310,13 +324,17 @@ export function buildOffer(owned, rng, count, level = 1) {
 
 // Gesamt-Crit-Chance (0..1) eines Builds: Σ critChance-Perks + legendaryCritBonus (L4), dann
 // × Π critChanceMult (L5 halbiert), geklemmt. EINE Quelle für Engine-Wurf UND Anzeige (#25, kein Drift).
-export function critChanceFor(perks, ctx, legendaryCritBonus = 0) {
+// UNGEKLEMMTE Roh-Crit-Chance (kann >1 sein) — Basis für Überschusskrit (#71) und für critChanceFor.
+export function critChanceRawFor(perks, ctx, legendaryCritBonus = 0) {
   let raw = 0;
   for (const id of perks) { const f = PERK_DEFS[id].critChance; if (f) raw += f(ctx); }
   raw += legendaryCritBonus || 0;
   let mult = 1;
   for (const id of perks) { const f = PERK_DEFS[id].critChanceMult; if (f) mult *= f(ctx); }
-  return Math.min(1, Math.max(0, raw * mult));
+  return raw * mult;
+}
+export function critChanceFor(perks, ctx, legendaryCritBonus = 0) {
+  return Math.min(1, Math.max(0, critChanceRawFor(perks, ctx, legendaryCritBonus)));
 }
 // Crit-Faktor: L5 (Jackpot) ÜBERSCHREIBT die Basis (×4) statt zu addieren → höchster Hook-Wert gewinnt.
 // Geteilte Quelle für Engine-Score UND Anzeige.

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -31,6 +31,7 @@ export function initialState(rng = Math.random) {
     critFollowArmed: false, misfireBonus: 0, weaknessArmed: false, // #71 Crit-Historie: Crit-Folge / Fehlzündung / Schwachstellenanalyse
     cleanStreak: 0, notfallUsed: false, // #71 Per-Durchlauf: Sauberer Durchlauf / Notfallration
     ascRun: 0, lastPlayedValue: null, winSuit: null, winSuitStreak: 0, recentResults: [], // #71 Historie: Perfekte Folge / Farbserie / Volles Haus
+    overStreak: 0, rampTempo: 0, calmTricks: 0, tempTempo: 0, // #71 Phase 2e: Überzahl / Hochlauf / Ruhe vor dem Sturm
     perks: [], offer: null,
     pendingLevelUps: 0, // #57: noch ausstehende Level-Up-Angebote (Mehrfach-Level-Up-Queue)
     speedPct: 0,

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -536,3 +536,53 @@ describe("Historie-Rares — Engine (#71 Phase 2f)", () => {
     expect(resolveTrick(scenario(12, 0, { recentResults: ["loss", "win", "tie", "win"] }), rng).recentResults).toEqual(["win", "tie", "win", "win"]);
   });
 });
+
+describe("Serien-/Tempo-/Crit-Rares — Engine (#71 Phase 2e)", () => {
+  it("B10 Überzahl: klarer Sieg (Vorsprung ≥5) zählt für Serien-Effekte doppelt, Statistik bleibt 1 Sieg", () => {
+    const big = resolveTrick(scenario(12, 0, { perks: ["B10"] }), rng);
+    expect(big.wins).toBe(1); expect(big.winStreak).toBe(1); // Statistik: 1 Sieg
+    expect(big.overStreak).toBe(2);                          // effektive Serie: 2 Stufen
+    expect(big.lastTrick.gained).toBeCloseTo(104);          // 100 × streakBaseMult(2)=1,04
+    const small = resolveTrick(scenario(5, 3, { perks: ["B10"] }), rng); // Vorsprung 2 <5
+    expect(small.overStreak).toBe(1);
+  });
+  it("B10 + D2: effektive Serie speist Kombo & Anzeige (kein Drift)", () => {
+    let s = scenario(12, 0, { perks: ["B10", "D2"] });
+    s = resolveTrick(s, rng); expect(s.overStreak).toBe(2); expect(s.lastTrick.comboMult).toBeCloseTo(1.2);
+    s = resolveTrick(s, rng); expect(s.overStreak).toBe(4); expect(s.lastTrick.comboMult).toBeCloseTo(1.4);
+    expect(resolveTrick(scenario(0, 12, { perks: ["B10"], overStreak: 3, life: 100 }), rng).overStreak).toBe(0); // Niederlage bricht
+  });
+
+  it("E9 Hochlauf: +2 % Temp-Tempo je Sieg (Deckel 40), −10 pp je Niederlage; zählt für Tempo-Score", () => {
+    expect(resolveTrick(scenario(12, 0, { perks: ["E9"], rampTempo: 20, tempTempo: 20 }), rng).lastTrick.gained).toBeCloseTo(112.2); // Score nutzt curTempTempo 20 → ×1,10
+    const w = resolveTrick(scenario(12, 0, { perks: ["E9"], rampTempo: 20, tempTempo: 20 }), rng);
+    expect(w.rampTempo).toBe(22); expect(w.tempTempo).toBe(22);
+    expect(resolveTrick(scenario(12, 0, { perks: ["E9"], rampTempo: 39 }), rng).rampTempo).toBe(40); // Deckel
+    expect(resolveTrick(scenario(0, 12, { perks: ["E9"], rampTempo: 30, life: 100 }), rng).rampTempo).toBe(20); // −10
+  });
+
+  it("E10 Ruhe vor dem Sturm: Gleichstand startet 5-Stiche-Burst (50 % schneller, zählt für Tempo-Score)", () => {
+    const tie = resolveTrick(scenario(5, 5, { perks: ["E10"] }), rng);
+    expect(tie.calmTricks).toBe(5); expect(tie.tempTempo).toBe(50);
+    const fast = resolveTrick(scenario(12, 0, { perks: ["E10"], calmTricks: 5, tempTempo: 50 }), rng);
+    expect(fast.lastTrick.gained).toBeCloseTo(127.5); // ×(1+50×0,005)=1,25
+    expect(fast.calmTricks).toBe(4); expect(fast.tempTempo).toBe(50);
+    const last = resolveTrick(scenario(12, 0, { perks: ["E10"], calmTricks: 1, tempTempo: 50 }), rng);
+    expect(last.calmTricks).toBe(0); expect(last.tempTempo).toBe(0); // Burst endet
+  });
+
+  it("D19 Überschusskrit: Roh-Crit über 100 % → Chance auf Super-Crit (×1,5 auf den Faktor)", () => {
+    const build = { perks: ["D19", "D9", "D6", "D7", "D8", "D16"], wins: 9, winStreak: 10, weaknessArmed: true };
+    const zero = () => 0;   // Überschuss-Wurf trifft
+    const half = () => 0.5; // Überschuss-Wurf verfehlt (Überschuss 0,27)
+    const sup = resolveTrick(scenario(12, 0, build), zero);
+    expect(sup.lastTrick.critChance).toBe(1);      // Anzeige geklemmt
+    expect(sup.lastTrick.superCrit).toBe(true);
+    expect(sup.lastTrick.critMultiplier).toBe(3);  // ×2 × 1,5
+    expect(sup.lastTrick.scoreGain).toBeCloseTo(366); // scoreBeforeCrit 122 × 3
+    const noSup = resolveTrick(scenario(12, 0, build), half);
+    expect(noSup.lastTrick.superCrit).toBe(false);
+    expect(noSup.lastTrick.critMultiplier).toBe(2);
+    expect(resolveTrick(scenario(12, 0, { ...build, perks: ["D9", "D6", "D7", "D8", "D16"] }), zero).lastTrick.superCrit).toBe(false); // ohne D19 kein Super-Crit
+  });
+});

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildDeck, makeRng } from "../src/game/deck.js";
-import { PERK_DEFS, PERK_LIST, buildOffer, critChanceFor, comboMultFor, isLegendary, tempoScoreMultFor, baseScoreMultFor, streakBaseMult } from "../src/game/perks.js";
+import { PERK_DEFS, PERK_LIST, buildOffer, critChanceFor, critChanceRawFor, comboMultFor, isLegendary, tempoScoreMultFor, baseScoreMultFor, streakBaseMult } from "../src/game/perks.js";
 import { effectivePlayerValue } from "../src/game/engine.js";
 
 describe("Perks — Deck-Modifikationen (Kat. A)", () => {
@@ -117,6 +117,10 @@ describe("critChanceFor (Crit-Perks D6–D8, L4/L5)", () => {
   it("L5 Jackpot halbiert die (zufällige) Crit-Chance — inkl. L4-Bonus", () => {
     expect(critChanceFor(["D6", "L5"], {})).toBeCloseTo(0.06);          // 0.12 × 0.5
     expect(critChanceFor(["D6", "L5"], {}, 0.20)).toBeCloseTo(0.16);    // (0.12+0.20) × 0.5
+  });
+  it("critChanceRawFor bleibt UNgeklemmt (>1 für Überschusskrit), critChanceFor klemmt (#71)", () => {
+    expect(critChanceRawFor(["D6", "D7", "D8", "D16"], { winValue: 12, winStreak: 30, weaknessArmed: true })).toBeCloseTo(1.27);
+    expect(critChanceFor(["D6", "D7", "D8", "D16"], { winValue: 12, winStreak: 30, weaknessArmed: true })).toBe(1);
   });
 });
 


### PR DESCRIPTION
Teil von #71 — die vier **querschnittlichen** Rares (Serien-Effekte, temporäres Tempo, Super-Crit). Damit sind **alle 24 Rares** umgesetzt.

## Neue Perks (selten)
- **B10 Überzahl** (Stich) — Sieg mit ≥5 Vorsprung zählt für Siegesserien-Effekte als **zwei** Stufen; XP/Heilung/Statistik bleiben ein Sieg.
- **E9 Hochlauf** (Tempo) — jeder Sieg +2 % temporäres Tempo (max +40 %), Niederlage −10 pp.
- **E10 Ruhe vor dem Sturm** (Tempo) — nach einem Gleichstand 5 Stiche 50 % schneller.
- **D19 Überschusskrit** (Crit) — Roh-Crit-Chance über 100 % → Überschuss = Chance auf einen Super-Crit (×1,5 auf den Crit-Faktor: ×2→×3, mit Jackpot ×4→×6).

## Engine / App
- **Überzahl:** neues `overStreak`; als effektive Serie in `streakBaseMult`, `wctx.winStreak` (D2/D8) und `comboMult`-Anzeige (kein Drift). Ohne Perk identisch zu `winStreak`.
- **Temp-Tempo:** `rampTempo` (Hochlauf) + `calmTricks` (Ruhe) → `tempTempo`. Zählt für **reale Speed** (`App.flipMs` = `speedPct+tempTempo`) **und** Tempo-Score; permanente Perks (Drehzahl/Kontrollverlust) bleiben auf `speedPct`.
- **Super-Crit:** neuer `critChanceRawFor` (ungeklemmt); `critChanceFor` baut darauf auf. Überschuss-Wurf über den injizierten rng → deterministisch.

## Verifikation
+6 Tests → **163 gesamt grün**, Build ok. Live-Smoke-Test (Dev-Server): Run startet und spielt normal durch, **keine Konsolenfehler**.

Fortschritt #71: **Rares 24/24 ✅** · Legendaries 6/11. Rest: 5 neue Legendaries (Phase 3).