### PR TITLE
Fix: globales Leaderboard — level-Spalte wieder befüllen (Rundenzahl)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -116,7 +116,9 @@ export function Autostich() {
     // Globalen Lauf posten (#14) — additiv, fehlertolerant. myEntry hebt ihn im Board hervor;
     // pubToken lädt das Board nach dem Submit neu (damit der eigene Lauf drin ist).
     const name = (username || "").trim().slice(0, 20);
-    const gEntry = { name, score: finalScore, tricks: state.trickNo, cycles: state.cycle };
+    // `level` bleibt im Payload (= Rundenzahl), damit die bestehende Supabase-Spalte befüllt ist
+    // (falls NOT NULL) — kein Schema-Wechsel nötig. Angezeigt wird ohnehin `cycles`.
+    const gEntry = { name, score: finalScore, level: state.cycle, tricks: state.trickNo, cycles: state.cycle };
     setMyEntry(gEntry);
     if (leaderboardConfigured && name) {
       publishRun(gEntry).then(() => setPubToken((t) => t + 1)).catch(() => {});

--- a/src/game/leaderboard.js
+++ b/src/game/leaderboard.js
@@ -17,6 +17,7 @@ export async function fetchGlobalTop(limit = 10) {
 }
 
 // Lauf veröffentlichen. entry: { name, score, level, tricks, cycles }.
+// Hinweis: `level` = Rundenzahl (= cycles); die Spalte bleibt aus Kompatibilität mit der bestehenden Tabelle befüllt.
 export async function publishRun(entry) {
   const res = await fetch(REST, {
     method: "POST",

--- a/src/ui/useEscape.js
+++ b/src/ui/useEscape.js
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 
 /* #58: Escape schließt ein abweisbares Overlay — gemeinsam genutzt, damit Username/Optionen/
-   Anleitung einheitlich per Backdrop-Klick UND Escape schließen. (GameOver/PerkSelect/
-   PredictionSelect nutzen ihn bewusst NICHT — dort ist eine Auswahl erforderlich.) */
+   Anleitung einheitlich per Backdrop-Klick UND Escape schließen. (GameOver/PerkSelect nutzen ihn
+   bewusst NICHT — dort ist eine Auswahl erforderlich.) */
 export function useEscape(onClose) {
   useEffect(() => {
     if (!onClose) return;


### PR DESCRIPTION
Korrektur zu #90: dort war `level` aus dem Score-Payload entfernt worden. Das **globale Board (Supabase) wird genutzt** und die Tabelle `autostich_scores` hat eine `level`-Spalte — fehlt sie im Insert und ist `NOT NULL`, schlagen **neue Score-Posts fehl**.

## Fix
- Der globale Entry (`publishRun`) enthält wieder **`level` = `state.cycle`** (Rundenzahl) → Insert bleibt kompatibel, **kein Schema-Wechsel nötig**. Angezeigt wird ohnehin `cycles`.
- Kommentare in `leaderboard.js` / `useEscape.js` aktualisiert (Verweise auf das entfernte `PredictionSelect`).

## Verifikation
**153 Tests grün**, Build ok. Das **Global — Top 10** Board rendert live mit echten Einträgen (mehrere Spieler), Anzeige „N R · Stiche". Der `level`-Select im Fetch ist unverändert und funktioniert.

_(Hinweis: die Vite-HMR-„Failed to reload PredictionSelect"-Meldungen im lokalen Dev sind reine Altlast des laufenden Dev-Servers vom Mid-Session-Delete — ein Dev-Server-Neustart räumt sie weg; die Produktion ist sauber.)_