### PR TITLE
Prozentuale Schadensreduktion (C3/C6) + sanftere Eskalation (0,5→0,3)

### DIFF
--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -4,10 +4,10 @@
 export const START_LIFE       = 2000;   // Leben = Run-Timer [TUNING]
 export const DMG_PER_LOSS     = 2;      // Basis-Schaden je Niederlage im 1. Durchlauf — sanfter Auftakt (#87) [TUNING]
 // Anti-Infinity (#87, cycle-basiert, Umbau von #85/#59): der ZUSATZSCHADEN PRO NIEDERLAGE eskaliert je
-// Deck-DURCHLAUF (nicht Echtzeit) → Tempo/Turbo beeinflusst den Score nicht mehr. Aufschlag = round(0,5·n²),
-// n = cycle (0-indiziert): +0, +0, +2, +5, +8, +13, +18 … kein Cap. Ziel: Run-Bogen über ~20 Durchläufe.
+// Deck-DURCHLAUF (nicht Echtzeit) → Tempo/Turbo beeinflusst den Score nicht mehr. Aufschlag = round(0,3·n²),
+// n = cycle (0-indiziert): +0, +0, +1, +3, +5, +8, +11 … kein Cap. Sanftere Kurve (#89) für längeren Bogen.
 // Voll deterministisch — die Engine leitet n aus `cycle` ab (kein Date, kein App-Payload nötig).
-export const LIFE_DRAIN_BASE        = 0.5;             // Aufschlag pro Niederlage = round(LIFE_DRAIN_BASE · cycle²) [TUNING]
+export const LIFE_DRAIN_BASE        = 0.3;             // Aufschlag pro Niederlage = round(LIFE_DRAIN_BASE · cycle²) [TUNING]
 export const XP_PER_WIN       = 10;     // XP je gewonnenem Stich [TUNING]
 export const SCORE_PER_WIN    = 100;    // Basispunkte je Sieg (Perks/Tempo skalieren darauf) [TUNING]
 export const TEMPO_SCORE_FACTOR = 0.005; // je %-Punkt speedPct +0,5 % Stichscore [TUNING]
@@ -79,6 +79,14 @@ export const BASE_FLIP_MS = 1750;   // ms je Stich bei 0 % Speed (Basis-Tempo, e
 // Aufschlag pro Niederlage im n-ten Deck-Durchlauf (n = cycle, ≥0) — quadratisch, gerundet, kein Cap. Rein.
 // Die Engine ruft lifeDrainAt(cycle) direkt im Niederlage-Zweig auf; kein Date/Payload nötig (#87).
 export const lifeDrainAt = (n) => Math.round(LIFE_DRAIN_BASE * n * n);
