### PR TITLE
#85 Anti-Infinity: Quadrat-Eskalation auf Schaden pro Niederlage statt Einmal-Tick

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,19 +169,17 @@ export function Autostich() {
 
   const best = Math.max(recordTotal.current, highscores[0]?.score || 0);
   const elapsedMs = timeBase.current + (segStart.current != null ? Date.now() - segStart.current : 0);
-  // Anti-Infinity (#59): periodischer, quadratisch eskalierender Leben-Abzug über die AKTIVE Zeit.
-  // drainInterval = Zahl der überschrittenen 2,5-Min-Schwellen; nextDrain = Betrag des nächsten Abzugs.
+  // Anti-Infinity (#85): quadratisch eskalierender Zusatzschaden PRO NIEDERLAGE über die AKTIVE Zeit.
+  // drainInterval = aktuelles 2,5-Min-Intervall; lossSurcharge = Aufschlag pro Niederlage im laufenden Intervall.
   const drainInterval = Math.floor(elapsedMs / LIFE_DRAIN_INTERVAL_MS);
-  const nextDrain = lifeDrainAt(drainInterval + 1);
-  // Neue Schwelle(n) → für jede verpasste Stufe LIFE_DRAIN dispatchen (Payload: Betrag; Determinismus,
-  // der Reducer sieht kein Date) + kurzer, selbst-verschwindender Float. Reset via startRun.
+  const lossSurcharge = lifeDrainAt(drainInterval);
+  // Neue Schwelle → der Engine das aktuelle Intervall melden (SET_DRAIN_LEVEL; Determinismus, der Reducer
+  // sieht kein Date) + kurzer, selbst-verschwindender Hinweis-Float. Reset via startRun (lastDrainInterval=0).
   useEffect(() => {
     if (state.phase !== "play" || drainInterval <= lastDrainInterval.current) return;
-    for (let n = lastDrainInterval.current + 1; n <= drainInterval; n++) {
-      dispatch({ type: "LIFE_DRAIN", amount: lifeDrainAt(n) });
-    }
+    dispatch({ type: "SET_DRAIN_LEVEL", level: drainInterval });
     lastDrainInterval.current = drainInterval;
-    setDrainNotice({ interval: drainInterval, amount: lifeDrainAt(drainInterval) });
+    setDrainNotice({ interval: drainInterval, surcharge: lifeDrainAt(drainInterval) });
     const id = setTimeout(() => setDrainNotice(null), 2000);
     return () => clearTimeout(id);
   }, [drainInterval, state.phase]);
@@ -271,7 +269,7 @@ export function Autostich() {
               <Battlefield lastTrick={state.lastTrick} remaining={TRICKS_PER_CYCLE - state.pos} flipMs={flipMs} drainNotice={drainNotice} />
               <BuildPanel perks={state.perks} />
             </div>
-            <StatusRail state={state} speedPct={state.speedPct} nextDrain={nextDrain} currentTraj={currentTraj.current} recordTraj={recordTraj.current} />
+            <StatusRail state={state} speedPct={state.speedPct} lossSurcharge={lossSurcharge} currentTraj={currentTraj.current} recordTraj={recordTraj.current} />
           </div>
 
           {/* Chronik — Deck-Werte-Histogramm, volle Breite ganz unten (#28) */}

--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -3,10 +3,11 @@
    ============================================================ */
 export const START_LIFE       = 2000;   // Leben = Run-Timer [TUNING]
 export const DMG_PER_LOSS     = 10;     // Schaden je Niederlage (flat) [TUNING]
-// Anti-Infinity (#59, ersetzt #32): periodischer, quadratisch eskalierender Leben-Abzug über die
-// AKTIVE Laufzeit — alle 2,5 Min −LIFE_DRAIN_BASE·n² (n = Intervall-Index): −5, −20, −45, −80 … kein Cap.
-export const LIFE_DRAIN_INTERVAL_MS = 2.5 * 60 * 1000; // 2,5 Min aktiver Spielzeit je Abzug [TUNING]
-export const LIFE_DRAIN_BASE        = 5;               // Abzug = LIFE_DRAIN_BASE · n² [TUNING]
+// Anti-Infinity (#85, Umbau von #59): quadratisch eskalierender ZUSATZSCHADEN PRO NIEDERLAGE über die
+// aktive Laufzeit — im n-ten 2,5-Min-Intervall kostet jede Niederlage +LIFE_DRAIN_BASE·n² (n=0 im ersten
+// Intervall → +0): +0, +5, +20, +45, +80 … kein Cap. Kein isolierter Zeit-Tick mehr.
+export const LIFE_DRAIN_INTERVAL_MS = 2.5 * 60 * 1000; // 2,5 Min aktiver Spielzeit je Eskalationsstufe [TUNING]
+export const LIFE_DRAIN_BASE        = 5;               // Aufschlag pro Niederlage = LIFE_DRAIN_BASE · n² [TUNING]
 export const XP_PER_WIN       = 10;     // XP je gewonnenem Stich [TUNING]
 export const SCORE_PER_WIN    = 100;    // Basispunkte je Sieg (Perks/Tempo skalieren darauf) [TUNING]
 export const TEMPO_SCORE_FACTOR = 0.005; // je %-Punkt speedPct +0,5 % Stichscore [TUNING]
@@ -75,9 +76,9 @@ export const VALUE_CAP = null;
 // speedPct), kein manueller Regler (#2, Design-Doc §5.3).
 export const BASE_FLIP_MS = 1750;   // ms je Stich bei 0 % Speed (Basis-Tempo, etwas flotter; Turbo/Perks oben drauf) [TUNING]
 
-// Anti-Infinity (#59): Abzug im n-ten 2,5-Min-Intervall (n≥1) — quadratisch, kein Cap. Rein.
-// App.jsx erkennt aus elapsedMs das Überschreiten einer Intervall-Schwelle und dispatcht LIFE_DRAIN
-// mit lifeDrainAt(n) (Determinismus: der game/-Layer sieht kein Date, nur den Betrag als Payload).
+// Aufschlag pro Niederlage im n-ten 2,5-Min-Intervall (n≥0) — quadratisch, kein Cap. Rein.
+// App.jsx meldet das aktuelle Intervall via SET_DRAIN_LEVEL an die Engine (Determinismus: der game/-Layer
+// sieht kein Date, nur den Intervall-Index als State); die Engine addiert lifeDrainAt(drainLevel) auf den Niederlagenschaden.
 export const lifeDrainAt = (n) => LIFE_DRAIN_BASE * n * n;
 
 /* ============================================================

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -171,10 +171,11 @@ export function resolveTrick(state, rng = Math.random) {
     lastResult = "win";
   } else if (lost) {
     losses += 1; winStreak = 0;
-    // Flat-Grundschaden (#59: die #32-Zeiteskalation ist raus; Zeit-Pressure läuft jetzt über den
-    // periodischen LIFE_DRAIN). Legendär-Zusatzschaden (L1 +3 / L6 +2) addiert; dmgReduce (C3) zieht
-    // ab, Schild (C5) absorbiert danach (s. u.).
-    dmg = Math.max(0, C.DMG_PER_LOSS + sumHook(perks, "extraDamageTaken", {}) - sumHook(perks, "dmgReduce", { life, maxLife }));
+    // Grundschaden + Zeit-Aufschlag (#85): DMG_PER_LOSS + lifeDrainAt(drainLevel) — im n-ten 2,5-Min-Intervall
+    // kostet jede Niederlage +5·n² zusätzlich (Zeitdruck läuft jetzt über teurere Niederlagen statt einen Tick).
+    // Legendär-Zusatzschaden (L1 +3 / L6 +2) addiert; dmgReduce (C3/C6) zieht ab, Schild (C5) absorbiert danach.
+    dmg = Math.max(0, C.DMG_PER_LOSS + C.lifeDrainAt(state.drainLevel || 0)
+                      + sumHook(perks, "extraDamageTaken", {}) - sumHook(perks, "dmgReduce", { life, maxLife }));
     // Schild (C5) absorbiert NACH der Schadensberechnung, vor dem Leben.
     if (shield > 0 && dmg > 0) { const absorbed = Math.min(shield, dmg); shield -= absorbed; dmg -= absorbed; }
     life -= dmg;

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -39,6 +39,7 @@ export function initialState(rng = Math.random) {
     speedPct: 0,
     shield: 0,
     tieArmed: false,
+    drainLevel: 0, // #85 Anti-Infinity: aktuelles 2,5-Min-Intervall → Zusatzschaden pro Niederlage
     lastTrick: null,
   };
 }
@@ -64,13 +65,11 @@ export function reducer(state, action) {
     case "RESOLVE_TRICK":
       return resolveTrick(state, action.rng);
 
-    case "LIFE_DRAIN": {
-      // Anti-Infinity (#59): periodischer, quadratisch eskalierender Leben-Abzug. Betrag kommt als
-      // Payload aus App.jsx (Determinismus: kein Date im Reducer). Nur im Spiel; ≤0 → Game Over.
+    case "SET_DRAIN_LEVEL": {
+      // Anti-Infinity (#85, ersetzt den #59-Tick): App meldet das aktuelle 2,5-Min-Intervall; die Engine
+      // erhöht daraus den Schaden PRO NIEDERLAGE (lifeDrainAt). Kein direkter Leben-Abzug (kein Date im Reducer).
       if (state.phase !== "play") return state;
-      const life = state.life - (action.amount || 0);
-      if (life <= 0) return { ...state, life: 0, phase: "gameover" };
-      return { ...state, life };
+      return { ...state, drainLevel: action.level || 0 };
     }
 
     case "SUBMIT_PREDICTION": {

--- a/src/ui/Battlefield.jsx
+++ b/src/ui/Battlefield.jsx
@@ -150,14 +150,14 @@ export function Battlefield({ lastTrick, remaining = TRICKS_PER_CYCLE, flipMs = 
           </div>
         )}
 
-        {/* Anti-Infinity (#59): einmaliger Hinweis beim periodischen Zeit-Abzug —
+        {/* Anti-Infinity (#85): Hinweis, wenn der Zeit-Aufschlag pro Niederlage steigt —
             non-blocking, selbst-verschwindend; reduced-motion → statisch (App räumt nach 2 s ab). */}
         {drainNotice && (
           <div key={`drainnotice-${drainNotice.interval}`} className="pointer-events-none absolute left-1/2 top-0 font-bold whitespace-nowrap z-20"
             style={{ fontSize: 14, color: "#e0605a", textShadow: "0 0 10px #e0605a99",
                      transform: reduced ? "translateX(-50%)" : undefined,
                      animation: fx("as-notice 2000ms ease-out forwards") }}>
-            ⏳ Zeit-Abzug −{drainNotice.amount}♥
+            ⏳ Niederlagen jetzt +{drainNotice.surcharge}♥
           </div>
         )}
 

--- a/src/ui/StatusRail.jsx
+++ b/src/ui/StatusRail.jsx
@@ -21,7 +21,7 @@ function Stat({ label, value, tone }) {
   );
 }
 
