### PR TITLE
Perk-Karten: 3-Stufen-Rarität sichtbar (grau/grün/gold)

### DIFF
--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -316,6 +316,15 @@ export const PERK_LIST = Object.values(PERK_DEFS);
 export const rarityOf    = (id) => PERK_DEFS[id]?.rarity || "common";
 export const isLegendary = (id) => rarityOf(id) === "legendary";
 
+// UI-Metadaten je Seltenheit (#71): grau / grün / gold — geteilte Quelle für PerkSelect,
+// BuildSummary und GameOver (analog zu CATEGORIES.color). `badge` leer = keine Marke (Normal).
+export const RARITY_META = {
+  common:    { key: "common",    label: "Normal",   badge: "",           mark: "",   color: "#8a8a95" }, // grau
+  rare:      { key: "rare",      label: "Selten",   badge: "◆ SELTEN",   mark: "◆",  color: "#4ade80" }, // grün
+  legendary: { key: "legendary", label: "Legendär", badge: "★ LEGENDÄR", mark: "★",  color: "#d4a63a" }, // gold
+};
+export const rarityMeta = (id) => RARITY_META[rarityOf(id)];
+
 // Angebot: bis zu `count` noch nicht besessene Perks, GEWICHTET nach Seltenheit (#33, §10.3).
 // Legendaries: erst ab LEGENDARY_MIN_LEVEL, höchstens MAX_LEGENDARIES_PER_OFFER je Angebot.
 // Deterministisch über den injizierten rng (ein rng()-Zug je Auswahl). Pool leer → weniger Perks.

--- a/src/ui/BuildSummary.jsx
+++ b/src/ui/BuildSummary.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { PERK_DEFS, CATEGORIES, isLegendary } from "../game/perks.js";
+import { PERK_DEFS, CATEGORIES, rarityOf, RARITY_META } from "../game/perks.js";
 import { SUIT_ORDER, suitColor, suitName } from "../game/constants.js";
 
 /* Gemeinsame Build-Kontext-Bausteine (#22): geteilt von BuildPanel und PerkSelect. */
@@ -20,14 +20,16 @@ export function PerkList({ perks, empty = "Noch keine Perks." }) {
               style={{ background: `${CATEGORIES[c].color}22`, color: CATEGORIES[c].color }}>{CATEGORIES[c].name}</span>
             {byCat[c].map((id) => {
               const active = openPerk === id;
-              const leg = isLegendary(id);
+              const rar = rarityOf(id);
+              const rm = RARITY_META[rar];
+              const special = rar !== "common"; // selten/legendär: Raritäts-Farbe + Marke
               return (
                 <button key={id} type="button" onClick={() => setOpenPerk(active ? null : id)}
                   className="text-xs px-2 py-0.5 rounded transition-all"
                   style={{ background: active ? `${CATEGORIES[c].color}33` : "#22222b",
-                           color: leg ? "#d4a63a" : undefined,
-                           outline: active ? `1px solid ${CATEGORIES[c].color}` : (leg ? "1px solid #d4a63a88" : "none") }}>
-                  {leg ? "★ " : ""}{PERK_DEFS[id].label}
+                           color: special ? rm.color : undefined,
+                           outline: active ? `1px solid ${CATEGORIES[c].color}` : (special ? `1px solid ${rm.color}88` : "none") }}>
+                  {rm.mark ? `${rm.mark} ` : ""}{PERK_DEFS[id].label}
                 </button>
               );
             })}

--- a/src/ui/GameOver.jsx
+++ b/src/ui/GameOver.jsx
@@ -1,4 +1,4 @@
-import { PERK_DEFS, CATEGORIES } from "../game/perks.js";
+import { PERK_DEFS, CATEGORIES, rarityOf, RARITY_META } from "../game/perks.js";
 import { Sparkline } from "./Sparkline.jsx";
 
 // Highscore-Listen (lokal + global) bewusst NICHT hier — sie stehen auf dem Startbildschirm und