+
+// Prozentuale Schadensreduktion (#89): skaliert mit dem EINGEHENDEN Schaden statt flat → bleibt spät relevant,
+// kann aber nie ganz negieren (Anti-Infinity intakt). Minimum hält sie früh (kleiner Schaden) integer/spürbar. [TUNING]
+export const PANZERUNG_PCT = 0.25;  // C3 Panzerung: Anteil des eingehenden Schadens …
+export const PANZERUNG_MIN = 1;     // …          … mindestens so viel
+export const TROTZ_PCT_MID = 0.15;  // C6 Trotz: unter 50 % Leben …
+export const TROTZ_PCT_LOW = 0.30;  // …          … unter 25 % Leben …
+export const TROTZ_MIN     = 1;     // …          … Minimum
 
 /* ============================================================
    DECK / FARBEN

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -174,8 +174,10 @@ export function resolveTrick(state, rng = Math.random) {
     // Grundschaden + Durchlauf-Aufschlag (#87): DMG_PER_LOSS + lifeDrainAt(cycle) — je Deck-Durchlauf kostet
     // jede Niederlage mehr (round(0,5·cycle²)). Zeitdruck läuft über den Fortschritt, nicht über Echtzeit
     // → Tempo neutral. Legendär-Zusatzschaden (L1/L6/E7) addiert; dmgReduce (C3/C6) zieht ab, Schild (C5) danach.
-    dmg = Math.max(0, C.DMG_PER_LOSS + C.lifeDrainAt(cycle)
-                      + sumHook(perks, "extraDamageTaken", {}) - sumHook(perks, "dmgReduce", { life, maxLife }));
+    // #89: dmgReduce sieht jetzt den eingehenden Gesamtschaden (`incoming`) → prozentuale Reduktion (C3/C6)
+    // skaliert mit der Eskalation, kann aber nie ganz negieren.
+    const grossDmg = C.DMG_PER_LOSS + C.lifeDrainAt(cycle) + sumHook(perks, "extraDamageTaken", {});
+    dmg = Math.max(0, grossDmg - sumHook(perks, "dmgReduce", { life, maxLife, incoming: grossDmg }));
     // Schild (C5) absorbiert NACH der Schadensberechnung, vor dem Leben.
     if (shield > 0 && dmg > 0) { const absorbed = Math.min(shield, dmg); shield -= absorbed; dmg -= absorbed; }
     life -= dmg;

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -100,8 +100,13 @@ export const PERK_DEFS = {
         desc: "Nach fünf Stichen ohne Sieg erhält die nächste Karte +10 Wert (Sieg setzt zurück, Gleichstand zählt weiter).",
         cardBonus: (ctx) => ((ctx.sinceWin || 0) >= 5 ? 10 : 0) },
   C6: { id: "C6", cat: "C", label: "Trotz",
-        desc: "Unter 50 % Leben −1 Schaden bei Niederlagen; bei 25 % oder weniger insgesamt −2.",
-        dmgReduce: ({ life, maxLife }) => (maxLife > 0 && life / maxLife <= 0.25 ? 2 : maxLife > 0 && life / maxLife < 0.5 ? 1 : 0) },
+        desc: "Unter 50 % Leben −15 % Schaden bei Niederlagen; bei 25 % oder weniger −30 % (jeweils mindestens 1).",
+        dmgReduce: ({ life, maxLife, incoming }) => {
+          if (!(maxLife > 0)) return 0;
+          const r = life / maxLife;
+          const pct = r <= 0.25 ? C.TROTZ_PCT_LOW : r < 0.5 ? C.TROTZ_PCT_MID : 0;
+          return pct > 0 ? Math.max(C.TROTZ_MIN, Math.round(pct * (incoming || 0))) : 0;
+        } },
 
   // ---- Seltene Perks (#71, Phase 2a) — rarity: "rare"; reine Hooks über bestehende Kontexte ----
   A9: { id: "A9", cat: "A", rarity: "rare", label: "Farbduell",
@@ -220,8 +225,8 @@ export const PERK_DEFS = {
         desc: "Ein Sieg mit Kartenwert 8 oder höher heilt 6 Leben.",
         healOnWin: (ctx) => (ctx.winValue >= C.D3_HIGH_MIN ? 6 : 0) },
   C3: { id: "C3", cat: "C", label: "Panzerung",
-        desc: "Verlorene Stiche verursachen 2 weniger Schaden.",
-        dmgReduce: () => 2 },
+        desc: "Verlorene Stiche verursachen 25 % weniger Schaden (mindestens 1).",
+        dmgReduce: ({ incoming }) => Math.max(C.PANZERUNG_MIN, Math.round(C.PANZERUNG_PCT * (incoming || 0))) },
   C4: { id: "C4", cat: "C", label: "Zweite Luft",
         desc: "Nach jedem vollen Deck-Durchlauf heilst du 50 Leben.",
         healOnCycle: () => 50 },

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -81,9 +81,9 @@ describe("resolveTrick — Grundausgänge", () => {
 });
 
 describe("resolveTrick — Verteidigungs-Perks", () => {
-  it("C3 Panzerung reduziert um 2 (Durchlauf 4: Schaden 10 → 8)", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C3"], cycle: 4 }), rng); // 2 + 8 − 2 = 8
-    expect(s.life).toBe(92);
+  it("C3 Panzerung: 25 % Reduktion (Durchlauf 10: 32 → 24 Schaden)", () => {
+    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C3"], cycle: 10 }), rng); // gross 2+30=32, −25 %=8 → 24
+    expect(s.life).toBe(76);
   });
 
   it("C1 Lebensraub heilt 2 bei Sieg, respektiert maxLife", () => {
@@ -91,15 +91,15 @@ describe("resolveTrick — Verteidigungs-Perks", () => {
     expect(resolveTrick(scenario(12, 0, { life: 2000, perks: ["C1"] }), rng).life).toBe(2000);
   });
 
-  it("C5 Schutzschild: 50 Schildpunkte absorbieren Schaden vor dem Leben (Durchlauf 4 → 10 Schaden)", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C5"], shield: 50, cycle: 4 }), rng);
+  it("C5 Schutzschild: 50 Schildpunkte absorbieren Schaden vor dem Leben (Durchlauf 5 → 10 Schaden)", () => {
+    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C5"], shield: 50, cycle: 5 }), rng);
     expect(s.life).toBe(100);   // Verlust 2+8=10 → Schild 50→40
     expect(s.shield).toBe(40);
   });
 
-  it("C5 + Panzerung: erst Schaden reduzieren (−2), dann Schild absorbieren (Durchlauf 4)", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C5", "C3"], shield: 50, cycle: 4 }), rng);
-    expect(s.shield).toBe(42);  // 10 − 2 = 8 abgezogen
+  it("C5 + Panzerung: erst Schaden prozentual reduzieren, dann Schild absorbieren (Durchlauf 5)", () => {
+    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["C5", "C3"], shield: 50, cycle: 5 }), rng);
+    expect(s.shield).toBe(43);  // gross 10, C3 25 % → round(2,5)=3 → 7 abgezogen
     expect(s.life).toBe(100);
   });
 
@@ -129,29 +129,29 @@ describe("resolveTrick — Verteidigungs-Perks", () => {
 });
 
 describe("Anti-Infinity — Aufschlag pro Niederlage je Deck-Durchlauf (#87, cycle-basiert)", () => {
-  it("lifeDrainAt: gerundetes 0,5·n² (0, 1, 2, 5, 8, 13, …, 50, 200)", () => {
+  it("lifeDrainAt: gerundetes 0,3·n² (0, 0, 1, 3, 5, 8, …, 30, 120)", () => {
     expect(lifeDrainAt(0)).toBe(0);
-    expect(lifeDrainAt(1)).toBe(1);   // round(0,5)
-    expect(lifeDrainAt(2)).toBe(2);
-    expect(lifeDrainAt(3)).toBe(5);   // round(4,5)
-    expect(lifeDrainAt(4)).toBe(8);
-    expect(lifeDrainAt(5)).toBe(13);  // round(12,5)
-    expect(lifeDrainAt(10)).toBe(50);
-    expect(lifeDrainAt(20)).toBe(200);
+    expect(lifeDrainAt(1)).toBe(0);   // round(0,3)
+    expect(lifeDrainAt(2)).toBe(1);   // round(1,2)
+    expect(lifeDrainAt(3)).toBe(3);   // round(2,7)
+    expect(lifeDrainAt(4)).toBe(5);   // round(4,8)
+    expect(lifeDrainAt(5)).toBe(8);   // round(7,5)
+    expect(lifeDrainAt(10)).toBe(30);
+    expect(lifeDrainAt(20)).toBe(120);
   });
-  it("Niederlagenschaden eskaliert mit dem Durchlauf (cycle): DMG_PER_LOSS(2) + round(0,5·cycle²)", () => {
+  it("Niederlagenschaden eskaliert mit dem Durchlauf (cycle): DMG_PER_LOSS(2) + round(0,3·cycle²)", () => {
     expect(resolveTrick(scenario(0, 12, { life: 100 }), rng).life).toBe(98);              // cycle 0 → 2 + 0
-    expect(resolveTrick(scenario(0, 12, { life: 100, cycle: 2 }), rng).life).toBe(96);    // 2 + 2
-    expect(resolveTrick(scenario(0, 12, { life: 200, cycle: 5 }), rng).life).toBe(185);   // 2 + 13
+    expect(resolveTrick(scenario(0, 12, { life: 100, cycle: 2 }), rng).life).toBe(97);    // 2 + 1
+    expect(resolveTrick(scenario(0, 12, { life: 200, cycle: 5 }), rng).life).toBe(190);   // 2 + 8
   });
-  it("Aufschlag stapelt mit Perk-Schaden (L1) und wird von Reduktion (C3) gemindert", () => {
-    // cycle 4 (+8): 2 + 8 + L1(+3) = 13
-    expect(resolveTrick(scenario(0, 12, { life: 100, cycle: 4, perks: ["L1"] }), rng).life).toBe(87);
-    // cycle 4 (+8): 2 + 8 − C3(−2) = 8
-    expect(resolveTrick(scenario(0, 12, { life: 100, cycle: 4, perks: ["C3"] }), rng).life).toBe(92);
+  it("Aufschlag stapelt mit Perk-Schaden (L1) und wird von prozentualer Reduktion (C3) gemindert", () => {
+    // cycle 4 (+5): 2 + 5 + L1(+3) = 10
+    expect(resolveTrick(scenario(0, 12, { life: 100, cycle: 4, perks: ["L1"] }), rng).life).toBe(90);
+    // cycle 4: gross 2+5=7, C3 25 % → round(1,75)=2 → nimmt 5
+    expect(resolveTrick(scenario(0, 12, { life: 100, cycle: 4, perks: ["C3"] }), rng).life).toBe(95);
   });
   it("hoher Aufschlag in späten Durchläufen kann tödlich sein → Game Over", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 40, cycle: 10 }), rng); // 2 + 50 = 52 ≥ 40
+    const s = resolveTrick(scenario(0, 12, { life: 30, cycle: 10 }), rng); // 2 + 30 = 32 ≥ 30
     expect(s.phase).toBe("gameover");
     expect(s.life).toBe(0);
   });
@@ -247,8 +247,8 @@ describe("Legendäre Perks (#33) — Engine-Integration", () => {
   it("L1+L6: extraDamageTaken summiert korrekt (+5)", () => {
     expect(resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "L6"] }), rng).life).toBe(93); // 2+3+2 (#87)
   });
-  it("C5 Schild verhindert den ersten Verlust je Durchlauf voll — auch mit L1-Zusatzschaden (Durchlauf 4)", () => {
-    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "C5"], shield: 50, cycle: 4 }), rng);
+  it("C5 Schild verhindert den ersten Verlust je Durchlauf voll — auch mit L1-Zusatzschaden (Durchlauf 5)", () => {
+    const s = resolveTrick(scenario(0, 12, { life: 100, perks: ["L1", "C5"], shield: 50, cycle: 5 }), rng);
     expect(s.life).toBe(100);   // 2+8+3 = 13 Schaden komplett vom Schild absorbiert
     expect(s.shield).toBe(37);  // 50 − 13
   });
@@ -494,7 +494,7 @@ describe("Per-Durchlauf-Rares — Engine (#71 Phase 2d)", () => {
   });
   it("C8: echter Lebensverlust setzt den Zähler zurück; Schild-Absorption zählt als sauber", () => {
     expect(resolveTrick(scenario(0, 12, { perks: ["C8"], cleanStreak: 9, life: 1000 }), rng).cleanStreak).toBe(0); // Verlust
-    const shielded = resolveTrick(scenario(0, 12, { perks: ["C8", "C5"], cleanStreak: 9, shield: 50, life: 1000, maxLife: 2000, cycle: 4 }), rng);
+    const shielded = resolveTrick(scenario(0, 12, { perks: ["C8", "C5"], cleanStreak: 9, shield: 50, life: 1000, maxLife: 2000, cycle: 5 }), rng);
     expect(shielded.life).toBe(1015); // 10 Schaden voll vom Schild → sauber → 10. Stich heilt
     expect(shielded.shield).toBe(40);
   });

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -241,10 +241,16 @@ describe("Neue Normal-Perks (#71)", () => {
     expect(PERK_DEFS.B7.cardBonus({ sinceWin: 5 })).toBe(10);
     expect(PERK_DEFS.B7.cardBonus({ sinceWin: 8 })).toBe(10);
   });
-  it("C6 Trotz: −1 unter 50 %, −2 bei ≤ 25 % Leben", () => {
-    expect(PERK_DEFS.C6.dmgReduce({ life: 1500, maxLife: 2000 })).toBe(0); // 75 %
-    expect(PERK_DEFS.C6.dmgReduce({ life: 900, maxLife: 2000 })).toBe(1);  // 45 %
-    expect(PERK_DEFS.C6.dmgReduce({ life: 500, maxLife: 2000 })).toBe(2);  // 25 %
+  it("C3 Panzerung: 25 % des eingehenden Schadens, mindestens 1 (#89)", () => {
+    expect(PERK_DEFS.C3.dmgReduce({ incoming: 100 })).toBe(25);
+    expect(PERK_DEFS.C3.dmgReduce({ incoming: 40 })).toBe(10);
+    expect(PERK_DEFS.C3.dmgReduce({ incoming: 2 })).toBe(1); // Minimum greift bei kleinem Schaden
+  });
+  it("C6 Trotz: prozentuale Reduktion je Lebensstand (mind. 1), erst ab < 50 % (#89)", () => {
+    expect(PERK_DEFS.C6.dmgReduce({ life: 1500, maxLife: 2000, incoming: 100 })).toBe(0);  // 75 % → keine
+    expect(PERK_DEFS.C6.dmgReduce({ life: 900, maxLife: 2000, incoming: 100 })).toBe(15);  // 45 % → 15 %
+    expect(PERK_DEFS.C6.dmgReduce({ life: 500, maxLife: 2000, incoming: 100 })).toBe(30);  // 25 % → 30 %
+    expect(PERK_DEFS.C6.dmgReduce({ life: 500, maxLife: 2000, incoming: 2 })).toBe(1);     // Minimum greift
   });
 });
 


### PR DESCRIPTION
Zwei Balance-Änderungen aus dem Playtest-Gespräch.

## 1. Schadensreduktion prozentual (C3/C6)
Flat-Reduktion war gegen den eskalierenden Schaden „früh-immun, spät egal". Jetzt skaliert sie mit dem eingehenden Schaden:
- `dmgReduce`-Hook bekommt `incoming` (Gesamtschaden vor Reduktion).
- **C3 Panzerung:** 25 % des eingehenden Schadens (mind. 1) statt flat −2.
- **C6 Trotz:** −15 % (< 50 % Leben) / −30 % (≤ 25 %), mind. 1, statt flat −1/−2.

**Wichtig:** prozentual kann eine Niederlage **nie ganz negieren** → Anti-Infinity bleibt intakt. Beispiel C3: Durchlauf 0 (2 Schaden) → −1; Durchlauf 10 (32) → −8; Durchlauf 20 (122) → −31.

## 2. Sanftere Eskalation (`LIFE_DRAIN_BASE` 0,5 → 0,3)
Die Kurve war zu krass. Neu `round(0,3·n²)`: **0, 0, +1, +3, +5, +8, +11 …** (n = Durchlauf) → längerer Run-Bogen (~20+ Durchläufe je nach Build).

## Verifikation
Tests angepasst (C3/C6 als Prozent-Hooks mit `incoming`, cycle/Schild-Tests auf 0,3, neuer C3-Hook-Test). **171 grün**, Build ok, live keine Konsolenfehler.

_(Heilung bewusst weiter flat — flat-Heilung, die spät ausblendet, ist gutes Pacing; erst nachziehen, falls Heil-Builds im Test zu schnell sterben.)_