### PR TITLE
#71 Phase 3: 5 neue Legendaries — Pool komplett (70 Perks)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,8 +54,10 @@ export function Autostich() {
   const active = state.phase === "play" && !paused && !showOptions;
   // Effektive Flip-Zeit: Basis / (1+Speed) / Turbo (1×/2×/3×). Beschleunigt nur Ablauf + Animation,
   // NICHT den Basis-Score (permanenter speedPct → Tempo-Score bleibt separat). #71: temporäres Tempo
-  // (Hochlauf/Ruhe, state.tempTempo) beschleunigt hier zusätzlich die reale Anzeige.
-  const effSpeedPct = (state.speedPct || 0) + (state.tempTempo || 0);
+  // (Hochlauf/Ruhe, state.tempTempo) beschleunigt hier zusätzlich; L11 Zeitraffer verdoppelt die Tempo-Boni
+  // NUR für die reale Geschwindigkeit (der Tempo-Score bleibt einfach — Engine).
+  const zeitraffer = (state.perks || []).includes("L11");
+  const effSpeedPct = ((state.speedPct || 0) + (state.tempTempo || 0)) * (zeitraffer ? 2 : 1);
   const flipMs = (BASE_FLIP_MS / (1 + effSpeedPct / 100)) / speedMult; // #55: speedPct fehlt im Menü → NaN vermeiden
 
   useEffect(() => {

--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -52,6 +52,18 @@ export const MAX_LEGENDARIES_PER_OFFER = 1;    // höchstens so viele Legendarie
 export const L4_CRIT_STEP = 0.01;  // L4 Kritische Masse: +1 pp Crit-Chance je Crit
 export const L4_CRIT_CAP  = 0.30;  // L4  … dauerhaft gedeckelt bei +30 pp
 
+// Neue Legendaries (#71 Phase 3) [TUNING]
+export const KINGMAKER_THRESHOLD = 13; // L7 Königsmacher: ab diesem (permanenten) Wert …
+export const KINGMAKER_BONUS     = 2;  // …          … erhält eine Karte einmalig dauerhaft +2
+export const FATE_CARD_BONUS     = 8;  // L8 Schicksalsmaschine: Wert-Bonus auf Karten des Schicksalswerts (je Durchlauf)
+export const FATE_SCORE_MULT     = 2;  // L8 …          … und ×2 Score bei Sieg mit einer solchen Karte
+export const BLOOD_SACRIFICE     = 100;  // L9 Blutvertrag: Leben-Opfer je Durchlauf (nur bei >100 Leben → kann nicht töten)
+export const BLOOD_SCORE_STEP    = 0.20; // L9 …          … dafür je Stapel +20 % Score …
+export const BLOOD_MAX_STACKS    = 5;    // L9 …          … max 5 Stapel (+100 %)
+export const CHAIN_MAX_STAGES    = 3;    // L10 Kettenreaktion: max Zusatz-Crit-Stufen (Chance = halbe finale Crit-Chance)
+export const ZEITRAFFER_SCORE_STEP = 0.10; // L11 Zeitraffer: je vollem Durchlauf +10 % Score …
+export const ZEITRAFFER_MAX_STACKS = 5;    // L11 …          … max +50 %; Tempo-Boni ×2 auf reale Speed (App)
+
 // Geist (Rekord-Vergleich): Score-Stützstelle alle N Stiche [TUNING]
 export const GHOST_STEP = 13;
 

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -54,6 +54,7 @@ export function resolveTrick(state, rng = Math.random) {
     recentResults = [], // #71 Volles Haus: die letzten (bis zu 4) Ergebnisse VOR diesem Stich
     overStreak = 0, // #71 Überzahl: effektive Serie für Serien-Effekte (klare Siege zählen doppelt)
     rampTempo = 0, calmTricks = 0, tempTempo = 0, // #71 Tempo: Hochlauf (Rampe) / Ruhe vor dem Sturm (Burst) / effektives Temp-Tempo
+    fateValue = null, bloodStacks = 0, zeitrafferStacks = 0, // #71 Legendaries: Schicksalsmaschine / Blutvertrag / Zeitraffer
     crits, critBonusScore, bestTrickScore, legendaryCritBonus = 0,
     // Ansage-System (#36)
     cycleWins = 0, cycleBaseScore = 0, prediction = null, lastPrediction = null,
@@ -89,6 +90,7 @@ export function resolveTrick(state, rng = Math.random) {
     sinceWin, // #71 Durchbruch: Stiche ohne Sieg (Stand VOR diesem Stich)
     lossStreak, // #71 Revanche: aufeinanderfolgende Niederlagen (Stand VOR diesem Stich)
     ascChain, // #71 Perfekte Folge
+    fateValue, // #71 Schicksalsmaschine: cardBonus vergleicht pValueBase mit dem Schicksalswert
     life, maxLife, // L3 „Letztes Aufbäumen": cardBonus prüft das Leben-Verhältnis VOR der Auflösung
   };
   const pValue = effectivePlayerValue(pCard.value, perks, ctx);
@@ -121,7 +123,8 @@ export function resolveTrick(state, rng = Math.random) {
     const wctx = { winValue: pValue, margin: pValue - oValue, winStreak: serieStreak, wins, trickNo, posInCycle: pos, speedPct: state.speedPct || 0,
                    lastWinValue, altLen, // #71: Präzision (Vergleich mit letztem Siegwert) / Wechselspiel
                    critFollowArmed, misfireBonus, weaknessArmed, // #71 Crit-Historie: Stand VOR diesem Sieg (feed critChance-Hooks)
-                   suitStreak, recentWinCount }; // #71 Farbserie / Volles Haus
+                   suitStreak, recentWinCount, // #71 Farbserie / Volles Haus
+                   baseValue: pCard.value, fateValue, bloodStacks, zeitrafferStacks }; // #71 Legendaries: Schicksalsmaschine / Blutvertrag / Zeitraffer
     winSuit = pCard.suit; winSuitStreak = suitStreak; // Farbserie fortschreiben
     // Score: Basis-Serien-Mult (#39, immer) × Perk-Multiplikatoren × Tempo, DANN additive Boni (D3/D5), DANN Crit.
     // #71 Hochlauf/Ruhe: temporäres Tempo zählt zusätzlich zum permanenten speedPct für den Tempo-Score.
@@ -136,6 +139,12 @@ export function resolveTrick(state, rng = Math.random) {
     if (isCrit && ownsFlag(perks, "superCrit") && rawCrit > 1) {
       const excess = Math.min(rawCrit - 1, 1);
       if (rng() < excess) { superCrit = true; critMultiplier *= C.SUPERCRIT_MULT_FACTOR; }
+    }
+    // #71 Kettenreaktion (L10): nach einem Crit erneute Würfe mit HALBER finaler Crit-Chance; je Treffer
+    // verdoppelt sich der Crit-Faktor (×2→×4→×8→×16), max 3 Zusatzstufen. Bricht beim ersten Fehlwurf ab.
+    if (isCrit && ownsFlag(perks, "chainCrit")) {
+      const chainChance = critChance / 2;
+      for (let i = 0; i < C.CHAIN_MAX_STAGES; i++) { if (rng() < chainChance) critMultiplier *= 2; else break; }
     }
     // #71 Crit-Historie: Update NACH dem Wurf (wctx trug den Stand davor).
     critFollowArmed = isCrit;                                        // Crit-Folge: nur ein Crit rüstet den nächsten Sieg
@@ -235,6 +244,7 @@ export function resolveTrick(state, rng = Math.random) {
       critFollowArmed, misfireBonus, weaknessArmed, cleanStreak, notfallUsed,
       ascRun, lastPlayedValue, winSuit, winSuitStreak, recentResults,
       overStreak, rampTempo, calmTricks, tempTempo,
+      fateValue, bloodStacks, zeitrafferStacks,
       lastTrick, phase: "gameover",
     };
   }
@@ -249,6 +259,18 @@ export function resolveTrick(state, rng = Math.random) {
     if (ch > 0) life = Math.min(maxLife, life + ch);
     // #71 Opfergabe (C9): zu Beginn jedes Durchlaufs −30 Leben (kann nicht töten → min 1); +20 % Score via scoreMult.
     if (ownsFlag(perks, "sacrificeCycle")) life = Math.max(1, life - C.SACRIFICE_LIFE);
+    // #71 Blutvertrag (L9): je Durchlauf 100 Leben opfern → dauerhaft +20 % Score (max 5×). Nur bei >100 Leben (kann nicht töten).
+    if (ownsFlag(perks, "bloodPact") && life > C.BLOOD_SACRIFICE && bloodStacks < C.BLOOD_MAX_STACKS) {
+      life -= C.BLOOD_SACRIFICE; bloodStacks += 1;
+    }
+    // #71 Zeitraffer (L11): je vollem Durchlauf +10 % Score (max +50 %); reale Speed ×2 läuft in App.jsx.
+    if (ownsFlag(perks, "zeitraffer") && zeitrafferStacks < C.ZEITRAFFER_MAX_STACKS) zeitrafferStacks += 1;
+    // #71 Schicksalsmaschine (L8): einen aktuell vorhandenen Kartenwert zufällig bestimmen (Deck-Werte).
+    // rng-Zug NUR bei gehaltenem Perk → Determinismus/rng-Reihenfolge für andere Builds unberührt.
+    if (ownsFlag(perks, "schicksal")) {
+      const vals = [...new Set(deck.map((c) => c.value))];
+      fateValue = vals.length ? vals[Math.floor(rng() * vals.length)] : null;
+    }
     notfallUsed = false; // #71 Notfallration (C10): 1× je Durchlauf → beim Durchlauf-Wechsel zurücksetzen
     shield = perks.reduce((m, id) => Math.max(m, PERK_DEFS[id].shieldPerCycle || 0), 0); // C5: Schild je Durchlauf (kein Stapeln)
     if (prediction != null) { // ab dem 2. Durchlauf: Ansage auswerten
@@ -299,6 +321,7 @@ export function resolveTrick(state, rng = Math.random) {
     critFollowArmed, misfireBonus, weaknessArmed, cleanStreak, notfallUsed,
     ascRun, lastPlayedValue, winSuit, winSuitStreak, recentResults,
     overStreak, rampTempo, calmTricks, tempTempo,
+    fateValue, bloodStacks, zeitrafferStacks,
     lastTrick, phase,
   };
 }

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -288,6 +288,27 @@ export const PERK_DEFS = {
   L6: { id: "L6", cat: "E", rarity: "legendary", label: "Raserei",
         desc: "Der Tempo-Score-Bonus wirkt doppelt — dafür verursachen verlorene Stiche +2 Schaden.",
         tempoScoreFactorMult: () => 2, extraDamageTaken: () => 2 },
+
+  // ---- Neue Legendaries (#71 Phase 3) — regelverändernde Motoren, teils mit eigenem Engine-/Reducer-State ----
+  L7: { id: "L7", cat: "A", rarity: "legendary", label: "Königsmacher",
+        desc: "Erreicht eine Karte durch Aufwertungen erstmals Wert 13 oder höher, erhält sie dauerhaft weitere +2 (je Karte nur einmal).",
+        kingmaker: true }, // Reducer prüft nach jeder Deck-Mod (kingBoosted)
+  L8: { id: "L8", cat: "A", rarity: "legendary", label: "Schicksalsmaschine",
+        desc: "Zu Beginn jedes Durchlaufs wird ein vorhandener Kartenwert zufällig bestimmt; Karten dieses Werts erhalten +8 Wert und geben bei Sieg ×2 Score (diesen Durchlauf).",
+        schicksal: true,
+        cardBonus: (ctx) => (ctx.fateValue != null && ctx.pValueBase === ctx.fateValue ? C.FATE_CARD_BONUS : 0),
+        scoreMult: (ctx) => (ctx.fateValue != null && ctx.baseValue === ctx.fateValue ? C.FATE_SCORE_MULT : 1) },
+  L9: { id: "L9", cat: "C", rarity: "legendary", label: "Blutvertrag",
+        desc: "Zu Beginn jedes Durchlaufs 100 Leben opfern → dauerhaft +20 % Score (max 5×, +100 %). Nur bei über 100 Leben; kann nicht töten.",
+        bloodPact: true, // Engine führt bloodStacks (Opfer im Durchlauf-Ende-Block)
+        scoreMult: (ctx) => 1 + C.BLOOD_SCORE_STEP * (ctx.bloodStacks || 0) },
+  L10: { id: "L10", cat: "D", rarity: "legendary", label: "Kettenreaktion",
+        desc: "Ein Crit kann erneut critten (Chance = halbe finale Crit-Chance); je Stufe verdoppelt sich der Crit-Faktor, max 3 Zusatzstufen (×2→×4→×8→×16).",
+        chainCrit: true }, // Engine würfelt die Kette nach dem Crit
+  L11: { id: "L11", cat: "E", rarity: "legendary", label: "Zeitraffer",
+        desc: "Alle Tempo-Boni wirken doppelt auf die reale Geschwindigkeit (normal auf den Tempo-Score). Nach jedem vollen Durchlauf dauerhaft +10 % Score (max +50 %).",
+        zeitraffer: true, // App verdoppelt die reale Speed; Engine führt zeitrafferStacks
+        scoreMult: (ctx) => 1 + C.ZEITRAFFER_SCORE_STEP * (ctx.zeitrafferStacks || 0) },
 };
 
 export const PERK_LIST = Object.values(PERK_DEFS);

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -2,6 +2,7 @@ import { buildDeck, shuffledOrder } from "./deck.js";
 import { PERK_DEFS, buildOffer } from "./perks.js";
 import { resolveTrick } from "./engine.js";
 import { START_LIFE, PREDICTION_MIN, PREDICTION_MAX, PERKS_OFFERED } from "./constants.js";
+import * as C from "./constants.js";
 
 /* Reiner Reducer — Determinismus-Invariante: kein Math.random / Date hier drin.
    Zufall kommt als Action-Payload (rng), siehe App.jsx. Phasen:
@@ -32,6 +33,7 @@ export function initialState(rng = Math.random) {
     cleanStreak: 0, notfallUsed: false, // #71 Per-Durchlauf: Sauberer Durchlauf / Notfallration
     ascRun: 0, lastPlayedValue: null, winSuit: null, winSuitStreak: 0, recentResults: [], // #71 Historie: Perfekte Folge / Farbserie / Volles Haus
     overStreak: 0, rampTempo: 0, calmTricks: 0, tempTempo: 0, // #71 Phase 2e: Überzahl / Hochlauf / Ruhe vor dem Sturm
+    fateValue: null, bloodStacks: 0, zeitrafferStacks: 0, kingBoosted: [], // #71 Phase 3 Legendaries: Schicksalsmaschine / Blutvertrag / Zeitraffer / Königsmacher
     perks: [], offer: null,
     pendingLevelUps: 0, // #57: noch ausstehende Level-Up-Angebote (Mehrfach-Level-Up-Queue)
     speedPct: 0,
@@ -91,8 +93,19 @@ export function reducer(state, action) {
       const { perkId, rng } = action;
       if (!state.offer || !state.offer.includes(perkId)) return state;
       const def = PERK_DEFS[perkId];
-      const deck = def.onPick ? def.onPick(state.deck, rng) : state.deck; // Kat.-A-Mods sofort dauerhaft
       const perks = [...state.perks, perkId];
+      let deck = def.onPick ? def.onPick(state.deck, rng) : state.deck; // Kat.-A-Mods sofort dauerhaft
+      // #71 Königsmacher (L7): erreicht eine Karte (durch DIESE oder eine frühere Aufwertung) erstmals Wert
+      // ≥13, erhält sie einmalig dauerhaft +2. Nach jeder Deck-Mod prüfen; je Karte nur einmal (kingBoosted).
+      let kingBoosted = state.kingBoosted || [];
+      if (perks.some((id) => PERK_DEFS[id].kingmaker)) {
+        const boosted = new Set(kingBoosted);
+        deck = deck.map((c) => {
+          if (c.value >= C.KINGMAKER_THRESHOLD && !boosted.has(c.id)) { boosted.add(c.id); return { ...c, value: c.value + C.KINGMAKER_BONUS }; }
+          return c;
+        });
+        kingBoosted = [...boosted];
+      }
       const speedPct = perks.reduce((t, id) => t + (PERK_DEFS[id].speedPct || 0), 0);
       // C5: Schild sofort gewähren (sonst erst beim nächsten Durchlauf-Start)
       const shieldGrant = perks.reduce((m, id) => Math.max(m, PERK_DEFS[id].shieldPerCycle || 0), 0);
@@ -103,12 +116,12 @@ export function reducer(state, action) {
       if (pending > 0) {
         const off = buildOffer(perks, rng, PERKS_OFFERED, state.level);
         if (off.length > 0)
-          return { ...state, deck, perks, speedPct, shield, phase: "levelup", offer: off, pendingLevelUps: pending - 1 };
+          return { ...state, deck, kingBoosted, perks, speedPct, shield, phase: "levelup", offer: off, pendingLevelUps: pending - 1 };
         // Pool leer → keine weiteren Angebote möglich; restliche Level-Ups verfallen.
       }
       // Nach der Perk-Wahl: war ein Durchlauf-Ende fällig (#36), weiter in die Ansage-Phase, sonst play.
       const phase = state.predictionDue ? "prediction" : "play";
-      return { ...state, deck, perks, speedPct, shield, phase, offer: null, pendingLevelUps: 0 };
+      return { ...state, deck, kingBoosted, perks, speedPct, shield, phase, offer: null, pendingLevelUps: 0 };
     }
 
     default:

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -586,3 +586,35 @@ describe("Serien-/Tempo-/Crit-Rares — Engine (#71 Phase 2e)", () => {
     expect(resolveTrick(scenario(12, 0, { ...build, perks: ["D9", "D6", "D7", "D8", "D16"] }), zero).lastTrick.superCrit).toBe(false); // ohne D19 kein Super-Crit
   });
 });
+
+describe("Neue Legendaries — Engine (#71 Phase 3)", () => {
+  it("L8 Schicksalsmaschine: Schicksalswert bei Durchlauf-Ende gewählt; +8 Wert & ×2 Score für diese Karten", () => {
+    expect(resolveTrick(scenario(12, 0, { pos: 39, perks: ["L8"], life: 1000, maxLife: 2000 }), rng).fateValue).toBe(12); // Deck nur 12er
+    expect(resolveTrick(scenario(5, 10, { perks: ["L8"], fateValue: 5, life: 1000 }), rng).lastTrick.pValue).toBe(13); // 5 +8 → kippt den Stich
+    expect(resolveTrick(scenario(6, 10, { perks: ["L8"], fateValue: 5, life: 1000 }), rng).losses).toBe(1);            // Nicht-Schicksalswert: kein Bonus
+    expect(resolveTrick(scenario(12, 0, { perks: ["L8"], fateValue: 12 }), rng).lastTrick.gained).toBeCloseTo(204);    // 100×1,02 × 2
+    expect(resolveTrick(scenario(12, 0, { perks: ["L8"], fateValue: 5 }), rng).lastTrick.gained).toBeCloseTo(102);     // kein Match → ×1
+  });
+
+  it("L9 Blutvertrag: Durchlauf-Ende opfert 100 Leben → +Stack (nur >100 Leben, max 5), +20 %/Stack Score", () => {
+    const sac = resolveTrick(scenario(12, 0, { pos: 39, perks: ["L9"], life: 1000, maxLife: 2000, bloodStacks: 0 }), rng);
+    expect(sac.life).toBe(900); expect(sac.bloodStacks).toBe(1);
+    expect(resolveTrick(scenario(12, 0, { pos: 39, perks: ["L9"], life: 100, maxLife: 2000, bloodStacks: 0 }), rng).bloodStacks).toBe(0); // ≤100 → kein Opfer
+    expect(resolveTrick(scenario(12, 0, { pos: 39, perks: ["L9"], life: 1000, maxLife: 2000, bloodStacks: 5 }), rng).life).toBe(1000);   // Deckel 5 → kein Opfer
+    expect(resolveTrick(scenario(12, 0, { perks: ["L9"], bloodStacks: 3 }), rng).lastTrick.gained).toBeCloseTo(163.2); // 100×1,02×1,6
+  });
+
+  it("L10 Kettenreaktion: Crit kettet mit halber finaler Chance, je Stufe ×2 (max 3)", () => {
+    const build = { perks: ["L10", "D6", "D9"], wins: 9 }; // D9 garantiert Crit, D6 → 12 % finale Chance → Kette 6 %
+    expect(resolveTrick(scenario(12, 0, build), () => 0).lastTrick.critMultiplier).toBe(16);  // 3 Treffer: ×2→4→8→16
+    expect(resolveTrick(scenario(12, 0, build), () => 0.5).lastTrick.critMultiplier).toBe(2);  // kein Treffer
+    let n = 0; const once = () => (n++ === 0 ? 0 : 0.5);                                        // genau 1 Treffer
+    expect(resolveTrick(scenario(12, 0, build), once).lastTrick.critMultiplier).toBe(4);
+  });
+
+  it("L11 Zeitraffer: je Durchlauf +Stack (max 5), +10 %/Stack Score", () => {
+    expect(resolveTrick(scenario(12, 0, { pos: 39, perks: ["L11"], life: 1000, maxLife: 2000, zeitrafferStacks: 0 }), rng).zeitrafferStacks).toBe(1);
+    expect(resolveTrick(scenario(12, 0, { pos: 39, perks: ["L11"], life: 1000, maxLife: 2000, zeitrafferStacks: 5 }), rng).zeitrafferStacks).toBe(5); // Deckel
+    expect(resolveTrick(scenario(12, 0, { perks: ["L11"], zeitrafferStacks: 3 }), rng).lastTrick.gained).toBeCloseTo(132.6); // 100×1,02×1,3
+  });
+});

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -125,8 +125,8 @@ describe("critChanceFor (Crit-Perks D6–D8, L4/L5)", () => {
 });
 
 describe("Legendäre Perks — reine Hooks (#33)", () => {
-  it("alle sechs sind als legendary markiert", () => {
-    for (const id of ["L1", "L2", "L3", "L4", "L5", "L6"]) expect(isLegendary(id)).toBe(true);
+  it("alle elf L-Perks sind als legendary markiert (#71: L7–L11 ergänzt)", () => {
+    for (const id of ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8", "L9", "L10", "L11"]) expect(isLegendary(id)).toBe(true);
     expect(isLegendary("D1")).toBe(false);
   });
   it("L1 Überladung: onPick +2 deckweit, +3 Zusatzschaden", () => {
@@ -147,6 +147,22 @@ describe("Legendäre Perks — reine Hooks (#33)", () => {
     expect(tempoScoreMultFor([], 150)).toBeCloseTo(1.75);       // 1 + 150×0.005
     expect(tempoScoreMultFor(["L6"], 150)).toBeCloseTo(2.5);    // Faktor ×2
     expect(PERK_DEFS.L6.extraDamageTaken()).toBe(2);
+  });
+  it("L8 Schicksalsmaschine: +8 Wert & ×2 Score nur auf den Schicksalswert (#71)", () => {
+    expect(PERK_DEFS.L8.cardBonus({ pValueBase: 7, fateValue: 7 })).toBe(8);
+    expect(PERK_DEFS.L8.cardBonus({ pValueBase: 6, fateValue: 7 })).toBe(0);
+    expect(PERK_DEFS.L8.cardBonus({ pValueBase: 7, fateValue: null })).toBe(0);
+    expect(PERK_DEFS.L8.scoreMult({ baseValue: 7, fateValue: 7 })).toBe(2);
+    expect(PERK_DEFS.L8.scoreMult({ baseValue: 6, fateValue: 7 })).toBe(1);
+  });
+  it("L9 Blutvertrag: +20 % Score je Stapel (#71)", () => {
+    expect(PERK_DEFS.L9.scoreMult({ bloodStacks: 0 })).toBeCloseTo(1.0);
+    expect(PERK_DEFS.L9.scoreMult({ bloodStacks: 3 })).toBeCloseTo(1.6);
+    expect(PERK_DEFS.L9.scoreMult({ bloodStacks: 5 })).toBeCloseTo(2.0);
+  });
+  it("L11 Zeitraffer: +10 % Score je Stapel (#71)", () => {
+    expect(PERK_DEFS.L11.scoreMult({ zeitrafferStacks: 0 })).toBeCloseTo(1.0);
+    expect(PERK_DEFS.L11.scoreMult({ zeitrafferStacks: 5 })).toBeCloseTo(1.5);
   });
 });
 

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -40,6 +40,25 @@ describe("Reducer", () => {
     expect(reducer(s0, { type: "PICK_PERK", perkId: "D5", rng })).toBe(s0);
   });
 
+  it("L7 Königsmacher (#71): Karten ≥13 einmalig +2 — beim Pick und nach späteren Aufwertungen", () => {
+    const deck = [
+      { id: "A", suit: "R", baseRank: 0, value: 13 },
+      { id: "B", suit: "R", baseRank: 1, value: 11 },
+      { id: "C", suit: "R", baseRank: 2, value: 1 },
+    ];
+    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: ["L7"], deck, perks: [], level: 5, pendingLevelUps: 0 };
+    s = reducer(s, { type: "PICK_PERK", perkId: "L7", rng: makeRng(1) });
+    expect(s.deck.find((c) => c.id === "A").value).toBe(15); // 13 → +2
+    expect(s.deck.find((c) => c.id === "B").value).toBe(11); // <13 → unverändert
+    expect(s.kingBoosted).toEqual(["A"]);
+    // Spätere Aufwertung (L1 „Überladung": alle +2) hebt B auf 13 → Königsmacher +2 → 15; A schon geboostet.
+    s = { ...s, phase: "levelup", offer: ["L1"], pendingLevelUps: 0 };
+    s = reducer(s, { type: "PICK_PERK", perkId: "L1", rng: makeRng(1) });
+    expect(s.deck.find((c) => c.id === "B").value).toBe(15); // 11 +2(L1)=13 → +2(König)
+    expect(s.deck.find((c) => c.id === "A").value).toBe(17); // 15 +2(L1)=17, kein Doppel-Boost
+    expect(new Set(s.kingBoosted)).toEqual(new Set(["A", "B"]));
+  });
+
   it("RESET beginnt einen frischen Lauf", () => {
     const dirty = { ...initialState(makeRng(1)), score: 999, level: 8, perks: ["A1", "D1"] };
     const fresh = reducer(dirty, { type: "RESET", rng });


### PR DESCRIPTION
Schließt #71 ab: die fünf neuen Legendaries. Pool jetzt **35 normal / 24 selten / 11 legendär = 70** (verifiziert).

## Neue Perks (legendär)
- **L7 Königsmacher** (Deck) — erreicht eine Karte durch Aufwertungen erstmals Wert ≥13, dauerhaft +2 (je Karte einmal).
- **L8 Schicksalsmaschine** (Deck) — je Durchlauf zufälliger Kartenwert; diese Karten +8 Wert **und** ×2 Score bei Sieg (diesen Durchlauf).
- **L9 Blutvertrag** (Leben) — Durchlauf-Beginn 100 Leben opfern → +20 % Score/Stack (max 5×, +100 %). Nur bei >100 Leben, kann nicht töten.
- **L10 Kettenreaktion** (Crit) — Crit kettet mit halber finaler Crit-Chance, je Stufe ×2 (max 3: ×2→×4→×8→×16).
- **L11 Zeitraffer** (Tempo) — Tempo-Boni ×2 auf reale Speed (normal auf Tempo-Score); je Durchlauf +10 % Score (max +50 %).

## Mechanik
- **Königsmacher:** Reducer-Pass nach jeder Deck-Mod in `PICK_PERK`; `kingBoosted`-Set verhindert Doppel-Boosts, reagiert auch auf *spätere* Aufwertungen.
- **Schicksalsmaschine:** `fateValue` (rng-Zug am Durchlauf-Ende, **nur bei gehaltenem Perk** → rng-Reihenfolge anderer Builds unberührt); `cardBonus`/`scoreMult` vergleichen den **Basiswert**.
- **Blutvertrag/Zeitraffer:** `bloodStacks`/`zeitrafferStacks` im Durchlauf-Ende-Block; permanenter `scoreMult`.
- **Kettenreaktion:** Ketten-Würfe über den injizierten rng, gegated → deterministisch.
- **Zeitraffer real-speed:** `App.flipMs` verdoppelt die Tempo-Boni bei L11 (Tempo-Score bleibt einfach — Engine).

## Determinismus
Alle neuen rng-Züge (Schicksalswert, Crit-Kette) laufen über den injizierten rng **und sind auf den Perk-Besitz gegated**, sodass bestehende Builds/Tests bit-identisch bleiben.

## Verifikation
+8 Tests → **171 gesamt grün**; Pool-Zusammensetzung per Skript auf 35/24/11 geprüft; Build ok; App lädt & Menü rendert **ohne Konsolenfehler**.

**#71 abgeschlossen** ✅ — 3-Stufen-Rarität + Pool auf 70 komplett umgesetzt.