@@ -43,12 +43,18 @@ export function GameOver({ state, isRecord, timeStr, onRestart, onMenu, currentT
 
         {state.perks.length > 0 && (
           <div className="mt-4 flex flex-wrap gap-1.5 justify-center">
-            {state.perks.map((id) => (
-              <span key={id} className="text-[11px] px-2 py-0.5 rounded"
-                style={{ background: `${CATEGORIES[PERK_DEFS[id].cat].color}22`, color: CATEGORIES[PERK_DEFS[id].cat].color }}>
-                {PERK_DEFS[id].label}
-              </span>
-            ))}
+            {state.perks.map((id) => {
+              const cc = CATEGORIES[PERK_DEFS[id].cat].color;
+              const rar = rarityOf(id);
+              const rm = RARITY_META[rar];
+              return (
+                <span key={id} className="text-[11px] px-2 py-0.5 rounded"
+                  style={{ background: `${cc}22`, color: cc,
+                           border: rar !== "common" ? `1px solid ${rm.color}` : undefined }}>
+                  {rm.mark ? `${rm.mark} ` : ""}{PERK_DEFS[id].label}
+                </span>
+              );
+            })}
           </div>
         )}
 

--- a/src/ui/PerkSelect.jsx
+++ b/src/ui/PerkSelect.jsx
@@ -1,9 +1,8 @@
-import { PERK_DEFS, CATEGORIES, isLegendary, critChanceFor, hasCritPerk, tempoScoreMultFor, baseScoreMultFor } from "../game/perks.js";
+import { PERK_DEFS, CATEGORIES, rarityOf, RARITY_META, critChanceFor, hasCritPerk, tempoScoreMultFor, baseScoreMultFor } from "../game/perks.js";
 import { PerkList, DeckHistogram } from "./BuildSummary.jsx";
 
-// Legendär-Akzent: gold + violett, deutlich vom Kategorie-Look abgesetzt (#33).
+// Legendär-Akzent: durchgehend gold (Rahmen, Ring, Badge, Titel) — Teil des Grau/Grün/Gold-Schemas (#71).
 const LEG_GOLD = "#d4a63a";
-const LEG_VIOLET = "#8a7de0";
 const fmtMult = (x) => x.toFixed(2).replace(".", ",");
 
 /* Level-Up-Auswahl (§7.8): pausiert das Spiel, bietet PERKS_OFFERED Optionen.
@@ -38,25 +37,29 @@ export function PerkSelect({ offer, level, onPick, perks = [], deck = [], state 
           {offer.map((id) => {
             const p = PERK_DEFS[id];
             const cat = CATEGORIES[p.cat];
-            const leg = isLegendary(id);
+            const rar = rarityOf(id);
+            const rm = RARITY_META[rar];
+            const leg = rar === "legendary";
             return (
               <button
                 key={id}
                 onClick={() => onPick(id)}
                 className="text-left rounded-xl p-4 h-full flex flex-col gap-2 transition-all hover:-translate-y-0.5"
                 style={{ background: "#20202a",
-                         border: leg ? `1px solid ${LEG_GOLD}` : `1px solid ${cat.color}55`,
-                         boxShadow: leg ? `0 0 0 1px ${LEG_VIOLET}66, 0 0 16px ${LEG_GOLD}33` : undefined }}
+                         // Rahmen = Seltenheit: grau (normal) / grün (selten) / gold (legendär).
+                         border: `1px solid ${rm.color}${rar === "common" ? "55" : ""}`,
+                         boxShadow: leg ? `0 0 0 1px ${LEG_GOLD}66, 0 0 16px ${LEG_GOLD}33`
+                                  : rar === "rare" ? `0 0 12px ${rm.color}22` : undefined }}
               >
                 <div className="flex flex-wrap items-center gap-1.5">
                   <span className="text-[10px] px-1.5 py-0.5 rounded font-bold"
                     style={{ background: `${cat.color}22`, color: cat.color }}>
                     {cat.name}
                   </span>
-                  {leg && (
+                  {rm.badge && (
                     <span className="text-[10px] px-1.5 py-0.5 rounded font-bold tracking-wide"
-                      style={{ background: `${LEG_GOLD}1f`, color: LEG_GOLD, border: `1px solid ${LEG_VIOLET}88` }}>
-                      ★ LEGENDÄR
+                      style={{ background: `${rm.color}1f`, color: rm.color, border: `1px solid ${rm.color}88` }}>
+                      {rm.badge}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
Bisher waren nur **normal** vs. **legendär** optisch unterscheidbar — **selten** sah aus wie normal. Jetzt kodiert der **Rahmen die Seltenheit**:

- **normal → grau**, **selten → grün** (+ „◆ SELTEN"-Badge), **legendär → gold** (+ „★ LEGENDÄR"-Badge)
- **Kategorie bleibt erhalten** über das kleine Kategorie-Badge (Deck/Stich/Leben/Score/Tempo) und die Titelfarbe.
- **Legendär durchgehend gold** (kein Violett mehr — auf Wunsch).

## Umsetzung
- Geteilte Quelle `RARITY_META` (grau/grün/gold + Badge/Marke) in `perks.js` — analog zu `CATEGORIES.color`.
- Angewandt in `PerkSelect.jsx` (Draft-Karten: Rahmen + Badge + Ring), `BuildSummary.jsx`/`BuildPanel` (gewählte Perks: grüner ◆ / goldener ★) und `GameOver.jsx` (Summary-Chips).

Nur UI + eine Datenkonstante. **171 Tests grün**, Build ok, App lädt ohne Konsolenfehler.