-export function StatusRail({ state, speedPct, nextDrain = 0, currentTraj = [], recordTraj = [] }) {
+export function StatusRail({ state, speedPct, lossSurcharge = 0, currentTraj = [], recordTraj = [] }) {
   const { life, maxLife, xp, level, score, wins, losses, ties, cycle, trickNo, winStreak, bestStreak, pos, lastTrick, perks, crits, shield, legendaryCritBonus = 0, prediction = null, cycleWins = 0, tempTempo = 0 } = state;
   const need = xpToNext(level);
   const remaining = TRICKS_PER_CYCLE - pos; // Karten bis zum nächsten Mischen (#6)
@@ -46,8 +46,8 @@ export function StatusRail({ state, speedPct, nextDrain = 0, currentTraj = [], r
   const lowLifeRally = perks.includes("L3") && maxLife > 0 && life / maxLife <= 0.25;
   // Leben-Balken bei Schaden/Heilung kurz aufblitzen (#15).
   const lifeFlash = lastTrick ? (lastTrick.result === "loss" && lastTrick.dmg > 0 ? "#e0605a" : lastTrick.healed > 0 ? "#5ab87a" : null) : null;
-  // Passiver Indikator des nächsten periodischen Zeit-Abzugs (#59): grün → gelb → rot je Härte.
-  const drainColor = nextDrain <= 20 ? "#5ab87a" : nextDrain <= 80 ? "#d4a63a" : "#e0605a";
+  // Passiver Indikator des aktuellen Zeit-Aufschlags PRO NIEDERLAGE (#85): grün → gelb → rot je Härte.
+  const drainColor = lossSurcharge <= 20 ? "#5ab87a" : lossSurcharge <= 80 ? "#d4a63a" : "#e0605a";
   return (
     <div className="rounded-xl p-4 grid gap-3 as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
       {/* Leben */}
@@ -61,11 +61,11 @@ export function StatusRail({ state, speedPct, nextDrain = 0, currentTraj = [], r
           {lifeFlash && <div key={trickNo} className="absolute inset-0 rounded-full pointer-events-none"
             style={{ animation: "as-flash 400ms ease-out", "--flash": lifeFlash }} />}
         </div>
-        {/* Zeit-Abzug — passiver Indikator des NÄCHSTEN periodischen Abzugs (#59). */}
+        {/* Zeit-Aufschlag pro Niederlage — passiver Indikator, eskaliert über die Spielzeit (#85). */}
         <div className="flex justify-end mt-1">
           <span className="text-[10px]" style={{ color: drainColor }}
-            title="Periodischer Zeit-Abzug — alle 2,5 Min, quadratisch eskalierend (5·n²)">
-            Zeit-Abzug (nächster) −{nextDrain}♥
+            title="Zeitdruck — je 2,5 Min steigt der Zusatzschaden pro Niederlage: +5·n² (0, +5, +20, +45, +80 …)">
+            Niederlage-Aufschlag +{lossSurcharge}♥
           </span>
         </div>
         {/* L3 „Letztes Aufbäumen" aktiv (#33): deutlicher, aber statischer Status (kein Blinken). */}

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -128,16 +128,30 @@ describe("resolveTrick — Verteidigungs-Perks", () => {
   });
 });
 
-describe("Anti-Infinity — periodischer Leben-Abzug (#59, ersetzt #32)", () => {
-  it("lifeDrainAt: quadratische Kurve 5·n² (−5, −20, −45, −80, …, 500)", () => {
+describe("Anti-Infinity — Zeit-Eskalation pro Niederlage (#85, ersetzt den #59-Tick)", () => {
+  it("lifeDrainAt: quadratische Kurve 5·n² (0, 5, 20, 45, 80, …, 500)", () => {
+    expect(lifeDrainAt(0)).toBe(0);
     expect(lifeDrainAt(1)).toBe(5);
     expect(lifeDrainAt(2)).toBe(20);
     expect(lifeDrainAt(3)).toBe(45);
     expect(lifeDrainAt(4)).toBe(80);
     expect(lifeDrainAt(10)).toBe(500);
   });
-  it("Niederlagenschaden ist wieder flat (keine Zeit-Eskalation)", () => {
-    expect(resolveTrick(scenario(0, 12, { life: 100 }), rng).life).toBe(90); // DMG_PER_LOSS = 10
+  it("Niederlagenschaden eskaliert mit drainLevel: DMG_PER_LOSS + 5·n²", () => {
+    expect(resolveTrick(scenario(0, 12, { life: 100 }), rng).life).toBe(90);                 // Level 0 → 10
+    expect(resolveTrick(scenario(0, 12, { life: 100, drainLevel: 1 }), rng).life).toBe(85);  // 10 + 5
+    expect(resolveTrick(scenario(0, 12, { life: 200, drainLevel: 3 }), rng).life).toBe(145); // 10 + 45
+  });
+  it("Zeit-Aufschlag stapelt mit Perk-Schaden (L1) und wird von Reduktion (C3) gemindert", () => {
+    // drainLevel 2 (+20): 10 + 20 + L1(+3) = 33
+    expect(resolveTrick(scenario(0, 12, { life: 100, drainLevel: 2, perks: ["L1"] }), rng).life).toBe(67);
+    // drainLevel 2 (+20): 10 + 20 − C3(−2) = 28
+    expect(resolveTrick(scenario(0, 12, { life: 100, drainLevel: 2, perks: ["C3"] }), rng).life).toBe(72);
+  });
+  it("hoher Zeit-Aufschlag kann tödlich sein → Game Over", () => {
+    const s = resolveTrick(scenario(0, 12, { life: 40, drainLevel: 3 }), rng); // 10 + 45 = 55 ≥ 40
+    expect(s.phase).toBe("gameover");
+    expect(s.life).toBe(0);
   });
 });
 

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -118,24 +118,19 @@ describe("Reducer — Ansage-System (#36)", () => {
   });
 });
 
-describe("LIFE_DRAIN — periodischer Zeit-Abzug (#59)", () => {
-  it("zieht den Betrag vom Leben ab (bleibt in play)", () => {
+describe("SET_DRAIN_LEVEL — Zeit-Eskalation pro Niederlage (#85, ersetzt den #59-Tick)", () => {
+  it("setzt drainLevel, ohne Leben abzuziehen (bleibt in play)", () => {
     const s = { ...initialState(makeRng(1)), life: 100 };
-    const r = reducer(s, { type: "LIFE_DRAIN", amount: 20 });
-    expect(r.life).toBe(80);
+    const r = reducer(s, { type: "SET_DRAIN_LEVEL", level: 3 });
+    expect(r.drainLevel).toBe(3);
+    expect(r.life).toBe(100);      // kein direkter Abzug mehr
     expect(r.phase).toBe("play");
-  });
-  it("life ≤ 0 durch den Abzug → Game Over", () => {
-    const s = { ...initialState(makeRng(1)), life: 15 };
-    const r = reducer(s, { type: "LIFE_DRAIN", amount: 20 });
-    expect(r.life).toBe(0);
-    expect(r.phase).toBe("gameover");
   });
   it("greift nur in der play-Phase (Menü/Overlay unberührt)", () => {
     const menu = menuState();
-    expect(reducer(menu, { type: "LIFE_DRAIN", amount: 20 })).toBe(menu);
-    const lvl = { ...initialState(makeRng(1)), phase: "levelup", life: 100 };
-    expect(reducer(lvl, { type: "LIFE_DRAIN", amount: 20 }).life).toBe(100);
+    expect(reducer(menu, { type: "SET_DRAIN_LEVEL", level: 2 })).toBe(menu);
+    const lvl = { ...initialState(makeRng(1)), phase: "levelup" };
+    expect(reducer(lvl, { type: "SET_DRAIN_LEVEL", level: 2 }).drainLevel).toBe(0);
   });
 });
 


### PR DESCRIPTION
Schließt #85. Baut den Anti-Infinity-Mechanismus (#59) um: statt eines isolierten Zeit-Ticks alle 2,5 Min eskaliert jetzt der **Schaden pro Niederlage** über die Spielzeit.

## Verhalten
Im n-ten 2,5-Min-Intervall kostet jede Niederlage **+5·n²** zusätzlich (n=0 im ersten Intervall → +0): **+0 / +5 / +20 / +45 / +80 …** (kein Cap). Kein Einmal-Abzug mehr.

## Umsetzung (determinismus-erhaltend)
- `constants`: `lifeDrainAt(n) = 5·n²` ist jetzt der Aufschlag **pro Niederlage**.
- `reducer`: `LIFE_DRAIN` (Leben abziehen) → **`SET_DRAIN_LEVEL`** (setzt `state.drainLevel`). App meldet nur das Intervall, kein `Date` in `game/`.
- `engine`: Niederlage-`dmg += lifeDrainAt(state.drainLevel)`; stapelt mit L1/L6, minderbar durch C3/C6, danach Schild (C5), kann tödlich sein.
- `App`: `dispatch(SET_DRAIN_LEVEL)` beim Intervallwechsel; `lossSurcharge` für die Anzeige.
- `StatusRail`: Indikator „Niederlage-Aufschlag +N" (grün/gelb/rot). `Battlefield`: Hinweis-Float „Niederlagen jetzt +N" beim Stufenwechsel.

## Verifikation
Tests aktualisiert (SET_DRAIN_LEVEL; Eskalation Level 1/3, Stapeln mit L1/C3, tödlicher Fall). **172 grün**, Build ok; StatusRail live geprüft (`Niederlage-Aufschlag +0♥` grün), keine Konsolenfehler.

## ⚠️ Bewusster Nebeneffekt
Der alte Tick traf **auch Nie-Verlierer**. Jetzt kommt der Zeitdruck ausschließlich über Niederlagen — ein Deck, das **nie** verliert (alle Karten > 10), umgeht den Timer komplett. Falls harte Anti-Infinity gewünscht ist, kann ein kleiner periodischer Rest-Tick zusätzlich behalten werden (separater Schritt).