### PR TITLE
#87 Anti-Infinity cycle-basiert: Aufschlag pro Niederlage je Durchlauf (Base 2, 0,5·n²)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useReducer, useEffect, useRef, useState } from "react";
 import { reducer, initialState, menuState } from "./game/reducer.js";
-import { BASE_FLIP_MS, GHOST_STEP, TRICKS_PER_CYCLE, LIFE_DRAIN_INTERVAL_MS, lifeDrainAt } from "./game/constants.js";
+import { BASE_FLIP_MS, GHOST_STEP, TRICKS_PER_CYCLE, lifeDrainAt } from "./game/constants.js";
 import { baseScoreMultFor } from "./game/perks.js";
 import { loadGhost, saveGhost, loadHighscores, recordHighscore, loadOptions, saveOptions, loadUsername, saveUsername } from "./game/storage.js";
 import { leaderboardConfigured, publishRun } from "./game/leaderboard.js";
@@ -47,7 +47,7 @@ export function Autostich() {
   // RUN-TIMER (#10) — akkumulierte aktive Zeit; friert bei Pause / außerhalb „play" ein (#9)
   const timeBase = useRef(0);
   const segStart = useRef(null);
-  const lastDrainInterval = useRef(0); // zuletzt abgezogenes Zeit-Intervall (#59)
+  const lastDrainCycle = useRef(0); // zuletzt gemeldeter Durchlauf für den Aufschlag-Hinweis (#87)
   const prevMult = useRef(1);     // vorheriger Score-Mult (Puls nur bei Anstieg, #37)
   // Offenes Optionen-Overlay friert den Lauf ein (wie andere Overlays) — ohne den
   // Nutzer-Pause-Toggle zu verändern: beim Schließen läuft es im vorherigen Zustand weiter.
@@ -145,7 +145,7 @@ export function Autostich() {
     // null → elapsedMs=0 → Timer/Anti-Infinity (#59) fröre ein (#50). Der ==null-Guard im Effekt
     // verhindert Doppel-Setzen bei echten false→true-Einstiegen (Menü→Play, GameOver→Neu).
     segStart.current = Date.now();
-    lastDrainInterval.current = 0;
+    lastDrainCycle.current = 0;
     setDrainNotice(null);
     setPaused(false);
     setIsRecord(false);
@@ -169,20 +169,20 @@ export function Autostich() {
 
   const best = Math.max(recordTotal.current, highscores[0]?.score || 0);
   const elapsedMs = timeBase.current + (segStart.current != null ? Date.now() - segStart.current : 0);
-  // Anti-Infinity (#85): quadratisch eskalierender Zusatzschaden PRO NIEDERLAGE über die AKTIVE Zeit.
-  // drainInterval = aktuelles 2,5-Min-Intervall; lossSurcharge = Aufschlag pro Niederlage im laufenden Intervall.
-  const drainInterval = Math.floor(elapsedMs / LIFE_DRAIN_INTERVAL_MS);
-  const lossSurcharge = lifeDrainAt(drainInterval);
-  // Neue Schwelle → der Engine das aktuelle Intervall melden (SET_DRAIN_LEVEL; Determinismus, der Reducer
-  // sieht kein Date) + kurzer, selbst-verschwindender Hinweis-Float. Reset via startRun (lastDrainInterval=0).
+  // Anti-Infinity (#87): der Aufschlag pro Niederlage hängt am Deck-Durchlauf (cycle), NICHT an der Echtzeit
+  // → Tempo/Turbo ändert die Score-Ausbeute nicht mehr. Die Engine rechnet lifeDrainAt(cycle) selbst; hier nur
+  // die Anzeige + ein kurzer Hinweis-Float, wenn der Aufschlag beim Durchlauf-Wechsel steigt.
+  const lossSurcharge = lifeDrainAt(state.cycle || 0);
   useEffect(() => {
-    if (state.phase !== "play" || drainInterval <= lastDrainInterval.current) return;
-    dispatch({ type: "SET_DRAIN_LEVEL", level: drainInterval });
-    lastDrainInterval.current = drainInterval;
-    setDrainNotice({ interval: drainInterval, surcharge: lifeDrainAt(drainInterval) });
-    const id = setTimeout(() => setDrainNotice(null), 2000);
-    return () => clearTimeout(id);
-  }, [drainInterval, state.phase]);
+    const cyc = state.cycle || 0;
+    if (state.phase !== "play" || cyc <= lastDrainCycle.current) return;
+    lastDrainCycle.current = cyc;
+    if (lifeDrainAt(cyc) > lifeDrainAt(cyc - 1)) { // nur melden, wenn der Aufschlag tatsächlich hochgeht
+      setDrainNotice({ cycle: cyc, surcharge: lifeDrainAt(cyc) });
+      const id = setTimeout(() => setDrainNotice(null), 2000);
+      return () => clearTimeout(id);
+    }
+  }, [state.cycle, state.phase]);
 
   // Prominenter Score-Multiplikator-Chip (#37): geteilte Quelle mit der StatusRail (kein Drift).
   // perks || [] — im Menü (state = { phase:"menu" }) fehlen die Felder; Defaults greifen.

--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -2,12 +2,12 @@
    TUNING-BLOCK  — hier dreht der Dev im Playtest
    ============================================================ */
 export const START_LIFE       = 2000;   // Leben = Run-Timer [TUNING]
-export const DMG_PER_LOSS     = 10;     // Schaden je Niederlage (flat) [TUNING]
-// Anti-Infinity (#85, Umbau von #59): quadratisch eskalierender ZUSATZSCHADEN PRO NIEDERLAGE über die
-// aktive Laufzeit — im n-ten 2,5-Min-Intervall kostet jede Niederlage +LIFE_DRAIN_BASE·n² (n=0 im ersten
-// Intervall → +0): +0, +5, +20, +45, +80 … kein Cap. Kein isolierter Zeit-Tick mehr.
-export const LIFE_DRAIN_INTERVAL_MS = 2.5 * 60 * 1000; // 2,5 Min aktiver Spielzeit je Eskalationsstufe [TUNING]
-export const LIFE_DRAIN_BASE        = 5;               // Aufschlag pro Niederlage = LIFE_DRAIN_BASE · n² [TUNING]
+export const DMG_PER_LOSS     = 2;      // Basis-Schaden je Niederlage im 1. Durchlauf — sanfter Auftakt (#87) [TUNING]
+// Anti-Infinity (#87, cycle-basiert, Umbau von #85/#59): der ZUSATZSCHADEN PRO NIEDERLAGE eskaliert je
+// Deck-DURCHLAUF (nicht Echtzeit) → Tempo/Turbo beeinflusst den Score nicht mehr. Aufschlag = round(0,5·n²),
+// n = cycle (0-indiziert): +0, +0, +2, +5, +8, +13, +18 … kein Cap. Ziel: Run-Bogen über ~20 Durchläufe.
+// Voll deterministisch — die Engine leitet n aus `cycle` ab (kein Date, kein App-Payload nötig).
+export const LIFE_DRAIN_BASE        = 0.5;             // Aufschlag pro Niederlage = round(LIFE_DRAIN_BASE · cycle²) [TUNING]
 export const XP_PER_WIN       = 10;     // XP je gewonnenem Stich [TUNING]
 export const SCORE_PER_WIN    = 100;    // Basispunkte je Sieg (Perks/Tempo skalieren darauf) [TUNING]
 export const TEMPO_SCORE_FACTOR = 0.005; // je %-Punkt speedPct +0,5 % Stichscore [TUNING]
@@ -76,10 +76,9 @@ export const VALUE_CAP = null;
 // speedPct), kein manueller Regler (#2, Design-Doc §5.3).
 export const BASE_FLIP_MS = 1750;   // ms je Stich bei 0 % Speed (Basis-Tempo, etwas flotter; Turbo/Perks oben drauf) [TUNING]
 
-// Aufschlag pro Niederlage im n-ten 2,5-Min-Intervall (n≥0) — quadratisch, kein Cap. Rein.
-// App.jsx meldet das aktuelle Intervall via SET_DRAIN_LEVEL an die Engine (Determinismus: der game/-Layer
-// sieht kein Date, nur den Intervall-Index als State); die Engine addiert lifeDrainAt(drainLevel) auf den Niederlagenschaden.
-export const lifeDrainAt = (n) => LIFE_DRAIN_BASE * n * n;
+// Aufschlag pro Niederlage im n-ten Deck-Durchlauf (n = cycle, ≥0) — quadratisch, gerundet, kein Cap. Rein.
+// Die Engine ruft lifeDrainAt(cycle) direkt im Niederlage-Zweig auf; kein Date/Payload nötig (#87).
+export const lifeDrainAt = (n) => Math.round(LIFE_DRAIN_BASE * n * n);
 
 /* ============================================================
    DECK / FARBEN

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -171,10 +171,10 @@ export function resolveTrick(state, rng = Math.random) {
     lastResult = "win";
   } else if (lost) {
     losses += 1; winStreak = 0;
-    // Grundschaden + Zeit-Aufschlag (#85): DMG_PER_LOSS + lifeDrainAt(drainLevel) — im n-ten 2,5-Min-Intervall
-    // kostet jede Niederlage +5·n² zusätzlich (Zeitdruck läuft jetzt über teurere Niederlagen statt einen Tick).
-    // Legendär-Zusatzschaden (L1 +3 / L6 +2) addiert; dmgReduce (C3/C6) zieht ab, Schild (C5) absorbiert danach.
-    dmg = Math.max(0, C.DMG_PER_LOSS + C.lifeDrainAt(state.drainLevel || 0)
+    // Grundschaden + Durchlauf-Aufschlag (#87): DMG_PER_LOSS + lifeDrainAt(cycle) — je Deck-Durchlauf kostet
+    // jede Niederlage mehr (round(0,5·cycle²)). Zeitdruck läuft über den Fortschritt, nicht über Echtzeit
+    // → Tempo neutral. Legendär-Zusatzschaden (L1/L6/E7) addiert; dmgReduce (C3/C6) zieht ab, Schild (C5) danach.
+    dmg = Math.max(0, C.DMG_PER_LOSS + C.lifeDrainAt(cycle)
                       + sumHook(perks, "extraDamageTaken", {}) - sumHook(perks, "dmgReduce", { life, maxLife }));
     // Schild (C5) absorbiert NACH der Schadensberechnung, vor dem Leben.
     if (shield > 0 && dmg > 0) { const absorbed = Math.min(shield, dmg); shield -= absorbed; dmg -= absorbed; }

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -39,7 +39,6 @@ export function initialState(rng = Math.random) {
     speedPct: 0,
     shield: 0,
     tieArmed: false,
-    drainLevel: 0, // #85 Anti-Infinity: aktuelles 2,5-Min-Intervall → Zusatzschaden pro Niederlage
     lastTrick: null,
   };
 }
@@ -64,13 +63,6 @@ export function reducer(state, action) {
 
     case "RESOLVE_TRICK":
       return resolveTrick(state, action.rng);
-
-    case "SET_DRAIN_LEVEL": {
-      // Anti-Infinity (#85, ersetzt den #59-Tick): App meldet das aktuelle 2,5-Min-Intervall; die Engine
-      // erhöht daraus den Schaden PRO NIEDERLAGE (lifeDrainAt). Kein direkter Leben-Abzug (kein Date im Reducer).
-      if (state.phase !== "play") return state;
-      return { ...state, drainLevel: action.level || 0 };
-    }
 
     case "SUBMIT_PREDICTION": {
       // Ansage bestätigen (#36): erst JETZT neu mischen, pos/Zyklus-Akkus zurücksetzen, nächster Durchlauf.

--- a/src/ui/Battlefield.jsx
+++ b/src/ui/Battlefield.jsx
@@ -153,7 +153,7 @@ export function Battlefield({ lastTrick, remaining = TRICKS_PER_CYCLE, flipMs = 
         {/* Anti-Infinity (#85): Hinweis, wenn der Zeit-Aufschlag pro Niederlage steigt —
             non-blocking, selbst-verschwindend; reduced-motion → statisch (App räumt nach 2 s ab). */}
         {drainNotice && (
-          <div key={`drainnotice-${drainNotice.interval}`} className="pointer-events-none absolute left-1/2 top-0 font-bold whitespace-nowrap z-20"
+          <div key={`drainnotice-${drainNotice.cycle}`} className="pointer-events-none absolute left-1/2 top-0 font-bold whitespace-nowrap z-20"
             style={{ fontSize: 14, color: "#e0605a", textShadow: "0 0 10px #e0605a99",
                      transform: reduced ? "translateX(-50%)" : undefined,
                      animation: fx("as-notice 2000ms ease-out forwards") }}>

--- a/src/ui/StatusRail.jsx
+++ b/src/ui/StatusRail.jsx
@@ -64,7 +64,7 @@ export function StatusRail({ state, speedPct, lossSurcharge = 0, currentTraj = [
         {/* Zeit-Aufschlag pro Niederlage — passiver Indikator, eskaliert über die Spielzeit (#85). */}
         <div className="flex justify-end mt-1">
           <span className="text-[10px]" style={{ color: drainColor }}
-            title="Zeitdruck — je 2,5 Min steigt der Zusatzschaden pro Niederlage: +5·n² (0, +5, +20, +45, +80 …)">
+            title="Fortschrittsdruck — je Deck-Durchlauf steigt der Zusatzschaden pro Niederlage: round(0,5·n²) (0, 0, +2, +5, +8, +13 …)">
             Niederlage-Aufschlag +{lossSurcharge}♥
           </span>
         </div>

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -35,10 +35,10 @@ describe("resolveTrick — Grundausgänge", () => {
     expect(s.initiative).toBe("player");
   });
 
-  it("Niederlage: -10 Leben, Serie reißt, Initiative Gegner", () => {
+  it("Niederlage: -2 Leben (Basis, Durchlauf 0), Serie reißt, Initiative Gegner", () => {
     const s = resolveTrick(scenario(0, 12, { life: 100, winStreak: 4 }), rng);
     expect(s.losses).toBe(1);
-    expect(s.life).toBe(90);
+    expect(s.life).toBe(98); // DMG_PER_LOSS = 2 (#87)
     expect(s.winStreak).toBe(0);
     expect(s.lastResult).toBe("loss");
     expect(s.initiative).toBe("opp");
@@ -54,7 +54,7 @@ describe("resolveTrick — Grundausgänge", () => {
   });
 
   it("Tod bei ≤0 Leben → phase gameover, Leben auf 0 geklemmt", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 5 }), rng);
+    const s = resolveTrick(scenario(0, 12, { life: 2 }), rng); // 2 − DMG_PER_LOSS(2) = 0 ≤ 0
     expect(s.phase).toBe("gameover");
     expect(s.life).toBe(0);
   });
@@ -81,8 +81,8 @@ describe("resolveTrick — Grundausgänge", () => {
 });
 
 describe("resolveTrick — Verteidigungs-Perks", () => {
-  it("C3 Panzerung: Schaden 10 → 8", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C3"] }), rng);
+  it("C3 Panzerung reduziert um 2 (Durchlauf 4: Schaden 10 → 8)", () => {
+    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C3"], cycle: 4 }), rng); // 2 + 8 − 2 = 8
     expect(s.life).toBe(92);
   });
 
@@ -91,14 +91,14 @@ describe("resolveTrick — Verteidigungs-Perks", () => {
     expect(resolveTrick(scenario(12, 0, { life: 2000, perks: ["C1"] }), rng).life).toBe(2000);
   });
 
-  it("C5 Schutzschild: 50 Schildpunkte absorbieren Schaden vor dem Leben", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C5"], shield: 50 }), rng);
-    expect(s.life).toBe(100);   // Verlust 10 → Schild 50→40
+  it("C5 Schutzschild: 50 Schildpunkte absorbieren Schaden vor dem Leben (Durchlauf 4 → 10 Schaden)", () => {
+    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C5"], shield: 50, cycle: 4 }), rng);
+    expect(s.life).toBe(100);   // Verlust 2+8=10 → Schild 50→40
     expect(s.shield).toBe(40);
   });
 
-  it("C5 + Panzerung: erst Schaden reduzieren (−2), dann Schild absorbieren", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C5", "C3"], shield: 50 }), rng);
+  it("C5 + Panzerung: erst Schaden reduzieren (−2), dann Schild absorbieren (Durchlauf 4)", () => {
+    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C5", "C3"], shield: 50, cycle: 4 }), rng);
     expect(s.shield).toBe(42);  // 10 − 2 = 8 abgezogen
     expect(s.life).toBe(100);
   });
@@ -128,28 +128,30 @@ describe("resolveTrick — Verteidigungs-Perks", () => {
   });
 });
 
-describe("Anti-Infinity — Zeit-Eskalation pro Niederlage (#85, ersetzt den #59-Tick)", () => {
-  it("lifeDrainAt: quadratische Kurve 5·n² (0, 5, 20, 45, 80, …, 500)", () => {
+describe("Anti-Infinity — Aufschlag pro Niederlage je Deck-Durchlauf (#87, cycle-basiert)", () => {
+  it("lifeDrainAt: gerundetes 0,5·n² (0, 1, 2, 5, 8, 13, …, 50, 200)", () => {
     expect(lifeDrainAt(0)).toBe(0);
-    expect(lifeDrainAt(1)).toBe(5);
-    expect(lifeDrainAt(2)).toBe(20);
-    expect(lifeDrainAt(3)).toBe(45);
-    expect(lifeDrainAt(4)).toBe(80);
-    expect(lifeDrainAt(10)).toBe(500);
+    expect(lifeDrainAt(1)).toBe(1);   // round(0,5)
+    expect(lifeDrainAt(2)).toBe(2);
+    expect(lifeDrainAt(3)).toBe(5);   // round(4,5)
+    expect(lifeDrainAt(4)).toBe(8);
+    expect(lifeDrainAt(5)).toBe(13);  // round(12,5)
+    expect(lifeDrainAt(10)).toBe(50);
+    expect(lifeDrainAt(20)).toBe(200);
   });
-  it("Niederlagenschaden eskaliert mit drainLevel: DMG_PER_LOSS + 5·n²", () => {
-    expect(resolveTrick(scenario(0, 12, { life: 100 }), rng).life).toBe(90);                 // Level 0 → 10
-    expect(resolveTrick(scenario(0, 12, { life: 100, drainLevel: 1 }), rng).life).toBe(85);  // 10 + 5
-    expect(resolveTrick(scenario(0, 12, { life: 200, drainLevel: 3 }), rng).life).toBe(145); // 10 + 45
+  it("Niederlagenschaden eskaliert mit dem Durchlauf (cycle): DMG_PER_LOSS(2) + round(0,5·cycle²)", () => {
+    expect(resolveTrick(scenario(0, 12, { life: 100 }), rng).life).toBe(98);              // cycle 0 → 2 + 0
+    expect(resolveTrick(scenario(0, 12, { life: 100, cycle: 2 }), rng).life).toBe(96);    // 2 + 2
+    expect(resolveTrick(scenario(0, 12, { life: 200, cycle: 5 }), rng).life).toBe(185);   // 2 + 13
   });
-  it("Zeit-Aufschlag stapelt mit Perk-Schaden (L1) und wird von Reduktion (C3) gemindert", () => {
-    // drainLevel 2 (+20): 10 + 20 + L1(+3) = 33
-    expect(resolveTrick(scenario(0, 12, { life: 100, drainLevel: 2, perks: ["L1"] }), rng).life).toBe(67);
-    // drainLevel 2 (+20): 10 + 20 − C3(−2) = 28
-    expect(resolveTrick(scenario(0, 12, { life: 100, drainLevel: 2, perks: ["C3"] }), rng).life).toBe(72);
+  it("Aufschlag stapelt mit Perk-Schaden (L1) und wird von Reduktion (C3) gemindert", () => {
+    // cycle 4 (+8): 2 + 8 + L1(+3) = 13
+    expect(resolveTrick(scenario(0, 12, { life: 100, cycle: 4, perks: ["L1"] }), rng).life).toBe(87);
+    // cycle 4 (+8): 2 + 8 − C3(−2) = 8
+    expect(resolveTrick(scenario(0, 12, { life: 100, cycle: 4, perks: ["C3"] }), rng).life).toBe(92);
   });
-  it("hoher Zeit-Aufschlag kann tödlich sein → Game Over", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 40, drainLevel: 3 }), rng); // 10 + 45 = 55 ≥ 40
+  it("hoher Aufschlag in späten Durchläufen kann tödlich sein → Game Over", () => {
+    const s = resolveTrick(scenario(0, 12, { life: 40, cycle: 10 }), rng); // 2 + 50 = 52 ≥ 40
     expect(s.phase).toBe("gameover");
     expect(s.life).toBe(0);
   });
@@ -240,14 +242,14 @@ describe("resolveTrick — Tempo-Score & Crit (#19)", () => {
 
 describe("Legendäre Perks (#33) — Engine-Integration", () => {
   it("L1 Überladung: +3 Zusatzschaden je Niederlage (auf den flat Grundschaden)", () => {
-    expect(resolveTrick(scenario(0, 12, { life: 100, perks: ["L1"] }), rng).life).toBe(87); // 10+3
+    expect(resolveTrick(scenario(0, 12, { life: 100, perks: ["L1"] }), rng).life).toBe(95); // 2+3 (#87)
   });
   it("L1+L6: extraDamageTaken summiert korrekt (+5)", () => {
-    expect(resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "L6"] }), rng).life).toBe(85); // 10+3+2
+    expect(resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "L6"] }), rng).life).toBe(93); // 2+3+2 (#87)
   });
-  it("C5 Schild verhindert den ersten Verlust je Durchlauf voll — auch mit L1-Zusatzschaden", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "C5"], shield: 50 }), rng);
-    expect(s.life).toBe(100);   // 13 Schaden komplett vom Schild absorbiert
+  it("C5 Schild verhindert den ersten Verlust je Durchlauf voll — auch mit L1-Zusatzschaden (Durchlauf 4)", () => {
+    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "C5"], shield: 50, cycle: 4 }), rng);
+    expect(s.life).toBe(100);   // 2+8+3 = 13 Schaden komplett vom Schild absorbiert
     expect(s.shield).toBe(37);  // 50 − 13
   });
   it("L2 Unaufhaltsam: Gleichstand ab Serie ≥3 wird Sieg und erhöht die Serie", () => {
@@ -361,7 +363,7 @@ describe("Ansage-System (#36)", () => {
   });
 
   it("Tod vor Durchlauf-Ende → gameover, KEIN Ansage-Bonus (Ansage nicht abgeschlossen)", () => {
-    const s = resolveTrick(scenario(0, 12, { pos: 39, prediction: 20, cycleWins: 20, cycleBaseScore: 1000, score: 5000, life: 5 }), rng);
+    const s = resolveTrick(scenario(0, 12, { pos: 39, prediction: 20, cycleWins: 20, cycleBaseScore: 1000, score: 5000, life: 2 }), rng);
     expect(s.phase).toBe("gameover");
     expect(s.score).toBe(5000);            // kein Bonus
     expect(s.predictionBonusScore).toBe(0);
@@ -427,7 +429,7 @@ describe("Seltene Perks — Engine (#71)", () => {
     expect(s.life).toBe(105);
   });
   it("E7 Kontrollverlust: +1 Zusatzschaden bei Niederlage", () => {
-    expect(resolveTrick(scenario(0, 12, { perks: ["E7"], life: 100 }), rng).life).toBe(89); // 10+1
+    expect(resolveTrick(scenario(0, 12, { perks: ["E7"], life: 100 }), rng).life).toBe(97); // 2+1 (#87)
   });
 });
 
@@ -492,8 +494,8 @@ describe("Per-Durchlauf-Rares — Engine (#71 Phase 2d)", () => {
   });
   it("C8: echter Lebensverlust setzt den Zähler zurück; Schild-Absorption zählt als sauber", () => {
     expect(resolveTrick(scenario(0, 12, { perks: ["C8"], cleanStreak: 9, life: 1000 }), rng).cleanStreak).toBe(0); // Verlust
-    const shielded = resolveTrick(scenario(0, 12, { perks: ["C8", "C5"], cleanStreak: 9, shield: 50, life: 1000, maxLife: 2000 }), rng);
-    expect(shielded.life).toBe(1015); // Schaden voll vom Schild → sauber → 10. Stich heilt
+    const shielded = resolveTrick(scenario(0, 12, { perks: ["C8", "C5"], cleanStreak: 9, shield: 50, life: 1000, maxLife: 2000, cycle: 4 }), rng);
+    expect(shielded.life).toBe(1015); // 10 Schaden voll vom Schild → sauber → 10. Stich heilt
     expect(shielded.shield).toBe(40);
   });
 
@@ -505,9 +507,9 @@ describe("Per-Durchlauf-Rares — Engine (#71 Phase 2d)", () => {
 
   it("C10 Notfallration: 1× je Durchlauf bei ≤25 % Leben +40, dann verbraucht", () => {
     const hit = resolveTrick(scenario(0, 12, { perks: ["C10"], life: 400, maxLife: 2000 }), rng);
-    expect(hit.life).toBe(430); // 400 −10 Verlust +40 Notfall
+    expect(hit.life).toBe(438); // 400 −2 Verlust +40 Notfall (#87)
     expect(hit.notfallUsed).toBe(true);
-    expect(resolveTrick(scenario(0, 12, { perks: ["C10"], life: 400, maxLife: 2000, notfallUsed: true }), rng).life).toBe(390); // schon genutzt
+    expect(resolveTrick(scenario(0, 12, { perks: ["C10"], life: 400, maxLife: 2000, notfallUsed: true }), rng).life).toBe(398); // schon genutzt
   });
   it("C10: notfallUsed wird beim Durchlauf-Wechsel zurückgesetzt", () => {
     expect(resolveTrick(scenario(13, 0, { pos: 39, perks: ["C10"], notfallUsed: true, life: 1000, maxLife: 2000 }), rng).notfallUsed).toBe(false);

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -118,22 +118,6 @@ describe("Reducer — Ansage-System (#36)", () => {
   });
 });
 
-describe("SET_DRAIN_LEVEL — Zeit-Eskalation pro Niederlage (#85, ersetzt den #59-Tick)", () => {
-  it("setzt drainLevel, ohne Leben abzuziehen (bleibt in play)", () => {
-    const s = { ...initialState(makeRng(1)), life: 100 };
-    const r = reducer(s, { type: "SET_DRAIN_LEVEL", level: 3 });
-    expect(r.drainLevel).toBe(3);
-    expect(r.life).toBe(100);      // kein direkter Abzug mehr
-    expect(r.phase).toBe("play");
-  });
-  it("greift nur in der play-Phase (Menü/Overlay unberührt)", () => {
-    const menu = menuState();
-    expect(reducer(menu, { type: "SET_DRAIN_LEVEL", level: 2 })).toBe(menu);
-    const lvl = { ...initialState(makeRng(1)), phase: "levelup" };
-    expect(reducer(lvl, { type: "SET_DRAIN_LEVEL", level: 2 }).drainLevel).toBe(0);
-  });
-});
-
 describe("Level-Up-Queue — PICK_PERK (#57)", () => {
   it("bei pendingLevelUps > 0 folgt ein weiteres Angebot mit dem neuen Build", () => {
     const s0 = { ...initialState(makeRng(1)), phase: "levelup", level: 4, offer: ["A1", "C1", "E2"], pendingLevelUps: 2 };


### PR DESCRIPTION
Schließt #87. Löst den **Tempo/Turbo-Score-Cheese**: der Zeitdruck hängt nicht mehr an der Echtzeit, sondern am **Deck-Durchlauf** (`cycle`) → Tempo ist reine QoL, die Score-Ausbeute pro Run unbeeinflusst.

## Modell (Option A, cycle-basiert)
- **Base-Schaden** `DMG_PER_LOSS` 10 → **2** (sanfter Auftakt, keine Früh-Tode).
- **Aufschlag pro Niederlage** = `round(0,5·n²)`, `n = cycle`: **0, 0, +2, +5, +8, +13, +18 …** → Ziel: Run-Bogen über **~20 Durchläufe**.
- Loss-`dmg = max(0, 2 + lifeDrainAt(cycle) + Σ extraDamageTaken − Σ dmgReduce)`, danach Schild.

## Architektur
- Engine leitet den Aufschlag **direkt aus `cycle`** ab → **voll deterministisch, kein `Date`/Payload mehr**. `SET_DRAIN_LEVEL`, `state.drainLevel` und der `elapsedMs`-Drain-Effekt sind raus; `LIFE_DRAIN_INTERVAL_MS` entfernt.
- App: `lossSurcharge = lifeDrainAt(cycle)`; Hinweis-Float beim Durchlauf-Wechsel, wenn der Aufschlag steigt. StatusRail/Tooltip auf Durchlauf-Basis.

## Kalibrierung (Erst-Test)
Bei Basis-Tempo ≈ 70 Sek/Durchlauf → grobe Run-Längen: Glaskanone ~5–7, ausgewogen ~12–14, Tank ~18–20 Durchläufe. Stellschrauben: `LIFE_DRAIN_BASE` (0,5) und ggf. `n = floor(cycle/2)`.

## Verifikation
Tests cycle-basiert angepasst (Anti-Infinity + Verteidigungs-Tests C3/C5/L1 mit `cycle:4` für sinnvollen Schaden) → **170 grün**. Build ok. Live geprüft: Niederlage = **−2♥** (Durchlauf 0), Indikator „Niederlage-Aufschlag +0♥" grün, keine Konsolenfehler.

## ⚠️ Balance-Notiz (Folge-Blick)
Mit Base 2 negiert **Panzerung (C3, −2)** eine Basis-Niederlage früh komplett (2−2=0) und wird spät bedeutungslos — die `dmgReduce`-Perks (C3/C6) verschieben sich zu „früh-immun, spät egal". Für den ersten Test okay, aber notiert.

_(Der Perfekt-Deck-∞-Fall aus #85 bleibt bewusst offen — separate Entscheidung.)_