### PR TITLE
Preview-Deploy: Testbranch als /autostich/test/ (gh-pages + Datentrennung)

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,42 @@
+name: Deploy Testbranch to Pages (/test/)
+
+# Deployt den Testbranch als Unterpfad /autostich/test/ auf DIESELBE Pages-Seite wie main.
+# So lassen sich große Features live prüfen, ohne die Hauptseite anzufassen.
+on:
+  push:
+    branches: [Autostich_Test]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Gleiche Gruppe wie der main-Deploy → serialisiert die gh-pages-Pushes (kein Race).
+concurrency:
+  group: gh-pages-publish
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+        env:
+          # Assets müssen unter dem Unterpfad aufgelöst werden.
+          DEPLOY_BASE: /autostich/test/
+          # Preview-Build: eigener localStorage-Namespace + kein Schreiben ins echte Leaderboard.
+          VITE_PREVIEW: "1"
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          # Nur in den Unterordner test/ schreiben; Root (main-Seite) unangetastet lassen.
+          destination_dir: test
+          keep_files: true
+          commit_message: "deploy(test): ${{ github.sha }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,16 +5,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Rechte, die actions/deploy-pages braucht.
+# peaceiris pusht das Build-Ergebnis in den gh-pages-Branch → braucht Schreibrecht.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Immer nur ein Pages-Deploy gleichzeitig.
+# main- und Testbranch-Deploy teilen sich diese Gruppe, damit nie zwei gleichzeitig
+# in gh-pages pushen (Race). Laufende Deploys werden NICHT abgebrochen, sondern eingereiht.
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: gh-pages-publish
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -27,17 +26,11 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
-      - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - run: npm run build   # base = /autostich/ (Default in vite.config.js)
+      - uses: peaceiris/actions-gh-pages@v4
         with:
