### PR TITLE
#83 Fix: temporäres Tempo (Hochlauf/Ruhe) in den Tempo-Anzeigen mitzählen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -189,7 +189,8 @@ export function Autostich() {
   // Prominenter Score-Multiplikator-Chip (#37): geteilte Quelle mit der StatusRail (kein Drift).
   // perks || [] — im Menü (state = { phase:"menu" }) fehlen die Felder; Defaults greifen.
   const baseScoreMult = baseScoreMultFor(state.perks || [], {
-    winStreak: state.winStreak, wins: state.wins, trickNo: state.trickNo, pos: state.pos, speedPct: state.speedPct,
+    winStreak: state.winStreak, wins: state.wins, trickNo: state.trickNo, pos: state.pos,
+    speedPct: (state.speedPct || 0) + (state.tempTempo || 0), // #83: temporäres Tempo (Hochlauf/Ruhe) mitzählen
   });
   const multHot = baseScoreMult > 1.001; // >1 → Gold; ×1,00 → gedämpft
   const fmtMult = (x) => x.toFixed(2).replace(".", ",");

--- a/src/ui/PerkSelect.jsx
+++ b/src/ui/PerkSelect.jsx
@@ -9,10 +9,12 @@ const fmtMult = (x) => x.toFixed(2).replace(".", ",");
    Zeigt zusätzlich den Build-Kontext (aktive Perks + Deck-Histogramm, #22) und die Kern-Stats (#40). */
 export function PerkSelect({ offer, level, onPick, perks = [], deck = [], state = {} }) {
   // Kern-Stats — dieselben Helfer/Kontexte wie die StatusRail → kein Drift (#40).
-  const { life, maxLife, shield = 0, winStreak = 0, wins = 0, trickNo = 0, pos = 0, speedPct = 0, legendaryCritBonus = 0, crits = 0 } = state;
+  const { life, maxLife, shield = 0, winStreak = 0, wins = 0, trickNo = 0, pos = 0, speedPct = 0, tempTempo = 0, legendaryCritBonus = 0, crits = 0 } = state;
+  // Effektives Tempo inkl. temporärem Tempo (E9/E10, #83) für Tempo-Score & Score-Mult; Crit bleibt permanent (E6).
+  const effTempo = speedPct + tempTempo;
   const critPct = Math.round(critChanceFor(perks, { winValue: 0, winStreak: winStreak + 1, wins: wins + 1, trickNo, posInCycle: pos, speedPct }, legendaryCritBonus) * 100);
-  const tempoScoreMult = tempoScoreMultFor(perks, speedPct);
-  const scoreMult = baseScoreMultFor(perks, { winStreak, wins, trickNo, pos, speedPct });
+  const tempoScoreMult = tempoScoreMultFor(perks, effTempo);
+  const scoreMult = baseScoreMultFor(perks, { winStreak, wins, trickNo, pos, speedPct: effTempo });
   const showCrit = hasCritPerk(perks) || crits > 0;
   return (
     <div className="fixed inset-0 z-20 flex items-center justify-center p-4" style={{ background: "#0c0c1099", backdropFilter: "blur(3px)" }}>
@@ -27,7 +29,7 @@ export function PerkSelect({ offer, level, onPick, perks = [], deck = [], state 
           <div className="flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs mt-3">
             <span><span className="opacity-50">Leben </span><span style={{ color: "#5ab87a" }}>{life} / {maxLife}</span>{shield > 0 && <span style={{ color: "#5a8ade" }}> · 🛡 {shield}</span>}</span>
             {showCrit && <span><span className="opacity-50">Crit </span><span style={{ color: "#e879f9" }}>{critPct}%</span></span>}
-            <span><span className="opacity-50">Tempo </span><span style={{ color: "#5a8ade" }}>+{speedPct}%</span></span>
+            <span><span className="opacity-50">Tempo </span><span style={{ color: "#5a8ade" }}>+{effTempo}%</span></span>
             <span><span className="opacity-50">Tempo-Score </span><span style={{ color: "#d4a63a" }}>×{fmtMult(tempoScoreMult)}</span></span>
             <span><span className="opacity-50">Score-Mult </span><span style={{ color: "#d4a63a" }}>×{fmtMult(scoreMult)}</span></span>
           </div>

--- a/src/ui/StatusRail.jsx
+++ b/src/ui/StatusRail.jsx
@@ -22,15 +22,18 @@ function Stat({ label, value, tone }) {
 }
 
 export function StatusRail({ state, speedPct, nextDrain = 0, currentTraj = [], recordTraj = [] }) {
-  const { life, maxLife, xp, level, score, wins, losses, ties, cycle, trickNo, winStreak, bestStreak, pos, lastTrick, perks, crits, shield, legendaryCritBonus = 0, prediction = null, cycleWins = 0 } = state;
+  const { life, maxLife, xp, level, score, wins, losses, ties, cycle, trickNo, winStreak, bestStreak, pos, lastTrick, perks, crits, shield, legendaryCritBonus = 0, prediction = null, cycleWins = 0, tempTempo = 0 } = state;
   const need = xpToNext(level);
   const remaining = TRICKS_PER_CYCLE - pos; // Karten bis zum nächsten Mischen (#6)
   const decided = wins + losses;            // Gleichstände zählen nicht als entschieden (§4.4)
   const winPct = decided > 0 ? Math.round((wins / decided) * 100) : 0;
+  // Effektives Tempo = permanentes speedPct + temporäres tempTempo (E9 Hochlauf / E10 Ruhe, #83).
+  // Speist Anzeige UND — via denselben Helfer — den Tempo-Score, sodass Anzeige == echter Score (kein Drift).
+  const effTempo = (speedPct || 0) + (tempTempo || 0);
   // Gesamt-Score-Mult sitzt dauerhaft im Header-Chip (#37) — hier NICHT doppeln (#46).
   // Nur der Tempo-Score-Anteil (monoton, poppt nicht) bleibt im Panel sichtbar.
   const fmtMult = (x) => x.toFixed(2).replace(".", ",");
-  const tempoScoreMult = tempoScoreMultFor(perks, speedPct);
+  const tempoScoreMult = tempoScoreMultFor(perks, effTempo);
   const ownsD4 = perks.includes("D4");
   const showCrit = hasCritPerk(perks) || (crits || 0) > 0;
   // Live-Crit-Chance des NÄCHSTEN Siegs: D8 nutzt die resultierende Serie (winStreak+1), analog zum
@@ -92,7 +95,7 @@ export function StatusRail({ state, speedPct, nextDrain = 0, currentTraj = [], r
         <div><span className="opacity-50">Siege </span><span style={{ color: "#5ab87a" }}>{wins}</span></div>
         <div><span className="opacity-50">Verl. </span><span style={{ color: "#e0605a" }}>{losses}</span></div>
         <div><span className="opacity-50">Quote </span><span style={{ color: winPct >= 50 ? "#5ab87a" : "#e0605a" }}>{winPct}%</span></div>
-        <div><span className="opacity-50">Tempo </span><span style={{ color: "#5a8ade" }}>+{speedPct}%</span></div>
+        <div><span className="opacity-50">Tempo </span><span style={{ color: "#5a8ade" }}>+{effTempo}%</span></div>
       </div>
       {/* Rest-Karten des laufenden Deck-Durchlaufs (#6) */}
       <div>


### PR DESCRIPTION
Schließt #83.

## Bug
Mit **E9 Hochlauf** (oder E10 Ruhe) gingen in der StatusRail **Tempo** und **Tempo-Score** bei Siegen nicht hoch — obwohl das Spiel das temporäre Tempo (`state.tempTempo`) real anwendet (reale Speed via `App.flipMs` und der echte Tempo-Score via `tempoScoreMultFor(perks, speedPct + tempTempo)`). Drei Anzeigen rechneten nur mit dem permanenten `speedPct`.

## Fix — `effTempo = speedPct + tempTempo`
- **StatusRail** — Tempo-Readout + Tempo-Score-Zeile.
- **PerkSelect** (Level-Up-Overlay) — Kern-Stats Tempo / Tempo-Score / Score-Mult.
- **App Header-Score-Mult-Chip (#37)** — `baseScoreMultFor` mit effektivem Tempo.

Speist denselben Helfer (`tempoScoreMultFor`/`baseScoreMultFor`) wie die Engine → **Anzeige == echter Score** (kein Drift). Die **Crit-Anzeige bleibt** auf permanentem `speedPct` (E6 Drehzahl ist bewusst permanent).

## Verifikation
Nur UI. **171 Tests grün**, Build ok; StatusRail rendert im Run fehlerfrei (`Tempo +0%` ohne Tempo-Perks, keine Fehler). Der Anstieg mit Hochlauf lässt sich im Spiel direkt beobachten.