-          path: dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          # Root der Pages-Seite. keep_files: den Unterordner test/ (Preview) NICHT mitlöschen.
+          keep_files: true
+          commit_message: "deploy(main): ${{ github.sha }}"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -203,6 +203,17 @@ export function Autostich() {
       {/* CRT-Scanline-/Vignette-Overlay (#41) — immer im DOM, nur unter [data-skin="crt"]
           sichtbar (CSS), klick-durchlässig. */}
       <div className="crt-overlay" aria-hidden="true" />
+      {/* Preview-Marker — nur im Testbranch-Build (/autostich/test/), damit man die
+          Test-Page nie mit der echten Seite verwechselt. Klick-durchlässig. */}
+      {import.meta.env.VITE_PREVIEW === "1" && (
+        <div
+          className="fixed top-2 left-2 z-50 px-2 py-1 rounded text-[10px] font-bold font-pixel tracking-wide"
+          style={{ background: "#d4a63a", color: "#141419", pointerEvents: "none", boxShadow: "0 0 8px rgba(212,166,58,.6)" }}
+          aria-hidden="true"
+        >
+          TESTBRANCH
+        </div>
+      )}
       {/* Ambient-Partikel — nur unter Skin und nur auf dem Hauptscreen (Menü): dort gibt es
           offene Fläche, sodass sie ohne durchscheinende Panels sichtbar sind. Im Run bleiben
           die Panels deckend. (reduced-motion-gated in der Komponente.) */}

--- a/src/game/leaderboard.js
+++ b/src/game/leaderboard.js
@@ -3,6 +3,9 @@
 // nur select + insert. Alle Aufrufer fangen Fehler ab (graceful degradation). (#14)
 const BASE = import.meta.env.VITE_SUPABASE_URL;
 const KEY  = import.meta.env.VITE_SUPABASE_KEY;
+// Preview-Build (Testbranch): globale Bestenliste NUR lesen, nie schreiben — Test-Runs
+// sollen die echte Tabelle `autostich_scores` nicht verunreinigen.
+const PREVIEW = import.meta.env.VITE_PREVIEW === "1";
 export const leaderboardConfigured = !!(BASE && KEY);
 
 const REST = `${BASE}/rest/v1/autostich_scores`;
@@ -19,6 +22,7 @@ export async function fetchGlobalTop(limit = 10) {
 // Lauf veröffentlichen. entry: { name, score, level, tricks, cycles }.
 // Hinweis: `level` = Rundenzahl (= cycles); die Spalte bleibt aus Kompatibilität mit der bestehenden Tabelle befüllt.
 export async function publishRun(entry) {
+  if (PREVIEW) return; // Preview-Build: kein Schreiben ins echte Leaderboard.
   const res = await fetch(REST, {
     method: "POST",
     headers: { ...headers, "Content-Type": "application/json", Prefer: "return=minimal" },

--- a/src/game/storage.js
+++ b/src/game/storage.js
@@ -1,5 +1,11 @@
 import { GHOST_STEP } from "./constants.js";
 
+/* Preview-Build (Testbranch auf /autostich/test/) teilt sich die Origin mit der echten
+   Seite → derselbe localStorage. Ein Präfix trennt die Namespaces, damit Test-Runs den
+   echten Geist/Highscore nicht überschreiben. Produktions-/Dev-Build: kein Präfix (P=""). */
+const P = import.meta.env.VITE_PREVIEW === "1" ? "preview_" : "";
+const k = (key) => P + key;
+
 /* Persistenz — lokaler Rekord überlebt Reload via localStorage.
 
    GEIST (Rekord-Vergleich, getrennt von der Highscore-Liste):
@@ -7,7 +13,7 @@ import { GHOST_STEP } from "./constants.js";
    der aktuelle Lauf „an genau dieser Stelle" gegen den Rekord vergleichen. */
 export function loadGhost() {
   try {
-    const raw = localStorage.getItem("as_ghost");
+    const raw = localStorage.getItem(k("as_ghost"));
     if (raw) {
       const g = JSON.parse(raw);
       // step-Wechsel invalidiert alte Trajektorien (nicht mehr vergleichbar).
@@ -18,22 +24,22 @@ export function loadGhost() {
   return { traj: [], total: 0, step: GHOST_STEP };
 }
 export function saveGhost(traj, total) {
-  try { localStorage.setItem("as_ghost", JSON.stringify({ traj, total, step: GHOST_STEP })); } catch (e) {}
+  try { localStorage.setItem(k("as_ghost"), JSON.stringify({ traj, total, step: GHOST_STEP })); } catch (e) {}
 }
 
 /* Lokaler Nickname (#14) — hängt an globalen Highscore-Einträgen. Leer ⇒ „erster Start". */
 export function loadUsername() {
-  try { return localStorage.getItem("as_username") || ""; } catch (e) { return ""; }
+  try { return localStorage.getItem(k("as_username")) || ""; } catch (e) { return ""; }
 }
 export function saveUsername(name) {
-  try { localStorage.setItem("as_username", name); } catch (e) {}
+  try { localStorage.setItem(k("as_username"), name); } catch (e) {}
 }
 
 /* Lokale Highscore-Liste (Top 5) — getrennt vom Geist.
    Eintrag: { score, level, tricks, cycles, ts }. */
 export function loadHighscores() {
   try {
-    const raw = localStorage.getItem("as_highscores");
+    const raw = localStorage.getItem(k("as_highscores"));
     if (raw) { const l = JSON.parse(raw); if (Array.isArray(l)) return l; }
   } catch (e) {}
   return [];
@@ -48,7 +54,7 @@ export function rankHighscores(list, entry) {
 // Neuen Lauf einsortieren + persistieren. Gibt die neue Top-5-Liste zurück.
 export function recordHighscore(entry) {
   const top = rankHighscores(loadHighscores(), entry);
-  try { localStorage.setItem("as_highscores", JSON.stringify(top)); } catch (e) {}
+  try { localStorage.setItem(k("as_highscores"), JSON.stringify(top)); } catch (e) {}
   return top;
 }
 
@@ -59,12 +65,21 @@ export function recordHighscore(entry) {
 const DEFAULT_OPTIONS = { skin: "crt" };
 export function loadOptions() {
   try {
-    const raw = localStorage.getItem("as_options");
+    const raw = localStorage.getItem(k("as_options"));
     if (raw) { const o = JSON.parse(raw); if (o && typeof o === "object") return { ...DEFAULT_OPTIONS, ...o }; }
   } catch (e) {}
   return { ...DEFAULT_OPTIONS };
 }
 export function saveOptions(opts) {
-  try { localStorage.setItem("as_options", JSON.stringify(opts)); } catch (e) {}
+  try { localStorage.setItem(k("as_options"), JSON.stringify(opts)); } catch (e) {}
   return opts;
+}
+
+/* Anleitung-einmal-gesehen (#12) — hier zentral, damit der Preview-Namespace (P) auch
+   diesen Key trennt und der Test-Build den Erstbesuch-Zustand der echten Seite nicht setzt. */
+export function loadSeenGuide() {
+  try { return !!localStorage.getItem(k("as_seen_guide")); } catch (e) { return false; }
+}
+export function saveSeenGuide() {
+  try { localStorage.setItem(k("as_seen_guide"), "1"); } catch (e) {}
 }

--- a/src/ui/StartScreen.jsx
+++ b/src/ui/StartScreen.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { AnleitungModal } from "./AnleitungModal.jsx";
 import { CardLogo } from "./CardLogo.jsx";
 import { GlobalLeaderboard } from "./GlobalLeaderboard.jsx";
+import { loadSeenGuide, saveSeenGuide } from "../game/storage.js";
 
 /* Startbildschirm (#4): Einstieg mit „Neuer Run", Anleitung (#12) und lokaler Bestenliste. */
 export function StartScreen({ onStart, highscores, best, onOptions, username = "", onEditName, myEntry = null, pubToken = 0 }) {
@@ -9,11 +10,11 @@ export function StartScreen({ onStart, highscores, best, onOptions, username = "
 
   // Beim allerersten Start die Anleitung einmal automatisch zeigen (#12).
   useEffect(() => {
-    try { if (!localStorage.getItem("as_seen_guide")) setShowGuide(true); } catch (e) {}
+    if (!loadSeenGuide()) setShowGuide(true);
   }, []);
   const closeGuide = () => {
     setShowGuide(false);
-    try { localStorage.setItem("as_seen_guide", "1"); } catch (e) {}
+    saveSeenGuide();
   };
 
   return (

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,8 +6,9 @@ import tailwindcss from "@tailwindcss/vite";
 // Vitest liest den `test`-Block aus dieser Config.
 export default defineConfig(({ command }) => ({
   // Build läuft unter dem GitHub-Pages-Projektpfad /autostich/. Dev-Server bleibt auf "/"
-  // (sonst läuft localhost unter dem Unterpfad).
-  base: command === "build" ? "/autostich/" : "/",
+  // (sonst läuft localhost unter dem Unterpfad). Der Testbranch-Deploy überschreibt die
+  // Base per DEPLOY_BASE (→ /autostich/test/), damit die Preview-Page als Unterpfad läuft.
+  base: command === "build" ? (process.env.DEPLOY_BASE || "/autostich/") : "/",
   plugins: [react(), tailwindcss()],
   test: {
     // Engine/Reducer sind reine Logik → schnelle Node-Umgebung reicht.


### PR DESCRIPTION
## Ziel

Der Testbranch **`Autostich_Test`** soll als Unterpfad **`/autostich/test/`** auf *derselben* GitHub-Pages-Seite live gehen — große Features live prüfen, ohne die Hauptseite `/autostich/` anzufassen.

## Änderungen

**Deploy-Mechanik (Umstieg auf gh-pages-Branch, nötig für zwei Seiten pro Repo):**
- `deploy.yml` (main): baut mit Base `/autostich/`, published via `peaceiris/actions-gh-pages` in den **gh-pages-Root**, `keep_files: true` (löscht den `test/`-Unterordner nicht).
- `deploy-test.yml` (neu, nur auf `Autostich_Test`): baut mit Base `/autostich/test/` + `VITE_PREVIEW=1`, published nach **`gh-pages/test/`**.
- `vite.config.js`: Base dynamisch via `DEPLOY_BASE` (Default bleibt `/autostich/`).
- Gemeinsame `concurrency: gh-pages-publish` → die zwei Deploys pushen nie gleichzeitig.

**Datentrennung im Preview-Build** (`/autostich/test/` teilt sich die Origin mit der echten Seite):
- `storage.js`: localStorage-Keys bekommen im Preview das Präfix `preview_` → echter Geist/Highscore/Options/Name bleiben unberührt.
- `leaderboard.js`: `publishRun` im Preview = No-op → keine Test-Runs in der echten `autostich_scores`-Tabelle (Lesen/Anzeige bleibt).
- `App.jsx`: kleines **TESTBRANCH**-Badge, nur im Preview.

Ohne `VITE_PREVIEW` ist all das inert — der main-Build bleibt unverändert „echt".

## Nach dem Merge (manuell)
1. main-Deploy läuft → befüllt `gh-pages`-Root (alte Live-Seite bleibt bis dahin unangetastet).
2. Pages-Quelle einmalig `workflow` → Branch `gh-pages` (`/`) umstellen → nahtlos.
3. `Autostich_Test` auf main-Stand bringen + pushen → Test-Deploy → `…/autostich/test/`.

## Verifikation
- `npm test`: 153/153 grün.
- Preview-Build: Base `/autostich/test/`, `preview_`-Namespace im Bundle.
- Prod-Build: Base `/autostich/`, kein `preview_`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
