### PR TITLE
Rarität: reguläre Perks → 4-Stufen-Familien (A–E) + UI-Familienbewusstsein

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -218,8 +218,9 @@ export function Autostich() {
   const resetFormation = () => dispatch({ type: "RESET_FORMATION" });
   const confirmFormation = () => dispatch({ type: "CONFIRM_FORMATION" });
   const confirmTarget = (cardIds) => dispatch({ type: "CONFIRM_TARGET", cardIds });
-  // Familien-Ziel-Auswahl (Rarität #167, Kat. A): Farbe(n) für pickTarget-Stufen wählen und bestätigen.
+  // Familien-Ziel-Auswahl (Rarität #167): Farbe(n) (Kat. A) bzw. Karten (Kat. C Rollen) für pickTarget-Stufen wählen.
   const familyTargetSuit = (suit) => dispatch({ type: "FAMILY_TARGET_SUIT", suit });
+  const familyTargetCard = (cardId) => dispatch({ type: "FAMILY_TARGET_CARD", cardId });
   const familyTargetConfirm = () => dispatch({ type: "FAMILY_TARGET_CONFIRM", rng: Math.random });
   // Skill-Auswahl (jede 3. Runde): wählen (optional einen belegten Slot ersetzen) oder ablehnen → Perk.
   const pickSkill = (skillId, replaceId) => dispatch({ type: "PICK_SKILL", skillId, replaceId, rng: Math.random });
@@ -442,7 +443,7 @@ export function Autostich() {
         <TargetSelect state={state} onConfirm={confirmTarget} />
       )}
       {state.phase === "family-target" && (
-        <FamilyTargetSelect state={state} onSuit={familyTargetSuit} onConfirm={familyTargetConfirm} />
+        <FamilyTargetSelect state={state} onSuit={familyTargetSuit} onCard={familyTargetCard} onConfirm={familyTargetConfirm} />
       )}
       {showChronik && <ChronikOverview state={state} onClose={() => setShowChronik(false)} />}
       {state.phase === "levelup" && state.statOffer && (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -206,7 +206,10 @@ export function Autostich() {
   }
   const toMenu = () => { saveRun(); dispatch({ type: "TO_MENU" }); }; // Lauf verlassen (#5)
   const endRun = () => dispatch({ type: "END_RUN" }); // Beenden → Endscreen; saveRun läuft über den gameover-Effekt
-  const pick = (id) => dispatch({ type: "PICK_PERK", perkId: id, rng: Math.random });
+  // Perk-Auswahl: ein Angebotseintrag ist entweder eine Familie {familyId,tier} (Rarität #167) oder ein flacher perkId-String.
+  const pick = (entry) => (entry && typeof entry === "object" && entry.familyId)
+    ? dispatch({ type: "PICK_FAMILY", familyId: entry.familyId, tier: entry.tier, rng: Math.random })
+    : dispatch({ type: "PICK_PERK", perkId: entry, rng: Math.random });
   const pickStat = (id) => dispatch({ type: "PICK_STAT", statId: id, rng: Math.random });
   // Formationsphase (§22.8): Tausch / Undo / Zurücksetzen / Bestätigen.
   const swapCards = (i, j) => dispatch({ type: "SWAP_CARDS", i, j });
@@ -400,7 +403,7 @@ export function Autostich() {
               <CrystalBar active={(state.activeArchetypes || []).includes("ice")}
                 ownCount={frozenCount(state.deck)}
                 enemyCount={(state.frostbiteActive || []).length} />
-              <BuildPanel perks={state.perks} skills={state.skills} />
+              <BuildPanel perks={state.perks} skills={state.skills} familyTiers={state.familyTiers} />
             </div>
             <StatusRail state={state} currentTraj={currentTraj.current} recordTraj={recordTraj.current} />
           </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import { FormationPhase } from "./ui/FormationPhase.jsx";
 import { ShopScreen } from "./ui/ShopScreen.jsx";
 import { ShopTargetSelect } from "./ui/ShopTargetSelect.jsx";
 import { TargetSelect } from "./ui/TargetSelect.jsx";
+import { FamilyTargetSelect } from "./ui/FamilyTargetSelect.jsx";
 import { ChronikOverview } from "./ui/ChronikOverview.jsx";
 import { ChargeBar } from "./ui/ChargeBar.jsx";
 import { HeatBar } from "./ui/HeatBar.jsx";
@@ -217,6 +218,9 @@ export function Autostich() {
   const resetFormation = () => dispatch({ type: "RESET_FORMATION" });
   const confirmFormation = () => dispatch({ type: "CONFIRM_FORMATION" });
   const confirmTarget = (cardIds) => dispatch({ type: "CONFIRM_TARGET", cardIds });
+  // Familien-Ziel-Auswahl (Rarität #167, Kat. A): Farbe(n) für pickTarget-Stufen wählen und bestätigen.
+  const familyTargetSuit = (suit) => dispatch({ type: "FAMILY_TARGET_SUIT", suit });
+  const familyTargetConfirm = () => dispatch({ type: "FAMILY_TARGET_CONFIRM", rng: Math.random });
   // Skill-Auswahl (jede 3. Runde): wählen (optional einen belegten Slot ersetzen) oder ablehnen → Perk.
   const pickSkill = (skillId, replaceId) => dispatch({ type: "PICK_SKILL", skillId, replaceId, rng: Math.random });
   const declineSkill = () => dispatch({ type: "DECLINE_SKILL", rng: Math.random });
@@ -436,6 +440,9 @@ export function Autostich() {
       )}
       {state.phase === "target" && (
         <TargetSelect state={state} onConfirm={confirmTarget} />
+      )}
+      {state.phase === "family-target" && (
+        <FamilyTargetSelect state={state} onSuit={familyTargetSuit} onConfirm={familyTargetConfirm} />
       )}
       {showChronik && <ChronikOverview state={state} onClose={() => setShowChronik(false)} />}
       {state.phase === "levelup" && state.statOffer && (

--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -70,9 +70,7 @@ export const STREAK_BASE_CAP  = 1.50; // … gedeckelt bei +150 % (Cap ab Serie 
 // Deckel des Stat-Beitrags analog zum Basis-Cap; bewusst großzügig, damit starke Serien-Builds stark
 // bleiben, aber nicht unbegrenzt eskalieren. [TUNING · Balance-Pass 1]
 export const STREAK_STAT_CAP  = 3.00; // Stat-Serien-Faktor höchstens +300 %
-// Gemeinsame Schwellen für Score-Perks (Kategorie D) [TUNING]
-export const D3_HIGH_MIN  = 8;    // „hohe Karte"-Schwelle für D3/D5 (#34: Skala 1–10)
-export const D4_LOW_MAX   = 3;    // „Außenseiter" bis zu diesem Wert
+// (D3_HIGH_MIN/D4_LOW_MAX entfernt — die Score-Perks sind zu Familien migriert, #167; Schwellen jetzt je Stufe in families.js.)
 
 // Raritäts-System (#33) [TUNING]
 export const RARITY_WEIGHTS            = { common: 100, rare: 25, legendary: 9 }; // 3-Stufen-Rarität; „common" = normal [TUNING]

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -125,10 +125,9 @@ export function resolveTrick(state, rng = Math.random) {
   const isRole = (perkId) => (roles[perkId] || []).includes(pCard.id);
   const triumphActive = triumphArmed.includes(pCard.id);
   let isSegmentLow = false, isSegmentHigh = false, segmentLowRank = -1, segmentIndex = -1;
-  // Gate: flache C7 (segmentLow) ODER eine gehaltene segmentLow-Familie (C_SURVIVOR). segmentLowRank/segmentIndex
-  // liefern C_SURVIVOR den Rang der Karte im Segment (0=tiefste, 1=zweittiefste), ohne isSegmentLow/High zu ändern.
-  if (ownsFlag(perks, "segmentLow") || ownsFlag(perks, "segmentHigh")
-      || activeFamilyEntries(familyTiers).some((e) => e.def.segmentLow)) {
+  // Gate: eine gehaltene segmentLow-Familie (C_SURVIVOR; flache C7 ist zu Familie migriert #167). segmentLowRank/
+  // segmentIndex liefern den Rang der Karte im Segment (0=tiefste, 1=zweittiefste); isSegmentLow/High bleiben für ggf. spätere Nutzung.
+  if (activeFamilyEntries(familyTiers).some((e) => e.def.segmentLow)) {
     const segStart = Math.floor(actualPos / SEGMENT_SIZE) * SEGMENT_SIZE;
     segmentIndex = Math.floor(actualPos / SEGMENT_SIZE);
     let minVal = Infinity, minPos = -1, maxVal = -Infinity, maxPos = -1;
@@ -395,17 +394,13 @@ export function resolveTrick(state, rng = Math.random) {
     sinceWin = 0; // #71 Durchbruch: Sieg setzt den Zähler zurück
     lossStreak = 0; // #71 Revanche: Sieg beendet die Niederlagenserie
     lastWinValue = pValue; // #71 Präzision: letzten Siegwert merken (NACH dem Vergleich in wctx)
-    // C4/C5: gewinnt eine Relay-Rolle, bekommen die nächsten `relay` Karten +2 (Queue nach dem Verbrauch → Index 0 = nächste Karte).
-    for (const id of perks) {
-      const relay = PERK_DEFS[id].relay;
-      if (relay && isRole(id)) for (let i = 0; i < relay; i++) successorQueue[i] = (successorQueue[i] || 0) + 2;
-    }
-    // C_RELAY/C_LEADER (Familien): relay-Anzahl + relayBonus aus der gehaltenen Stufe; nur wenn die gewinnende Karte Rolle ist.
+    // C_RELAY/C_LEADER (Familien, Kat. C zu #167 migriert): gewinnt eine Relay-Rolle, bekommen die nächsten `relay`
+    // Karten je +relayBonus (Queue nach dem Verbrauch → Index 0 = nächste Karte). relay/relayBonus aus der gehaltenen Stufe.
     for (const { familyId, def } of activeFamilyEntries(familyTiers)) {
       if (def.relay && isRole(familyId)) for (let i = 0; i < def.relay; i++) successorQueue[i] = (successorQueue[i] || 0) + (def.relayBonus || 0);
     }
-    // C2 / C_TRIUMPH: gewinnt eine Triumph-Rolle, wird sie fürs nächste Auftauchen armiert (flach ODER Familie).
-    if (isRole("C2") || activeFamilyEntries(familyTiers).some((e) => e.def.triumph && isRole(e.familyId)))
+    // C_TRIUMPH: gewinnt eine Triumph-Rolle, wird sie fürs nächste Auftauchen armiert.
+    if (activeFamilyEntries(familyTiers).some((e) => e.def.triumph && isRole(e.familyId)))
       triumphArmed = [...triumphArmed, pCard.id];
     // L8 Schicksalsmaschine: Erfolge je Karte diesen Durchlauf (für den Wert-Tausch am Durchlauf-Ende).
     if (ownsFlag(perks, "swapExtremes")) l8Wins = { ...l8Wins, [pCard.id]: (l8Wins[pCard.id] || 0) + 1 };

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -1,7 +1,7 @@
 import * as C from "./constants.js";
 import { shuffledOrder } from "./deck.js";
 import { PERK_DEFS, buildOffer, critChanceRawFor, critMultiplierFor, streakBaseMult } from "./perks.js";
-import { familySumHook, familyProdHook } from "./families.js";
+import { familySumHook, familyProdHook, familyTierParam } from "./families.js";
 import { skillSum, lightningCritRaw, addCharge, buildSkillOffer, ionScoreFor, ionizeCountFor, consumeCharge, ionizeCards,
   hasIonize, hasProtect, hasStorm, chargeFloorFor,
   lightningCritMult, hasStaticCharge, hasConductivity, hasEndlessStorm, hasDischarge, // Blitz-Rework (#93 F2)
@@ -54,6 +54,7 @@ export function resolveTrick(state, rng = Math.random) {
     initiative, lastResult, perks, offer, tieArmed, sinceWin = 0,
     lossStreak = 0, lastWinValue = null, // #71 Rares: Revanche / Präzision
     critFollowArmed = false, weaknessArmed = false, // #71 Crit-Historie: Crit-Folge (D14) / Schwachstellenanalyse (D16)
+    weaknessBig = false, // Rarität #167: D_WEAKNESS IV — die rüstende Niederlage hatte großen Abstand (→ +900 statt +600)
     misfireScore = 0, // V2 §22.6 D15: Score-Ladung, +30 je Sieg ohne Crit (max 300), Auszahlung bei Crit
     winSuit = null, winSuitStreak = 0, // #71 Farbserie: gleicher-Farbe-Siegesserie
     recentResults = [], // #71 Volles Haus: die letzten (bis zu 4) Ergebnisse VOR diesem Stich
@@ -68,6 +69,19 @@ export function resolveTrick(state, rng = Math.random) {
     shop = null, economyStatLevel = 0, // Shop-System (Shop-Spec §3): Münzstand + Einkommen-Level
     familyTiers = {}, // Raritätssystem (Epic #167): Familienrang je Familie — Engine löst aktive Stufen-Hooks auf
   } = state;
+
+  // Rarität-Umbau #167 (Schritt 2): engine-gekoppelte D-Stufen liefern ihre Parameter über die GEHALTENE
+  // Familien-Stufe (familyTierParam). Ohne Familie greifen die alten flachen D15/D16/D17-Konstanten →
+  // Bestandsverhalten unverändert (der Accumulator lädt weiterhin, wird aber nur von einem Hook gelesen).
+  const misfireStep   = familyTierParam(familyTiers, "D_MISFIRE", "misfireStep")   ?? 30;   // D15/D_MISFIRE: Ladung je Sieg ohne Crit
+  const misfireCap    = familyTierParam(familyTiers, "D_MISFIRE", "misfireCap")    ?? 300;
+  const misfireRetain = familyTierParam(familyTiers, "D_MISFIRE", "misfireRetain") ?? 0;     // IV: 25 % der Ladung bleiben nach einem Crit
+  const weaknessDeficit    = familyTierParam(familyTiers, "D_WEAKNESS", "weaknessDeficit")    ?? 5; // D16/D_WEAKNESS: Abstand-Schwelle zum Rüsten
+  const weaknessBigDeficit = familyTierParam(familyTiers, "D_WEAKNESS", "weaknessBigDeficit");      // nur IV gesetzt → großer Abstand
+  const suitHalveOnSwitch  = !!familyTierParam(familyTiers, "D_SUIT_STREAK", "suitHalveOnSwitch");  // IV: Farbwechsel halbiert statt Reset
+  const streakGainOnCrit   = familyTierParam(familyTiers, "D_CRIT_MOMENTUM", "streakGainOnCrit") || 0; // IV: Crit erhöht die Serie um 1
+  const interplayStoreOnLoss = familyTierParam(familyTiers, "D_INTERPLAY", "storeOnLoss") || 0;     // IV: Niederlage bankt Score
+  const critFollowCritBonus  = familyTierParam(familyTiers, "D_CRIT_FOLLOW", "critFollowCritBonus") || 0; // IV: Crit-Folgesieg, der selbst Crit ist
 
   // Zeitsegment (Shop §8 A-L1): `pos` ist der Stich-Index dieses Durchlaufs, `actualPos` die zugehörige
   // Deckposition. Ohne Zeitsegment sind beide gleich; mit Zeitsegment wird das gewählte Segment direkt nach
@@ -187,11 +201,13 @@ export function resolveTrick(state, rng = Math.random) {
     if (winStreak > bestStreak) bestStreak = winStreak; // längste Serie des Runs (#8)
     serieStreak = winStreak; // effektive Serie NACH diesem Sieg
     // winStreak/wins enthalten hier bereits den gerade gewonnenen Stich.
-    // #71 Farbserie: Länge der Serie gewonnener Stiche gleicher Farbe INKL. dieses Siegs.
-    const suitStreak = pCard.suit === winSuit ? winSuitStreak + 1 : 1;
+    // #71 Farbserie: Länge der Serie gewonnener Stiche gleicher Farbe INKL. dieses Siegs. D_SUIT_STREAK IV:
+    // ein Farbwechsel HALBIERT die laufende Länge (min 1) statt sie auf 1 zurückzusetzen (suitHalveOnSwitch).
+    const suitStreak = pCard.suit === winSuit ? winSuitStreak + 1
+                     : (suitHalveOnSwitch ? Math.max(1, Math.floor(winSuitStreak / 2)) : 1);
     const wctx = { winValue: pValue, margin: pValue - oValue, winStreak: serieStreak, wins, trickNo, posInCycle: pos,
                    lastWinValue, // #71: Präzision (Vergleich mit letztem Siegwert)
-                   critFollowArmed, weaknessArmed, // Crit-Historie: Stand VOR diesem Sieg (D14/D16)
+                   critFollowArmed, weaknessArmed, weaknessBig, // Crit-Historie: Stand VOR diesem Sieg (D14/D16/D_WEAKNESS IV)
                    suitStreak, recentWinCount, // Farbserie / Volles Haus
                    baseValue: pCard.value, // Basiswert der gespielten Karte
                    hasFormation, lastResult, misfireScore }; // V2 §22.6 D: Formation-Sieg / Wechselspiel / Fehlzündungs-Ladung (D15)
@@ -255,7 +271,8 @@ export function resolveTrick(state, rng = Math.random) {
     // gehaltene Familien-Stufe zählt (activeTierDefs) → kein Doppel-Trigger über Stufen (Spec §2.3/§9).
     const scoreBase = C.SCORE_PER_WIN + sumHook(perks, "scoreFlat", wctx) + familySumHook(familyTiers, "scoreFlat", wctx)
                       + (isCrit ? sumHook(perks, "scoreFlatOnCrit", critCtx) + skillSum(skills, "scoreFlatOnCrit", critCtx)
-                                  + familySumHook(familyTiers, "scoreFlatOnCrit", critCtx) : 0)
+                                  + familySumHook(familyTiers, "scoreFlatOnCrit", critCtx)
+                                  + (critFollowArmed ? critFollowCritBonus : 0) : 0) // D_CRIT_FOLLOW IV: Crit-Folgesieg, der selbst Crit ist
                       + ionScoreFor(pCard) + stormScore + l5Flat + fireFlat + dischargeFlat + iceFlat
                       + (anchorType === "score" ? C.ANCHOR_SCORE : 0); // Punkteanker (§8 A2)
     // Score-Stapelung (§15/§22.7): Basis × Serie(#39) × Perk-scoreMult × Serien-Stat × Formations-Multiplikator
@@ -333,10 +350,15 @@ export function resolveTrick(state, rng = Math.random) {
     }
     // Crit-Historie: Update NACH dem Wurf (wctx trug den Stand davor).
     critFollowArmed = isCrit;                                        // D14 Crit-Folge: nur ein Crit rüstet den nächsten Sieg
-    misfireScore = isCrit ? 0 : Math.min((misfireScore || 0) + 30, 300); // D15: +30 Score-Ladung je Sieg ohne Crit, Crit zahlt aus & setzt zurück
-    weaknessArmed = false;                                           // D16 Schwachstellenanalyse: durch diesen Sieg verbraucht
+    // D15/D_MISFIRE: Ladung je Sieg ohne Crit (Stufen-Schritt/Cap); ein Crit zahlt oben die volle Ladung aus und
+    // behält danach misfireRetain-Anteil (IV: 25 %, sonst 0 → Reset). Default 30/300/0 = flaches D15.
+    misfireScore = isCrit ? Math.round((misfireScore || 0) * misfireRetain)
+                          : Math.min((misfireScore || 0) + misfireStep, misfireCap);
+    weaknessArmed = false; weaknessBig = false;                      // D16/D_WEAKNESS: durch diesen Sieg verbraucht
     if (isCrit) {
       crits += 1; critBonusScore += critBonus;
+      // D_CRIT_MOMENTUM IV: ein Crit erhöht die Siegesserie zusätzlich (wirkt ab dem nächsten Stich, wie der Serienanker).
+      if (streakGainOnCrit) { winStreak += streakGainOnCrit; if (winStreak > bestStreak) bestStreak = winStreak; }
       // L4 Kritische Masse: die kritisch getroffene Karte dauerhaft +1 (max +4 je Karte).
       if (ownsFlag(perks, "critValueGain") && (l4Boost[pCard.id] || 0) < 4) {
         deck = deck.map((c) => (c.id === pCard.id ? { ...c, value: c.value + 1 } : c));
@@ -373,7 +395,11 @@ export function resolveTrick(state, rng = Math.random) {
     if (ownsFlag(perks, "winTieAfterLoss")) tieArmed = true; // B5: nach Niederlage nächsten Gleichstand gewinnen
     sinceWin += 1; // #71 Durchbruch: kein Sieg → Zähler hoch
     lossStreak += 1; // #71 Revanche: aufeinanderfolgende Niederlagen
-    if (oValue - pValue >= 5) weaknessArmed = true; // D16 Schwachstellenanalyse: klare Niederlage rüstet nächsten Sieg
+    // D16/D_WEAKNESS: Niederlage ab der Stufen-Schwelle rüstet den nächsten Sieg (Default 5 = flaches D16; IV: 0 = jede
+    // Niederlage). D_WEAKNESS IV markiert zusätzlich einen großen Abstand (≥ weaknessBigDeficit → nächster Sieg +900).
+    if (oValue - pValue >= weaknessDeficit) weaknessArmed = true;
+    weaknessBig = weaknessBigDeficit != null && (oValue - pValue) >= weaknessBigDeficit;
+    if (interplayStoreOnLoss) score += interplayStoreOnLoss; // D_INTERPLAY IV: die nächste Niederlage bankt gespeicherten Score
     winSuit = null; winSuitStreak = 0; // #71 Farbserie: Niederlage beendet die Farbserie (auch mit Rahmen)
     serieStreak = 0;
     if (rahmenRedeemed) lightning = { ...lightning, armed: false }; // Rahmen eingelöst → entfernt
@@ -496,7 +522,7 @@ export function resolveTrick(state, rng = Math.random) {
     crits, critBonusScore, bestTrickScore, maxFormations, formationScore, // #161 FB-2: Run-Rückblick
     initiative, lastResult, perks, offer: newOffer, tieArmed, sinceWin, lossStreak, lastWinValue,
     freePerkReroll: newFreePerkReroll, freeSkillReroll: newFreeSkillReroll, // Planung (§10 P-L1)
-    critFollowArmed, weaknessArmed, misfireScore,
+    critFollowArmed, weaknessArmed, weaknessBig, misfireScore,
     winSuit, winSuitStreak, recentResults,
     formations, // Formations-Engine (V2 §22.7): pro-Position-Multiplikatoren, zu Durchlauf-Beginn berechnet
     formationEnergy: newFormationEnergy, formationSwaps: newFormationSwaps, // Formationsphase (V2 §22.8)

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -55,6 +55,7 @@ export function resolveTrick(state, rng = Math.random) {
     lossStreak = 0, lastWinValue = null, // #71 Rares: Revanche / Präzision
     critFollowArmed = false, weaknessArmed = false, // #71 Crit-Historie: Crit-Folge (D14) / Schwachstellenanalyse (D16)
     weaknessBig = false, // Rarität #167: D_WEAKNESS IV — die rüstende Niederlage hatte großen Abstand (→ +900 statt +600)
+    interplayStored = 0, // Rarität #167: D_INTERPLAY IV — in Niederlagen gebankter Score, beim nächsten Sieg als Flat ausgezahlt
     misfireScore = 0, // V2 §22.6 D15: Score-Ladung, +30 je Sieg ohne Crit (max 300), Auszahlung bei Crit
     winSuit = null, winSuitStreak = 0, // #71 Farbserie: gleicher-Farbe-Siegesserie
     recentResults = [], // #71 Volles Haus: die letzten (bis zu 4) Ergebnisse VOR diesem Stich
@@ -274,7 +275,8 @@ export function resolveTrick(state, rng = Math.random) {
                                   + familySumHook(familyTiers, "scoreFlatOnCrit", critCtx)
                                   + (critFollowArmed ? critFollowCritBonus : 0) : 0) // D_CRIT_FOLLOW IV: Crit-Folgesieg, der selbst Crit ist
                       + ionScoreFor(pCard) + stormScore + l5Flat + fireFlat + dischargeFlat + iceFlat
-                      + (anchorType === "score" ? C.ANCHOR_SCORE : 0); // Punkteanker (§8 A2)
+                      + (anchorType === "score" ? C.ANCHOR_SCORE : 0) // Punkteanker (§8 A2)
+                      + interplayStored; // D_INTERPLAY IV: der in Niederlagen gebankte Score wird mit diesem Sieg als Flat ausgezahlt
     // Score-Stapelung (§15/§22.7): Basis × Serie(#39) × Perk-scoreMult × Serien-Stat × Formations-Multiplikator
     // × Formations-Stat, DANN Crit. Zu benannten Faktoren gruppiert (identisches Produkt) → eine Quelle für
     // Score UND Ergebnis-Aufschlüsselung (§17), kein Drift.
@@ -355,6 +357,7 @@ export function resolveTrick(state, rng = Math.random) {
     misfireScore = isCrit ? Math.round((misfireScore || 0) * misfireRetain)
                           : Math.min((misfireScore || 0) + misfireStep, misfireCap);
     weaknessArmed = false; weaknessBig = false;                      // D16/D_WEAKNESS: durch diesen Sieg verbraucht
+    interplayStored = 0;                                            // D_INTERPLAY IV: der gebankte Score ist mit diesem Sieg ausgezahlt
     if (isCrit) {
       crits += 1; critBonusScore += critBonus;
       // D_CRIT_MOMENTUM IV: ein Crit erhöht die Siegesserie zusätzlich (wirkt ab dem nächsten Stich, wie der Serienanker).
@@ -399,7 +402,7 @@ export function resolveTrick(state, rng = Math.random) {
     // Niederlage). D_WEAKNESS IV markiert zusätzlich einen großen Abstand (≥ weaknessBigDeficit → nächster Sieg +900).
     if (oValue - pValue >= weaknessDeficit) weaknessArmed = true;
     weaknessBig = weaknessBigDeficit != null && (oValue - pValue) >= weaknessBigDeficit;
-    if (interplayStoreOnLoss) score += interplayStoreOnLoss; // D_INTERPLAY IV: die nächste Niederlage bankt gespeicherten Score
+    if (interplayStoreOnLoss) interplayStored += interplayStoreOnLoss; // D_INTERPLAY IV: Niederlage bankt Score für den nächsten Sieg
     winSuit = null; winSuitStreak = 0; // #71 Farbserie: Niederlage beendet die Farbserie (auch mit Rahmen)
     serieStreak = 0;
     if (rahmenRedeemed) lightning = { ...lightning, armed: false }; // Rahmen eingelöst → entfernt
@@ -522,7 +525,7 @@ export function resolveTrick(state, rng = Math.random) {
     crits, critBonusScore, bestTrickScore, maxFormations, formationScore, // #161 FB-2: Run-Rückblick
     initiative, lastResult, perks, offer: newOffer, tieArmed, sinceWin, lossStreak, lastWinValue,
     freePerkReroll: newFreePerkReroll, freeSkillReroll: newFreeSkillReroll, // Planung (§10 P-L1)
-    critFollowArmed, weaknessArmed, weaknessBig, misfireScore,
+    critFollowArmed, weaknessArmed, weaknessBig, interplayStored, misfireScore,
     winSuit, winSuitStreak, recentResults,
     formations, // Formations-Engine (V2 §22.7): pro-Position-Multiplikatoren, zu Durchlauf-Beginn berechnet
     formationEnergy: newFormationEnergy, formationSwaps: newFormationSwaps, // Formationsphase (V2 §22.8)

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -1,7 +1,7 @@
 import * as C from "./constants.js";
 import { shuffledOrder } from "./deck.js";
 import { PERK_DEFS, buildPerkOffer, critChanceRawFor, critMultiplierFor, streakBaseMult } from "./perks.js";
-import { familySumHook, familyProdHook, familyTierParam } from "./families.js";
+import { familySumHook, familyProdHook, familyTierParam, activeFamilyEntries } from "./families.js";
 import { skillSum, lightningCritRaw, addCharge, buildSkillOffer, ionScoreFor, ionizeCountFor, consumeCharge, ionizeCards,
   hasIonize, hasProtect, hasStorm, chargeFloorFor,
   lightningCritMult, hasStaticCharge, hasConductivity, hasEndlessStorm, hasDischarge, // Blitz-Rework (#93 F2)
@@ -124,16 +124,25 @@ export function resolveTrick(state, rng = Math.random) {
   // Kartenrollen (V2 §22.6 C): Rolle der aktuellen Karte, Triumph-Armierung, Segment-Tiefste.
   const isRole = (perkId) => (roles[perkId] || []).includes(pCard.id);
   const triumphActive = triumphArmed.includes(pCard.id);
-  let isSegmentLow = false, isSegmentHigh = false;
-  if (ownsFlag(perks, "segmentLow") || ownsFlag(perks, "segmentHigh")) { // C7 Tiefste / L7 Höchste im Segment (erste bei Gleichstand)
+  let isSegmentLow = false, isSegmentHigh = false, segmentLowRank = -1, segmentIndex = -1;
+  // Gate: flache C7 (segmentLow) ODER eine gehaltene segmentLow-Familie (C_SURVIVOR). segmentLowRank/segmentIndex
+  // liefern C_SURVIVOR den Rang der Karte im Segment (0=tiefste, 1=zweittiefste), ohne isSegmentLow/High zu ändern.
+  if (ownsFlag(perks, "segmentLow") || ownsFlag(perks, "segmentHigh")
+      || activeFamilyEntries(familyTiers).some((e) => e.def.segmentLow)) {
     const segStart = Math.floor(actualPos / SEGMENT_SIZE) * SEGMENT_SIZE;
+    segmentIndex = Math.floor(actualPos / SEGMENT_SIZE);
     let minVal = Infinity, minPos = -1, maxVal = -Infinity, maxPos = -1;
+    const segPositions = [];
     for (let k = segStart; k < segStart + SEGMENT_SIZE && k < playerOrder.length; k++) {
       const v = deck[playerOrder[k]].value;
+      segPositions.push(k);
       if (v < minVal) { minVal = v; minPos = k; }
       if (v > maxVal) { maxVal = v; maxPos = k; }
     }
     isSegmentLow = actualPos === minPos; isSegmentHigh = actualPos === maxPos;
+    // Rang nach aktuellem Wert aufsteigend, stabil nach Position bei Gleichwert (Rang 0 = minPos → deckungsgleich mit isSegmentLow).
+    const sorted = segPositions.slice().sort((a, b) => deck[playerOrder[a]].value - deck[playerOrder[b]].value || a - b);
+    segmentLowRank = sorted.indexOf(actualPos);
   }
   // L10 Kettenreaktion: der direkte Nachfolger eines Crits ist garantiert kritisch (falls er gewinnt).
   const forceCrit = chainArmed; chainArmed = false;
@@ -152,6 +161,9 @@ export function resolveTrick(state, rng = Math.random) {
     posForm, // V2 §22.6: Formation der gespielten Position (B6 Wiederholung / B9 Treppe)
     predValue, // V2 §22.6: Dauerwert des direkten Vorgängers (B10 Überzahl)
     isRole, triumphActive, isSegmentLow, isSegmentHigh, // V2 §22.6 C/L: Kartenrollen (C1/C2/C3/C6/C7/L7)
+    // Rarität #167 Kat. C: Ergebnis des ZWEITEN Vorgängers (C_GUARD IV), Segment-Rang/-Index (C_SURVIVOR).
+    secondLastResult: recentResults.length >= 2 ? recentResults[recentResults.length - 2] : null,
+    segmentLowRank, segmentIndex,
   };
   // Nachfolger-Bonus (C4 Staffelläufer / C5 Anführer): der Kopf der Queue gilt für DIESE Karte, dann verbraucht.
   const relayBonus = successorQueue[0] || 0;
@@ -388,8 +400,13 @@ export function resolveTrick(state, rng = Math.random) {
       const relay = PERK_DEFS[id].relay;
       if (relay && isRole(id)) for (let i = 0; i < relay; i++) successorQueue[i] = (successorQueue[i] || 0) + 2;
     }
-    // C2 Triumph: gewinnt eine Triumph-Rolle, wird sie fürs nächste Auftauchen armiert.
-    if (isRole("C2")) triumphArmed = [...triumphArmed, pCard.id];
+    // C_RELAY/C_LEADER (Familien): relay-Anzahl + relayBonus aus der gehaltenen Stufe; nur wenn die gewinnende Karte Rolle ist.
+    for (const { familyId, def } of activeFamilyEntries(familyTiers)) {
+      if (def.relay && isRole(familyId)) for (let i = 0; i < def.relay; i++) successorQueue[i] = (successorQueue[i] || 0) + (def.relayBonus || 0);
+    }
+    // C2 / C_TRIUMPH: gewinnt eine Triumph-Rolle, wird sie fürs nächste Auftauchen armiert (flach ODER Familie).
+    if (isRole("C2") || activeFamilyEntries(familyTiers).some((e) => e.def.triumph && isRole(e.familyId)))
+      triumphArmed = [...triumphArmed, pCard.id];
     // L8 Schicksalsmaschine: Erfolge je Karte diesen Durchlauf (für den Wert-Tausch am Durchlauf-Ende).
     if (ownsFlag(perks, "swapExtremes")) l8Wins = { ...l8Wins, [pCard.id]: (l8Wins[pCard.id] || 0) + 1 };
     // Serienanker (§8 A4): Sieg auf einer Serienanker-Position gibt +1 Serienpunkt — NACH der Wertung dieses Siegs.

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -104,7 +104,7 @@ export function resolveTrick(state, rng = Math.random) {
   let formations = state.formations || [];
   const anchors = (shop && shop.anchors) || []; // Shop-Positionsanker (§8) — an der Deckposition
   const permEffects = (shop && shop.permanentEffects) || {}; // Shop-Formationsitems (§9) — permanente Regeländerungen
-  if (pos === 0) formations = computeFormations(playerOrder, deck, roles, perks, skills, anchors, permEffects);
+  if (pos === 0) formations = computeFormations(playerOrder, deck, roles, perks, skills, anchors, permEffects, familyTiers);
   // #161 FB-2: Peak gleichzeitig aktiver Formationen über den Run — zu Durchlaufbeginn, sobald das Layout feststeht.
   if (pos === 0) maxFormations = Math.max(maxFormations || 0, summarizeFormations(formations).count);
   const posForm = formations[actualPos] || { mult: 1, formations: [] };
@@ -540,7 +540,7 @@ export function resolveTrick(state, rng = Math.random) {
         newFormationSwaps = [];
         // #137: anchors + permEffects mitgeben (wie bei pos-0/Tausch/Kauf), sonst zeigt die Formationsphase beim
         // Eintritt einen veralteten Stand (ohne regeländernde Shop-Effekte) — erst der erste Tausch korrigierte.
-        formations = computeFormations(playerOrder, deck, roles, perks, skills, anchors, permEffects);
+        formations = computeFormations(playerOrder, deck, roles, perks, skills, anchors, permEffects, familyTiers);
       }
     }
   }

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -1,6 +1,6 @@
 import * as C from "./constants.js";
 import { shuffledOrder } from "./deck.js";
-import { PERK_DEFS, buildOffer, critChanceRawFor, critMultiplierFor, streakBaseMult } from "./perks.js";
+import { PERK_DEFS, buildPerkOffer, critChanceRawFor, critMultiplierFor, streakBaseMult } from "./perks.js";
 import { familySumHook, familyProdHook, familyTierParam } from "./families.js";
 import { skillSum, lightningCritRaw, addCharge, buildSkillOffer, ionScoreFor, ionizeCountFor, consumeCharge, ionizeCards,
   hasIonize, hasProtect, hasStorm, chargeFloorFor,
@@ -493,9 +493,9 @@ export function resolveTrick(state, rng = Math.random) {
       } else if (decision === "skill") {
         const soff = buildSkillOffer(skills, activeArchetypes, rng, C.SKILLS_OFFERED, skillLegendaryChance(shop));
         if (soff.length > 0) { phase = "levelup"; newSkillOffer = soff; newFreeSkillReroll = fate; }
-        else { const off = buildOffer(perks, rng, C.PERKS_OFFERED, perkLegendaryChance(shop)); if (off.length > 0) { phase = "levelup"; newOffer = off; newFreePerkReroll = fate; } } // leerer Skill-Pool → Perk
+        else { const off = buildPerkOffer(perks, familyTiers, rng, C.PERKS_OFFERED, perkLegendaryChance(shop)); if (off.length > 0) { phase = "levelup"; newOffer = off; newFreePerkReroll = fate; } } // leerer Skill-Pool → Perk
       } else if (decision === "perk") {
-        const off = buildOffer(perks, rng, C.PERKS_OFFERED, perkLegendaryChance(shop));
+        const off = buildPerkOffer(perks, familyTiers, rng, C.PERKS_OFFERED, perkLegendaryChance(shop));
         if (off.length > 0) { phase = "levelup"; newOffer = off; newFreePerkReroll = fate; }
       } else if (decision === "shop") {
         // Shop-Runde (Shop-Spec §2.6): Shop-Phase öffnen, Einkommensbonus gutschreiben (+3 je Einkommen-Level,

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -1,6 +1,7 @@
 import * as C from "./constants.js";
 import { shuffledOrder } from "./deck.js";
 import { PERK_DEFS, buildOffer, critChanceRawFor, critMultiplierFor, streakBaseMult } from "./perks.js";
+import { familySumHook, familyProdHook } from "./families.js";
 import { skillSum, lightningCritRaw, addCharge, buildSkillOffer, ionScoreFor, ionizeCountFor, consumeCharge, ionizeCards,
   hasIonize, hasProtect, hasStorm, chargeFloorFor,
   lightningCritMult, hasStaticCharge, hasConductivity, hasEndlessStorm, hasDischarge, // Blitz-Rework (#93 F2)
@@ -65,6 +66,7 @@ export function resolveTrick(state, rng = Math.random) {
     skills = [], skillOffer = null, lightning = null, activeArchetypes = [], // Skill-System / Archetypen (#93)
     iceTemp = {}, frostbitePending = [], frostbiteActive = [], // Eis (#93 F3): temp. Wertboni je card.id / Frostbiss-Markierungen
     shop = null, economyStatLevel = 0, // Shop-System (Shop-Spec §3): Münzstand + Einkommen-Level
+    familyTiers = {}, // Raritätssystem (Epic #167): Familienrang je Familie — Engine löst aktive Stufen-Hooks auf
   } = state;
 
   // Zeitsegment (Shop §8 A-L1): `pos` ist der Stich-Index dieses Durchlaufs, `actualPos` die zugehörige
@@ -249,8 +251,11 @@ export function resolveTrick(state, rng = Math.random) {
     // Entladung (#93 F2): war der nächste Crit +500 armiert (aus einem früheren vollen Verbrauch)? Dieser Crit zahlt aus.
     const dischargeArmedBefore = !!(lightning && lightning.dischargeArmed);
     const dischargeFlat = (isCrit && dischargeArmedBefore) ? C.DISCHARGE_SCORE : 0;
-    const scoreBase = C.SCORE_PER_WIN + sumHook(perks, "scoreFlat", wctx)
-                      + (isCrit ? sumHook(perks, "scoreFlatOnCrit", critCtx) + skillSum(skills, "scoreFlatOnCrit", critCtx) : 0)
+    // Familien-Score-Flats (Rarität-Umbau #167, Kat. D) laufen ADDITIV neben den flachen Perk-Flats: nur die
+    // gehaltene Familien-Stufe zählt (activeTierDefs) → kein Doppel-Trigger über Stufen (Spec §2.3/§9).
+    const scoreBase = C.SCORE_PER_WIN + sumHook(perks, "scoreFlat", wctx) + familySumHook(familyTiers, "scoreFlat", wctx)
+                      + (isCrit ? sumHook(perks, "scoreFlatOnCrit", critCtx) + skillSum(skills, "scoreFlatOnCrit", critCtx)
+                                  + familySumHook(familyTiers, "scoreFlatOnCrit", critCtx) : 0)
                       + ionScoreFor(pCard) + stormScore + l5Flat + fireFlat + dischargeFlat + iceFlat
                       + (anchorType === "score" ? C.ANCHOR_SCORE : 0); // Punkteanker (§8 A2)
     // Score-Stapelung (§15/§22.7): Basis × Serie(#39) × Perk-scoreMult × Serien-Stat × Formations-Multiplikator
@@ -258,7 +263,7 @@ export function resolveTrick(state, rng = Math.random) {
     // Score UND Ergebnis-Aufschlüsselung (§17), kein Drift.
     const flats = scoreBase - C.SCORE_PER_WIN;                                         // additive Boni (Perk-/Crit-Flats, Ion, Storm, L5-Jackpot)
     const streakMult = streakBaseMult(serieStreak) * statStreakFactor(statStreakMult, serieStreak); // Serie (#39 + Serien-Stat)
-    const perkMult = prodHook(perks, "scoreMult", wctx);                               // globale Perk-Multiplikatoren
+    const perkMult = prodHook(perks, "scoreMult", wctx) * familyProdHook(familyTiers, "scoreMult", wctx); // globale Perk-/Familien-Multiplikatoren
     // Formation (§22.7) in drei benannte Faktoren (§13): Basis-Formationen×Formations-Stat, dann die Shop-Meta-Faktoren
     // Nachhall (F6) und Formationskern (F-L1) je eigen. Produkt = formationMult × Stat (unverändert; Aufspaltung ist rein
     // für die Ergebnis-Aufschlüsselung — Multiplikation ist kommutativ).

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -402,7 +402,6 @@ export function resolveTrick(state, rng = Math.random) {
     const rahmenRedeemed = !!(lightning && lightning.armed);
     winStreak = rahmenRedeemed ? winStreak : 0;
     initiative = "opp";
-    if (ownsFlag(perks, "winTieAfterLoss")) tieArmed = true; // B5 (flach): nach Niederlage nächsten Gleichstand gewinnen
     sinceWin += 1; // #71 Durchbruch: kein Sieg → Zähler hoch
     lossStreak += 1; // #71 Revanche: aufeinanderfolgende Niederlagen
     // B5 Initiative (Familie): Gleichstands-Sieg armieren, sobald die Niederlagenserie die Stufen-Schwelle erreicht.

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -83,6 +83,10 @@ export function resolveTrick(state, rng = Math.random) {
   const streakGainOnCrit   = familyTierParam(familyTiers, "D_CRIT_MOMENTUM", "streakGainOnCrit") || 0; // IV: Crit erhöht die Serie um 1
   const interplayStoreOnLoss = familyTierParam(familyTiers, "D_INTERPLAY", "storeOnLoss") || 0;     // IV: Niederlage bankt Score
   const critFollowCritBonus  = familyTierParam(familyTiers, "D_CRIT_FOLLOW", "critFollowCritBonus") || 0; // IV: Crit-Folgesieg, der selbst Crit ist
+  // Kategorie B (Stich): B5 Initiative armiert den Gleichstands-Sieg über tieArmLosses; B8 III armiert die
+  // successorQueue der nächsten Karten (revengeTwoCard {losses, bonus, count}). Beide werden im Niederlage-Zweig gelesen.
+  const tieArmLosses  = familyTierParam(familyTiers, "B_INITIATIVE", "tieArmLosses");
+  const revengeTwoCard = familyTierParam(familyTiers, "B_REVENGE", "revengeTwoCard");
 
   // Zeitsegment (Shop §8 A-L1): `pos` ist der Stich-Index dieses Durchlaufs, `actualPos` die zugehörige
   // Deckposition. Ohne Zeitsegment sind beide gleich; mit Zeitsegment wird das gewählte Segment direkt nach
@@ -174,7 +178,10 @@ export function resolveTrick(state, rng = Math.random) {
   // ---- Eis (#93 F3): temp. Wertbonus (Kältereserve/Kaltfront/Frostspur, an card.id) + Permafrost +2 (Dauerwert eingefroren).
   const iceValueBonus = (iceTemp[pCard.id] || 0) + (hasPermafrost(skills) && pCard.frozen ? C.PERMAFROST_VALUE : 0);
   const anchorPowerBonus = anchorType === "power" ? C.ANCHOR_POWER_VALUE : 0; // Kraftanker (§8 A1)
-  const pValue = effectivePlayerValue(pCard.value, perks, ctx) + relayBonus + l11Bonus + fireValueBonus + iceValueBonus + anchorPowerBonus;
+  // Familien-Wertboni (Kategorie B, Rarität #167) laufen ADDITIV neben den flachen Perk-cardBonus-Hooks —
+  // gleicher Kontext (inkl. pValueBase = Dauerwert der Karte), nur die aktive Familien-Stufe zählt.
+  const familyValueBonus = familySumHook(familyTiers, "cardBonus", { ...ctx, pValueBase: pCard.value });
+  const pValue = effectivePlayerValue(pCard.value, perks, ctx) + familyValueBonus + relayBonus + l11Bonus + fireValueBonus + iceValueBonus + anchorPowerBonus;
   // L11: den temporären Wertbonus dieser Karte an Position 20 für Position 40 merken.
   let newPos20Bonus = pos20Bonus;
   if (actualPos === 19) newPos20Bonus = pValue - pCard.value;
@@ -395,9 +402,14 @@ export function resolveTrick(state, rng = Math.random) {
     const rahmenRedeemed = !!(lightning && lightning.armed);
     winStreak = rahmenRedeemed ? winStreak : 0;
     initiative = "opp";
-    if (ownsFlag(perks, "winTieAfterLoss")) tieArmed = true; // B5: nach Niederlage nächsten Gleichstand gewinnen
+    if (ownsFlag(perks, "winTieAfterLoss")) tieArmed = true; // B5 (flach): nach Niederlage nächsten Gleichstand gewinnen
     sinceWin += 1; // #71 Durchbruch: kein Sieg → Zähler hoch
     lossStreak += 1; // #71 Revanche: aufeinanderfolgende Niederlagen
+    // B5 Initiative (Familie): Gleichstands-Sieg armieren, sobald die Niederlagenserie die Stufen-Schwelle erreicht.
+    if (tieArmLosses != null && lossStreak >= tieArmLosses) tieArmed = true;
+    // B8 Revanche III (Familie): erreicht die Serie GENAU die Schwelle, die nächsten `count` Karten je +bonus (successorQueue).
+    if (revengeTwoCard && lossStreak === revengeTwoCard.losses)
+      for (let i = 0; i < revengeTwoCard.count; i++) successorQueue[i] = (successorQueue[i] || 0) + revengeTwoCard.bonus;
     // D16/D_WEAKNESS: Niederlage ab der Stufen-Schwelle rüstet den nächsten Sieg (Default 5 = flaches D16; IV: 0 = jede
     // Niederlage). D_WEAKNESS IV markiert zusätzlich einen großen Abstand (≥ weaknessBigDeficit → nächster Sieg +900).
     if (oValue - pValue >= weaknessDeficit) weaknessArmed = true;

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -189,10 +189,14 @@ export function resolveTrick(state, rng = Math.random) {
   // ---- Eis (#93 F3): temp. Wertbonus (Kältereserve/Kaltfront/Frostspur, an card.id) + Permafrost +2 (Dauerwert eingefroren).
   const iceValueBonus = (iceTemp[pCard.id] || 0) + (hasPermafrost(skills) && pCard.frozen ? C.PERMAFROST_VALUE : 0);
   const anchorPowerBonus = anchorType === "power" ? C.ANCHOR_POWER_VALUE : 0; // Kraftanker (§8 A1)
+  // E_QUICKSHOT IV (Rarität #167 Kat. E, Spec §3.2 E8 IV): jede Anker-Position (jede fünfte) erhält zusätzlich +2 Wert.
+  // Der Anker-FAKTOR selbst läuft über computeFormations; hier nur der Stufe-IV-Wertbonus (anchor.value auf Anker-Positionen).
+  const eqAnchor = familyTierParam(familyTiers, "E_QUICKSHOT", "anchor");
+  const eQuickshotValue = eqAnchor && eqAnchor.value && eqAnchor.at(actualPos) ? eqAnchor.value : 0;
   // Familien-Wertboni (Kategorie B, Rarität #167) laufen ADDITIV neben den flachen Perk-cardBonus-Hooks —
   // gleicher Kontext (inkl. pValueBase = Dauerwert der Karte), nur die aktive Familien-Stufe zählt.
   const familyValueBonus = familySumHook(familyTiers, "cardBonus", { ...ctx, pValueBase: pCard.value });
-  const pValue = effectivePlayerValue(pCard.value, perks, ctx) + familyValueBonus + relayBonus + l11Bonus + fireValueBonus + iceValueBonus + anchorPowerBonus;
+  const pValue = effectivePlayerValue(pCard.value, perks, ctx) + familyValueBonus + relayBonus + l11Bonus + fireValueBonus + iceValueBonus + anchorPowerBonus + eQuickshotValue;
   // L11: den temporären Wertbonus dieser Karte an Position 20 für Position 40 merken.
   let newPos20Bonus = pos20Bonus;
   if (actualPos === 19) newPos20Bonus = pValue - pCard.value;

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -1,4 +1,4 @@
-import { UPGRADE_TYPES } from "./rarity.js";
+import { UPGRADE_TYPES, withFamilyTier } from "./rarity.js";
 
 /* ============================================================
    FAMILIEN-REGISTRY (Rarität-Umbau #163, Spec docs/rarity-system.md §3.2).
@@ -248,4 +248,25 @@ export function familyProdHook(familyTiers, name, ctx) {
   let m = 1;
   for (const def of activeTierDefs(familyTiers)) { const f = def[name]; if (f) m *= f(ctx); }
   return m;
+}
+
+/* Familien-Pick anwenden (Spec §2.4 applyFamilyPick). Reine Funktion: nimmt den relevanten Run-State-
+   Ausschnitt und liefert das Patch { familyTiers, deck, roles }.
+   - REPLACEMENT (Kat. B/C-Regel/D/E): NUR der Familienrang ändert sich; die aktive Regel löst die Engine
+     live über activeTierDefs auf — kein separates „install/removeRuntimeRule" nötig (Spec §2.3).
+   - CUMULATIVE (Kat. A / Shop-Karten, #163/#164): jede gewählte Stufe führt ihr Paket EINMALIG aus
+     (tierDef.onPick auf dem Deck); frühere Deckänderungen bleiben. Deterministisch über injizierten rng.
+   - ROLE (Kat. C-Rollen, #163): Rollenziele/-regel steigen; der Ziel-Flow folgt mit den C-Familien.
+   Der aufrufende Reducer bleibt frei von Registry-Wissen. */
+export function applyFamilyPick(familyId, targetTier, ctx = {}, rng = Math.random) {
+  const { familyTiers = {}, deck = null, roles = null } = ctx;
+  const fam = FAMILY_DEFS[familyId];
+  if (!fam || !targetTier) return { familyTiers, deck, roles }; // ungültige Familie/Stufe → No-Op
+  const tierDef = fam.tiers[targetTier] || null;
+  let nextDeck = deck, nextRoles = roles;
+  if (fam.upgradeType === UPGRADE_TYPES.CUMULATIVE && tierDef && tierDef.onPick && deck) {
+    nextDeck = tierDef.onPick(deck, rng); // Stufen-Paket einmalig aufs Deck (A-/Shop-Karten-Familien)
+  }
+  // ROLE-Zielauswahl folgt mit Kategorie C (#163) — hier noch reine Rangaktualisierung.
+  return { familyTiers: withFamilyTier(familyTiers, familyId, targetTier), deck: nextDeck, roles: nextRoles };
 }

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -208,8 +208,121 @@ const D_FAMILIES = {
   },
 };
 
+// ---- B · Stich (Spec §3.2 B) — temporäre Wertboni auf die gespielte Karte, allesamt Regelersetzung. ----
+// Kontextfelder (aus effectivePlayerValue): lostLastTrick, winStreak (effektive Serie), posInCycle, sinceWin,
+// lossStreak, posForm (Formationen + `mult` der Position), predValue (Dauerwert des Vorgängers), pValueBase.
+const inRepeat = (c) => !!(c.posForm && c.posForm.formations && c.posForm.formations.some((f) => f.type === "wiederholung"));
+const inAnyFormation = (c) => !!(c.posForm && c.posForm.mult > 1); // = positionHasFormation (mult > 1)
+// Treppen-Ordinal (1,2,3,…) → Bonus: die ersten drei Stufen aus `firstThree`, ab der vierten konstant `cap`.
+const stairBonus = (c, firstThree, cap) => {
+  const t = c.posForm && c.posForm.formations && c.posForm.formations.find((f) => f.type === "treppe");
+  if (!t) return 0;
+  return t.ordinal <= 3 ? firstThree[t.ordinal - 1] : cap;
+};
+
+const B_FAMILIES = {
+  B_COUNTER: {
+    id: "B_COUNTER", cat: "B", name: "Gegenangriff", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Nach einer Niederlage erhält die nächste Karte +3 Wert.",  cardBonus: (c) => (c.lostLastTrick ? 3 : 0) },
+      2: { desc: "Nach einer Niederlage erhält die nächste Karte +5 Wert.",  cardBonus: (c) => (c.lostLastTrick ? 5 : 0) },
+      3: { desc: "Nach einer Niederlage erhält die nächste Karte +7 Wert.",  cardBonus: (c) => (c.lostLastTrick ? 7 : 0) },
+      4: { desc: "Nach einer Niederlage erhält die nächste Karte +10 Wert.", cardBonus: (c) => (c.lostLastTrick ? 10 : 0) },
+    },
+  },
+  B_MOMENTUM: {
+    id: "B_MOMENTUM", cat: "B", name: "Momentum", upgradeType: REPLACEMENT,
+    // Spec §3.3: verstärkt IMMER nur die direkt nächste Karte; kein Trigger nach nur 2 Siegen (I braucht 4, sonst 3).
+    tiers: {
+      1: { desc: "Nach genau 4 Siegen in Folge erhält die nächste Karte +4 Wert.", cardBonus: (c) => (c.winStreak === 4 ? 4 : 0) },
+      2: { desc: "Nach genau 3 Siegen in Folge erhält die nächste Karte +5 Wert.", cardBonus: (c) => (c.winStreak === 3 ? 5 : 0) },
+      3: { desc: "Nach genau 3 Siegen in Folge erhält die nächste Karte +7 Wert.", cardBonus: (c) => (c.winStreak === 3 ? 7 : 0) },
+      4: { desc: "Nach genau 3 Siegen in Folge erhält die nächste Karte +10 Wert.", cardBonus: (c) => (c.winStreak === 3 ? 10 : 0) },
+    },
+  },
+  B_OPENING: {
+    id: "B_OPENING", cat: "B", name: "Starker Auftakt", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Die ersten 2 Karten jedes Durchlaufs erhalten je +2 Wert.", cardBonus: (c) => (c.posInCycle <= 1 ? 2 : 0) },
+      2: { desc: "Die ersten 3 Karten jedes Durchlaufs erhalten je +3 Wert.", cardBonus: (c) => (c.posInCycle <= 2 ? 3 : 0) },
+      3: { desc: "Die ersten 4 Karten jedes Durchlaufs erhalten je +4 Wert.", cardBonus: (c) => (c.posInCycle <= 3 ? 4 : 0) },
+      4: { desc: "Die ersten 5 Karten jedes Durchlaufs erhalten je +5 Wert.", cardBonus: (c) => (c.posInCycle <= 4 ? 5 : 0) },
+    },
+  },
+  B_TENTH_STRIKE: {
+    id: "B_TENTH_STRIKE", cat: "B", name: "Zehnter Schlag", upgradeType: REPLACEMENT,
+    // posInCycle ist 0-basiert → Position n = posInCycle n-1; „(pos+1) % k === 0" trifft jede k-te Position.
+    tiers: {
+      1: { desc: "Karten auf Position 20 und 40 erhalten +6 Wert.",               cardBonus: (c) => ((c.posInCycle + 1) % 20 === 0 ? 6 : 0) },
+      2: { desc: "Karten auf Position 10, 20, 30 und 40 erhalten +6 Wert.",       cardBonus: (c) => ((c.posInCycle + 1) % 10 === 0 ? 6 : 0) },
+      3: { desc: "Jede fünfte Position (5, 10, … 40) erhält +6 Wert.",            cardBonus: (c) => ((c.posInCycle + 1) % 5 === 0 ? 6 : 0) },
+      4: { desc: "Jede fünfte Position erhält +8 Wert.",                          cardBonus: (c) => ((c.posInCycle + 1) % 5 === 0 ? 8 : 0) },
+    },
+  },
+  B_INITIATIVE: {
+    id: "B_INITIATIVE", cat: "B", name: "Initiative", upgradeType: REPLACEMENT,
+    // Engine armiert den Gleichstands-Sieg über tieArmLosses (Niederlagen bis zur Armierung). IV gibt zusätzlich
+    // der nächsten Karte +2 Wert (cardBonus über lostLastTrick). III „+1 bei Gleichstand" = ebenfalls Gleichstand-Sieg.
+    tiers: {
+      1: { desc: "Nach zwei Niederlagen gewinnst du den nächsten Gleichstand.", tieArmLosses: 2 },
+      2: { desc: "Nach einer Niederlage gewinnst du den nächsten Gleichstand.", tieArmLosses: 1 },
+      3: { desc: "Nach einer Niederlage gewinnst du den nächsten Gleichstand (die nächste Karte zählt bei Gleichstand als +1).", tieArmLosses: 1 },
+      4: { desc: "Nach einer Niederlage erhält die nächste Karte +2 Wert und gewinnt den nächsten Gleichstand.", tieArmLosses: 1, cardBonus: (c) => (c.lostLastTrick ? 2 : 0) },
+    },
+  },
+  B_TIGHT: {
+    id: "B_TIGHT", cat: "B", name: "Knappe Kiste", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Liegt die Karte in einer Wiederholung, erhält sie +1 temporären Wert.",          cardBonus: (c) => (inRepeat(c) ? 1 : 0) },
+      2: { desc: "Liegt die Karte in einer Wiederholung, erhält sie +2 temporären Wert.",          cardBonus: (c) => (inRepeat(c) ? 2 : 0) },
+      3: { desc: "Liegt die Karte in mindestens einer Formation, erhält sie +2 temporären Wert.",  cardBonus: (c) => (inAnyFormation(c) ? 2 : 0) },
+      4: { desc: "Liegt die Karte in mindestens einer Formation, erhält sie +3 temporären Wert.",  cardBonus: (c) => (inAnyFormation(c) ? 3 : 0) },
+    },
+  },
+  B_BREAKTHROUGH: {
+    id: "B_BREAKTHROUGH", cat: "B", name: "Durchbruch", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Nach 6 Stichen ohne Sieg erhält die nächste Karte +7 Wert.",  cardBonus: (c) => ((c.sinceWin || 0) >= 6 ? 7 : 0) },
+      2: { desc: "Nach 5 Stichen ohne Sieg erhält die nächste Karte +10 Wert.", cardBonus: (c) => ((c.sinceWin || 0) >= 5 ? 10 : 0) },
+      3: { desc: "Nach 4 Stichen ohne Sieg erhält die nächste Karte +12 Wert.", cardBonus: (c) => ((c.sinceWin || 0) >= 4 ? 12 : 0) },
+      4: { desc: "Nach 3 Stichen ohne Sieg erhält die nächste Karte +15 Wert.", cardBonus: (c) => ((c.sinceWin || 0) >= 3 ? 15 : 0) },
+    },
+  },
+  B_REVENGE: {
+    id: "B_REVENGE", cat: "B", name: "Revanche", upgradeType: REPLACEMENT,
+    // I/II/IV: einfacher cardBonus über lossStreak. III: die nächsten ZWEI Karten je +6 (Engine armiert die
+    // successorQueue, wenn lossStreak GENAU die Schwelle erreicht — revengeTwoCard {losses, bonus, count}).
+    tiers: {
+      1: { desc: "Nach drei Niederlagen in Folge erhält die nächste Karte +6 Wert.", cardBonus: (c) => ((c.lossStreak || 0) >= 3 ? 6 : 0) },
+      2: { desc: "Nach zwei Niederlagen in Folge erhält die nächste Karte +7 Wert.", cardBonus: (c) => ((c.lossStreak || 0) >= 2 ? 7 : 0) },
+      3: { desc: "Nach zwei Niederlagen in Folge erhalten die nächsten zwei Karten je +6 Wert.", revengeTwoCard: { losses: 2, bonus: 6, count: 2 } },
+      4: { desc: "Nach jeder Niederlage erhält die nächste Karte +8 Wert.", cardBonus: (c) => ((c.lossStreak || 0) >= 1 ? 8 : 0) },
+    },
+  },
+  B_PERFECT: {
+    id: "B_PERFECT", cat: "B", name: "Perfekte Folge", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Treppenkarten erhalten ab der dritten Karte +1, danach +2 temporären Wert.", cardBonus: (c) => stairBonus(c, [0, 0, 1], 2) },
+      2: { desc: "Treppenkarten erhalten +1/+2/+3, danach +4 temporären Wert.",                cardBonus: (c) => stairBonus(c, [1, 2, 3], 4) },
+      3: { desc: "Treppenkarten erhalten +2/+3/+4, danach +5 temporären Wert.",                cardBonus: (c) => stairBonus(c, [2, 3, 4], 5) },
+      4: { desc: "Treppenkarten erhalten +3/+4/+5, danach +6 temporären Wert.",                cardBonus: (c) => stairBonus(c, [3, 4, 5], 6) },
+    },
+  },
+  B_SUPERIOR: {
+    id: "B_SUPERIOR", cat: "B", name: "Überzahl", upgradeType: REPLACEMENT,
+    // Vergleich des DAUERWERTS (pValueBase) mit dem des direkten Vorgängers (predValue). Pos 0 (kein Vorgänger) → 0.
+    tiers: {
+      1: { desc: "Ist der Dauerwert mindestens 2 höher als der des Vorgängers, +2 temporärer Wert.", cardBonus: (c) => (c.predValue != null && c.pValueBase - c.predValue >= 2 ? 2 : 0) },
+      2: { desc: "Ist der Dauerwert höher als der des Vorgängers, +3 temporärer Wert.",              cardBonus: (c) => (c.predValue != null && c.pValueBase > c.predValue ? 3 : 0) },
+      3: { desc: "Ist der Dauerwert nicht niedriger als der des Vorgängers, +3 temporärer Wert.",    cardBonus: (c) => (c.predValue != null && c.pValueBase >= c.predValue ? 3 : 0) },
+      4: { desc: "Höher als der Vorgänger: +5; genau gleich: +2 temporärer Wert.",                   cardBonus: (c) => (c.predValue == null ? 0 : c.pValueBase > c.predValue ? 5 : c.pValueBase === c.predValue ? 2 : 0) },
+    },
+  },
+};
+
 export const FAMILY_DEFS = {
   ...D_FAMILIES,
+  ...B_FAMILIES,
 };
 
 export const FAMILY_LIST = Object.values(FAMILY_DEFS);

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -1,0 +1,251 @@
+import { UPGRADE_TYPES } from "./rarity.js";
+
+/* ============================================================
+   FAMILIEN-REGISTRY (Rarität-Umbau #163, Spec docs/rarity-system.md §3.2).
+   Reguläre Perks als aufwertbare FAMILIEN mit vier Stufen (I–IV). Legendäre (L1–L11) bleiben
+   im flachen PERK_DEFS und außerhalb dieses Systems.
+
+   Schema:
+     FAMILY_DEFS[familyId] = {
+       id, cat ∈ A/B/C/D/E, name, upgradeType ∈ UPGRADE_TYPES,
+       tiers: { 1: TierDef, 2: TierDef, 3: TierDef, 4: TierDef },
+     }
+   TierDef trägt `desc` + je nach Effektart Hooks/Marker (gleiche Shape wie die Perk-Hooks):
+     - replacement: nur der Hook der HÖCHSTEN gehaltenen Stufe ist aktiv (resolveActiveTier).
+       Score-Hooks: scoreFlat(ctx) / scoreFlatOnCrit(ctx) / scoreMult(ctx); Wert-Hook: cardBonus(ctx).
+       Engine-gekoppelte Stufen führen zusätzlich Daten-Parameter (z. B. misfireStep/misfireCap), die die
+       Engine bei der Umstellung liest — der Hook liefert den Primäreffekt.
+     - cumulative / role: folgen mit den A-/C-Familien (#163 Fortsetzung).
+
+   Diese Datei ist ADDITIV: sie wird von der Engine erst mit der schrittweisen Umstellung konsumiert
+   (Resolver unten). Reine Logik — kein Math.random / Date.
+   ============================================================ */
+
+const { REPLACEMENT } = UPGRADE_TYPES;
+
+// ---- D · Score (Spec §3.2 D) — allesamt Regelersetzung (nur die höchste Stufe ist aktiv). ----
+// Kontextfelder je Sieg (aus der Engine): winValue, margin, winStreak, wins, hasFormation, lastResult,
+// suitStreak, recentWinCount, lastWinValue, critFollowArmed, weaknessArmed, misfireScore, rawCrit.
+const D_FAMILIES = {
+  D_FORMATION_BONUS: {
+    id: "D_FORMATION_BONUS", cat: "D", name: "Punktebonus", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Ein Sieg mit mindestens einer aktiven Formation gibt +50 Score.",  scoreFlat: (c) => (c.hasFormation ? 50 : 0) },
+      2: { desc: "Ein Sieg mit mindestens einer aktiven Formation gibt +100 Score.", scoreFlat: (c) => (c.hasFormation ? 100 : 0) },
+      3: { desc: "Ein Sieg mit mindestens einer aktiven Formation gibt +175 Score.", scoreFlat: (c) => (c.hasFormation ? 175 : 0) },
+      4: { desc: "Ein Sieg mit mindestens einer aktiven Formation gibt +300 Score.", scoreFlat: (c) => (c.hasFormation ? 300 : 0) },
+    },
+  },
+  D_STREAK: {
+    id: "D_STREAK", cat: "D", name: "Siegesserie", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Jeder Sieg gibt +15 Score je Serienpunkt, maximal +150.", scoreFlat: (c) => Math.min(15 * (c.winStreak || 0), 150) },
+      2: { desc: "Jeder Sieg gibt +25 Score je Serienpunkt, maximal +250.", scoreFlat: (c) => Math.min(25 * (c.winStreak || 0), 250) },
+      3: { desc: "Jeder Sieg gibt +35 Score je Serienpunkt, maximal +420.", scoreFlat: (c) => Math.min(35 * (c.winStreak || 0), 420) },
+      4: { desc: "Jeder Sieg gibt +50 Score je Serienpunkt, maximal +750.", scoreFlat: (c) => Math.min(50 * (c.winStreak || 0), 750) },
+    },
+  },
+  D_HIGH: {
+    id: "D_HIGH", cat: "D", name: "Hohe Karten, hohe Belohnung", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Ein Sieg mit Kartenwert 9 oder höher gibt +100 Score.", scoreFlat: (c) => (c.winValue >= 9 ? 100 : 0) },
+      2: { desc: "Ein Sieg mit Kartenwert 8 oder höher gibt +150 Score.", scoreFlat: (c) => (c.winValue >= 8 ? 150 : 0) },
+      3: { desc: "Ein Sieg mit Kartenwert 7 oder höher gibt +225 Score.", scoreFlat: (c) => (c.winValue >= 7 ? 225 : 0) },
+      4: { desc: "Ein Sieg mit Kartenwert 6 oder höher gibt +350 Score.", scoreFlat: (c) => (c.winValue >= 6 ? 350 : 0) },
+    },
+  },
+  D_UNDERDOG: {
+    id: "D_UNDERDOG", cat: "D", name: "Außenseitersieg", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Ein Sieg mit Kartenwert 2 oder niedriger gibt +250 Score.", scoreFlat: (c) => (c.winValue <= 2 ? 250 : 0) },
+      2: { desc: "Ein Sieg mit Kartenwert 3 oder niedriger gibt +350 Score.", scoreFlat: (c) => (c.winValue <= 3 ? 350 : 0) },
+      3: { desc: "Ein Sieg mit Kartenwert 4 oder niedriger gibt +500 Score.", scoreFlat: (c) => (c.winValue <= 4 ? 500 : 0) },
+      4: { desc: "Ein Sieg mit Kartenwert 5 oder niedriger gibt +750 Score.", scoreFlat: (c) => (c.winValue <= 5 ? 750 : 0) },
+    },
+  },
+  D_TENTH_WIN: {
+    id: "D_TENTH_WIN", cat: "D", name: "Zehnter Sieg", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Jeder 12. gewonnene Stich gibt +600 Score.",  scoreFlat: (c) => (c.wins % 12 === 0 ? 600 : 0) },
+      2: { desc: "Jeder 10. gewonnene Stich gibt +800 Score.",  scoreFlat: (c) => (c.wins % 10 === 0 ? 800 : 0) },
+      3: { desc: "Jeder 8. gewonnene Stich gibt +900 Score.",   scoreFlat: (c) => (c.wins % 8 === 0 ? 900 : 0) },
+      4: { desc: "Jeder 5. gewonnene Stich gibt +1.000 Score.", scoreFlat: (c) => (c.wins % 5 === 0 ? 1000 : 0) },
+    },
+  },
+  D_CRIT_SCORE: {
+    id: "D_CRIT_SCORE", cat: "D", name: "Kritische Chance", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Jeder Crit gibt +100 Score.", scoreFlatOnCrit: () => 100 },
+      2: { desc: "Jeder Crit gibt +175 Score.", scoreFlatOnCrit: () => 175 },
+      3: { desc: "Jeder Crit gibt +275 Score.", scoreFlatOnCrit: () => 275 },
+      4: { desc: "Jeder Crit gibt +450 Score.", scoreFlatOnCrit: () => 450 },
+    },
+  },
+  D_SHARP_EYE: {
+    id: "D_SHARP_EYE", cat: "D", name: "Geschärfter Blick", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Ein Crit mit Kartenwert 9 oder höher gibt +225 Score.", scoreFlatOnCrit: (c) => (c.winValue >= 9 ? 225 : 0) },
+      2: { desc: "Ein Crit mit Kartenwert 8 oder höher gibt +350 Score.", scoreFlatOnCrit: (c) => (c.winValue >= 8 ? 350 : 0) },
+      3: { desc: "Ein Crit mit Kartenwert 7 oder höher gibt +500 Score.", scoreFlatOnCrit: (c) => (c.winValue >= 7 ? 500 : 0) },
+      4: { desc: "Ein Crit mit Kartenwert 6 oder höher gibt +750 Score.", scoreFlatOnCrit: (c) => (c.winValue >= 6 ? 750 : 0) },
+    },
+  },
+  D_CRIT_MOMENTUM: {
+    id: "D_CRIT_MOMENTUM", cat: "D", name: "Kritisches Momentum", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Jeder Crit in einer Serie ab 3 gibt +150 Score.",       scoreFlatOnCrit: (c) => ((c.winStreak || 0) >= 3 ? 150 : 0) },
+      2: { desc: "Jeder Crit in einer Serie ab 2 gibt +250 Score.",       scoreFlatOnCrit: (c) => ((c.winStreak || 0) >= 2 ? 250 : 0) },
+      3: { desc: "Jeder Crit innerhalb einer Serie gibt +350 Score.",     scoreFlatOnCrit: (c) => ((c.winStreak || 0) >= 1 ? 350 : 0) },
+      // IV: zusätzlich steigt die Serie um 1 (Engine-Extra, liest streakGainOnCrit bei der Umstellung).
+      4: { desc: "Jeder Crit innerhalb einer Serie gibt +500 Score; die Serie steigt zusätzlich um 1.", scoreFlatOnCrit: (c) => ((c.winStreak || 0) >= 1 ? 500 : 0), streakGainOnCrit: 1 },
+    },
+  },
+  D_RHYTHM: {
+    id: "D_RHYTHM", cat: "D", name: "Perfekter Rhythmus", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Jeder 7. gewonnene Stich gibt +250 Score.", scoreFlat: (c) => (c.wins % 7 === 0 ? 250 : 0) },
+      2: { desc: "Jeder 5. gewonnene Stich gibt +350 Score.", scoreFlat: (c) => (c.wins % 5 === 0 ? 350 : 0) },
+      3: { desc: "Jeder 4. gewonnene Stich gibt +450 Score.", scoreFlat: (c) => (c.wins % 4 === 0 ? 450 : 0) },
+      4: { desc: "Jeder 3. gewonnene Stich gibt +600 Score.", scoreFlat: (c) => (c.wins % 3 === 0 ? 600 : 0) },
+    },
+  },
+  D_OVERPOWER: {
+    id: "D_OVERPOWER", cat: "D", name: "Übermacht", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Ein Sieg mit mindestens 10 Wertpunkten Vorsprung gibt +300 Score.", scoreFlat: (c) => (c.margin >= 10 ? 300 : 0) },
+      2: { desc: "Ein Sieg mit mindestens 8 Wertpunkten Vorsprung gibt +400 Score.",  scoreFlat: (c) => (c.margin >= 8 ? 400 : 0) },
+      3: { desc: "Ein Sieg mit mindestens 6 Wertpunkten Vorsprung gibt +550 Score.",  scoreFlat: (c) => (c.margin >= 6 ? 550 : 0) },
+      4: { desc: "Ein Sieg mit mindestens 4 Wertpunkten Vorsprung gibt +750 Score.",  scoreFlat: (c) => (c.margin >= 4 ? 750 : 0) },
+    },
+  },
+  D_CRIT_HARVEST: {
+    id: "D_CRIT_HARVEST", cat: "D", name: "Kritische Ernte", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Ein Crit mit einer Karte in mindestens einer aktiven Formation gibt +175 Score.", scoreFlatOnCrit: (c) => (c.hasFormation ? 175 : 0) },
+      2: { desc: "Ein Crit mit einer Karte in mindestens einer aktiven Formation gibt +300 Score.", scoreFlatOnCrit: (c) => (c.hasFormation ? 300 : 0) },
+      3: { desc: "Ein Crit mit einer Karte in mindestens einer aktiven Formation gibt +475 Score.", scoreFlatOnCrit: (c) => (c.hasFormation ? 475 : 0) },
+      4: { desc: "Ein Crit mit einer Karte in mindestens einer aktiven Formation gibt +750 Score.", scoreFlatOnCrit: (c) => (c.hasFormation ? 750 : 0) },
+    },
+  },
+  D_PRECISION: {
+    id: "D_PRECISION", cat: "D", name: "Präzision", upgradeType: REPLACEMENT,
+    // I/II: exakt gleicher Wert wie der letzte Sieg. III/IV: gleicher oder ±1 Wert. (IV-Kette: Engine-Extra.)
+    tiers: {
+      1: { desc: "Zwei aufeinanderfolgende Siege mit demselben Kartenwert geben dem zweiten +250 Score.",        scoreFlat: (c) => (c.lastWinValue != null && c.winValue === c.lastWinValue ? 250 : 0) },
+      2: { desc: "Zwei aufeinanderfolgende Siege mit demselben Kartenwert geben dem zweiten +450 Score.",        scoreFlat: (c) => (c.lastWinValue != null && c.winValue === c.lastWinValue ? 450 : 0) },
+      3: { desc: "Zwei aufeinanderfolgende Siege mit gleichem oder um 1 abweichendem Wert geben +550 Score.",    scoreFlat: (c) => (c.lastWinValue != null && Math.abs(c.winValue - c.lastWinValue) <= 1 ? 550 : 0) },
+      4: { desc: "Zwei aufeinanderfolgende Siege mit gleichem oder um 1 abweichendem Wert geben +800 Score; die Kette kann weiterlaufen.", scoreFlat: (c) => (c.lastWinValue != null && Math.abs(c.winValue - c.lastWinValue) <= 1 ? 800 : 0), chain: true },
+    },
+  },
+  D_INTERPLAY: {
+    id: "D_INTERPLAY", cat: "D", name: "Wechselspiel", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Ein Sieg direkt nach einer Niederlage gibt +150 Score.", scoreFlat: (c) => (c.lastResult === "loss" ? 150 : 0) },
+      2: { desc: "Ein Sieg direkt nach einer Niederlage gibt +275 Score.", scoreFlat: (c) => (c.lastResult === "loss" ? 275 : 0) },
+      3: { desc: "Ein Sieg direkt nach einer Niederlage gibt +450 Score.", scoreFlat: (c) => (c.lastResult === "loss" ? 450 : 0) },
+      // IV: zusätzlich gibt die nächste Niederlage +200 gespeicherten Score (Engine-Extra storeOnLoss).
+      4: { desc: "Ein Sieg direkt nach einer Niederlage gibt +700 Score; die nächste Niederlage gibt +200 gespeicherten Score.", scoreFlat: (c) => (c.lastResult === "loss" ? 700 : 0), storeOnLoss: 200 },
+    },
+  },
+  D_CRIT_FOLLOW: {
+    id: "D_CRIT_FOLLOW", cat: "D", name: "Crit-Folge", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Ein Sieg direkt nach einem Crit gibt +150 Score.", scoreFlat: (c) => (c.critFollowArmed ? 150 : 0) },
+      2: { desc: "Ein Sieg direkt nach einem Crit gibt +275 Score.", scoreFlat: (c) => (c.critFollowArmed ? 275 : 0) },
+      3: { desc: "Ein Sieg direkt nach einem Crit gibt +450 Score.", scoreFlat: (c) => (c.critFollowArmed ? 450 : 0) },
+      // IV: ist der Folgesieg selbst ein Crit, zusätzlich +300 (Engine-Extra critFollowCritBonus).
+      4: { desc: "Ein Sieg direkt nach einem Crit gibt +700 Score; ist der Folgesieg ebenfalls ein Crit, zusätzlich +300.", scoreFlat: (c) => (c.critFollowArmed ? 700 : 0), critFollowCritBonus: 300 },
+    },
+  },
+  D_MISFIRE: {
+    id: "D_MISFIRE", cat: "D", name: "Fehlzündung", upgradeType: REPLACEMENT,
+    // Ladung wird in der Engine geführt (misfireScore); Stufe legt Schritt & Cap fest (Engine liest misfireStep/misfireCap).
+    tiers: {
+      1: { desc: "Jeder Sieg ohne Crit lädt +20 Score für den nächsten Crit auf (max +200).", scoreFlatOnCrit: (c) => (c.misfireScore || 0), misfireStep: 20, misfireCap: 200 },
+      2: { desc: "Jeder Sieg ohne Crit lädt +35 Score für den nächsten Crit auf (max +350).", scoreFlatOnCrit: (c) => (c.misfireScore || 0), misfireStep: 35, misfireCap: 350 },
+      3: { desc: "Jeder Sieg ohne Crit lädt +50 Score für den nächsten Crit auf (max +500).", scoreFlatOnCrit: (c) => (c.misfireScore || 0), misfireStep: 50, misfireCap: 500 },
+      4: { desc: "Jeder Sieg ohne Crit lädt +75 Score auf (max +750); nach einem Crit bleiben 25 % der Ladung erhalten.", scoreFlatOnCrit: (c) => (c.misfireScore || 0), misfireStep: 75, misfireCap: 750, misfireRetain: 0.25 },
+    },
+  },
+  D_WEAKNESS: {
+    id: "D_WEAKNESS", cat: "D", name: "Schwachstellenanalyse", upgradeType: REPLACEMENT,
+    // Armierung läuft in der Engine (weaknessArmed) über die Abstand-Schwelle (Engine liest weaknessDeficit).
+    tiers: {
+      1: { desc: "Nach einer Niederlage mit mindestens 7 Wertpunkten Abstand gibt der nächste Sieg +250 Score.", scoreFlat: (c) => (c.weaknessArmed ? 250 : 0), weaknessDeficit: 7 },
+      2: { desc: "Nach einer Niederlage mit mindestens 5 Wertpunkten Abstand gibt der nächste Sieg +350 Score.", scoreFlat: (c) => (c.weaknessArmed ? 350 : 0), weaknessDeficit: 5 },
+      3: { desc: "Nach einer Niederlage mit mindestens 4 Wertpunkten Abstand gibt der nächste Sieg +500 Score.", scoreFlat: (c) => (c.weaknessArmed ? 500 : 0), weaknessDeficit: 4 },
+      4: { desc: "Nach jeder Niederlage gibt der nächste Sieg +600 Score; bei mindestens 5 Wertpunkten Abstand +900.", scoreFlat: (c) => (c.weaknessArmed ? (c.weaknessBig ? 900 : 600) : 0), weaknessDeficit: 0, weaknessBigDeficit: 5 },
+    },
+  },
+  D_SUIT_STREAK: {
+    id: "D_SUIT_STREAK", cat: "D", name: "Farbserie", upgradeType: REPLACEMENT,
+    // suitStreak wird in der Engine geführt; Stufe legt Schritt & Cap fest (Engine liest suitStep/suitCap/suitHalveOnSwitch).
+    tiers: {
+      1: { desc: "Aufeinanderfolgende Siege derselben Farbe geben je +75 mehr Score, maximal +300.",  scoreFlat: (c) => Math.min(Math.max(0, ((c.suitStreak || 0) - 1) * 75), 300),  suitStep: 75, suitCap: 300 },
+      2: { desc: "Aufeinanderfolgende Siege derselben Farbe geben je +100 mehr Score, maximal +500.", scoreFlat: (c) => Math.min(Math.max(0, ((c.suitStreak || 0) - 1) * 100), 500), suitStep: 100, suitCap: 500 },
+      3: { desc: "Aufeinanderfolgende Siege derselben Farbe geben je +150 mehr Score, maximal +750.", scoreFlat: (c) => Math.min(Math.max(0, ((c.suitStreak || 0) - 1) * 150), 750), suitStep: 150, suitCap: 750 },
+      4: { desc: "Aufeinanderfolgende Siege derselben Farbe geben je +200 mehr Score, maximal +1.200; ein Farbwechsel halbiert die Stufe statt sie zurückzusetzen.", scoreFlat: (c) => Math.min(Math.max(0, ((c.suitStreak || 0) - 1) * 200), 1200), suitStep: 200, suitCap: 1200, suitHalveOnSwitch: true },
+    },
+  },
+  D_FULL_HOUSE: {
+    id: "D_FULL_HOUSE", cat: "D", name: "Volles Haus", upgradeType: REPLACEMENT,
+    // Zählt die letzte Position eines Segments (posInCycle%5===4) + recentWinCount der Siege davor.
+    tiers: {
+      1: { desc: "Fünf Siege innerhalb desselben Segments geben dem fünften Sieg +500 Score.",  scoreFlat: (c) => (c.posInCycle % 5 === 4 && (c.recentWinCount || 0) >= 4 ? 500 : 0) },
+      2: { desc: "Vier Siege innerhalb desselben Segments geben dem vierten Sieg +650 Score.",  scoreFlat: (c) => (c.posInCycle % 5 === 3 && (c.recentWinCount || 0) >= 3 ? 650 : 0) },
+      3: { desc: "Vier Siege innerhalb desselben Segments geben dem vierten Sieg +900 Score.",  scoreFlat: (c) => (c.posInCycle % 5 === 3 && (c.recentWinCount || 0) >= 3 ? 900 : 0) },
+      4: { desc: "Drei Siege im Segment geben dem dritten +1.000 Score; der fünfte Sieg zusätzlich +1.000.", scoreFlat: (c) => ((c.posInCycle % 5 === 2 && (c.recentWinCount || 0) >= 2 ? 1000 : 0) + (c.posInCycle % 5 === 4 && (c.recentWinCount || 0) >= 4 ? 1000 : 0)) },
+    },
+  },
+  D_OVERCRIT: {
+    id: "D_OVERCRIT", cat: "D", name: "Überschusskrit", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Ein Crit über 110 % effektiver Crit-Chance gibt +200 Score.", scoreFlatOnCrit: (c) => ((c.rawCrit || 0) > 1.1 ? 200 : 0) },
+      2: { desc: "Ein Crit über 100 % effektiver Crit-Chance gibt +300 Score.", scoreFlatOnCrit: (c) => ((c.rawCrit || 0) > 1 ? 300 : 0) },
+      3: { desc: "Jeder Überschuss-Crit (über 100 %) gibt +500 Score.",         scoreFlatOnCrit: (c) => ((c.rawCrit || 0) > 1 ? 500 : 0) },
+      4: { desc: "Jeder Überschuss-Crit gibt +500 Score plus 5 Score je Prozentpunkt über 100 %.", scoreFlatOnCrit: (c) => ((c.rawCrit || 0) > 1 ? 500 + Math.round(((c.rawCrit || 0) - 1) * 100) * 5 : 0) },
+    },
+  },
+};
+
+export const FAMILY_DEFS = {
+  ...D_FAMILIES,
+};
+
+export const FAMILY_LIST = Object.values(FAMILY_DEFS);
+export const familyDef = (id) => FAMILY_DEFS[id] || null;
+export const familyCategory = (id) => FAMILY_DEFS[id]?.cat || null;
+
+/* ---- Resolver (Engine-Brücke) ---- */
+
+// Aktive Stufen-Definition einer gehaltenen Familie. Bei `replacement` ist NUR die höchste gehaltene
+// Stufe aktiv (Spec §2.3). `familyTiers` = { [familyId]: currentTier }. Null, wenn nicht gehalten.
+export function activeTierDef(familyId, tier) {
+  const fam = FAMILY_DEFS[familyId];
+  if (!fam || !tier) return null;
+  return fam.tiers[tier] || null;
+}
+
+// Alle aktiven Stufen-Defs (eine je gehaltener Familie) — die Liste, über die die Engine ihre Hooks summiert.
+export function activeTierDefs(familyTiers = {}) {
+  const out = [];
+  for (const [id, tier] of Object.entries(familyTiers)) {
+    const def = activeTierDef(id, tier);
+    if (def) out.push(def);
+  }
+  return out;
+}
+
+// Summe eines additiven Hooks (cardBonus/scoreFlat/scoreFlatOnCrit) über die aktiven Stufen-Defs.
+export function familySumHook(familyTiers, name, ctx) {
+  let t = 0;
+  for (const def of activeTierDefs(familyTiers)) { const f = def[name]; if (f) t += f(ctx); }
+  return t;
+}
+
+// Produkt eines multiplikativen Hooks (scoreMult) über die aktiven Stufen-Defs.
+export function familyProdHook(familyTiers, name, ctx) {
+  let m = 1;
+  for (const def of activeTierDefs(familyTiers)) { const f = def[name]; if (f) m *= f(ctx); }
+  return m;
+}

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -585,11 +585,113 @@ const C_FAMILIES = {
   },
 };
 
+// ---- E · Form (Spec §3.2 E) — Formationswerkzeuge, allesamt REGELERSETZUNG (nur die höchste Stufe aktiv).
+//      Reine Erkennungsregeln: kein per-Stich/-Sieg-Hook, sondern PARAMETER, die computeFormations je gehaltener
+//      E-Familie ausliest (familyTiers-bewusst, Schritt 2 — analog jokerRole/bridgeRole). Marker je Stufe:
+//        gapRun/gapSeg  → erlaubte fremde Karten je Lauf / je Segment (E_PACE Wiederholung, E_COLORBRIDGE Farbblock)
+//        eqRun/eqSeg    → erlaubte Gleichstände in Treppen (E_GENTLE); revRun/revSeg → Rückschritte (E_BIGSTEP)
+//        wMinLen/wMinDiff/wFactorStart → Wechsel-Schwellen/-Faktor (E_PENDULUM)
+//        drehSeg        → Karten, die je Segment zu zwei Treppen zählen dürfen (E_RPM)
+//        anchor {at(pos,n),factor,value} → Anker-Positionen/-Faktor/+Wert (E_LOSS, E_QUICKSHOT)
+//        openBoundaries → Anzahl offener Segmentgrenzen (E_SEGMENT; Infinity = alle)
+//      §10-Näherungen (der paarweise/laufbasierte Scanner kann einige IV-Sonderregeln nicht exakt abbilden):
+//        E_GENTLE IV „gleich = +1 Schritt" ≈ unbegrenzte Gleichstände; E_BIGSTEP IV „Richtung einmal wechseln"
+//        ≈ unbegrenzte Rückschritte; E_RPM I/II per-Segment-Budget 1 (mechanisch gleich); E_SEGMENT I/II öffnen
+//        die ersten 1/2 Grenzen deterministisch (statt Auswahl → kein zusätzlicher Ziel-Fluss), III/IV alle.
+const INF = Infinity;
+const ANKER = 1.25; // Standard-Anker-Faktor (= ANCHOR_FORM_FACTOR/ANKER_FACTOR in constants/formations); IV hebt auf 1,35.
+const E_FAMILIES = {
+  E_PACE: {
+    id: "E_PACE", cat: "E", name: "Schrittmacher", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Einmal pro Segment darf eine Wiederholung eine fremde Karte überbrücken.", gapRun: 1, gapSeg: 1 },
+      2: { desc: "Jede Wiederholung darf eine fremde Karte überbrücken.",                      gapRun: 1, gapSeg: INF },
+      3: { desc: "Jede Wiederholung darf bis zu zwei fremde Karten überbrücken.",              gapRun: 2, gapSeg: INF },
+      4: { desc: "Fremde Karten unterbrechen Wiederholungen nicht (zählen aber nicht mit).",   gapRun: INF, gapSeg: INF },
+    },
+  },
+  E_COLORBRIDGE: {
+    id: "E_COLORBRIDGE", cat: "E", name: "Farbbrücke", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Einmal pro Segment darf ein Farbblock eine Fremdfarbe überbrücken.", suitGapRun: 1, suitGapSeg: 1 },
+      2: { desc: "Jeder Farbblock darf eine Fremdfarbe enthalten.",                    suitGapRun: 1, suitGapSeg: INF },
+      3: { desc: "Jeder Farbblock darf zwei Fremdfarben enthalten.",                   suitGapRun: 2, suitGapSeg: INF },
+      4: { desc: "Fremdfarben unterbrechen Farbblöcke nicht (zählen aber nicht mit).", suitGapRun: INF, suitGapSeg: INF },
+    },
+  },
+  E_GENTLE: {
+    id: "E_GENTLE", cat: "E", name: "Sanfter Anstieg", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Einmal pro Segment darf eine Treppe einen Gleichstand enthalten.", eqRun: 1, eqSeg: 1 },
+      2: { desc: "Jede Treppe darf einen Gleichstand enthalten.",                     eqRun: 1, eqSeg: INF },
+      3: { desc: "Jede Treppe darf zwei Gleichstände enthalten.",                     eqRun: 2, eqSeg: INF },
+      4: { desc: "Gleiche Werte gelten in Treppen als ein Schritt, wenn nötig.",      eqRun: INF, eqSeg: INF },
+    },
+  },
+  E_BIGSTEP: {
+    id: "E_BIGSTEP", cat: "E", name: "Großer Schritt", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Einmal pro Segment darf eine Treppe einen Rückschritt enthalten.", revRun: 1, revSeg: 1 },
+      2: { desc: "Jede Treppe darf einen Rückschritt enthalten.",                     revRun: 1, revSeg: INF },
+      3: { desc: "Jede Treppe darf zwei Rückschritte enthalten.",                     revRun: 2, revSeg: INF },
+      4: { desc: "Treppen dürfen die Richtung wechseln.",                             revRun: INF, revSeg: INF },
+    },
+  },
+  E_PENDULUM: {
+    id: "E_PENDULUM", cat: "E", name: "Pendelwerk", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Wechsel bilden sich ab 3 Karten (Mindestdifferenz 3).",                       wMinLen: 3, wMinDiff: 3 },
+      2: { desc: "Wechsel bilden sich ab 2 Karten (Mindestdifferenz 4).",                        wMinLen: 2, wMinDiff: 4 },
+      3: { desc: "Wechsel bilden sich ab 2 Karten (Mindestdifferenz 3).",                        wMinLen: 2, wMinDiff: 3 },
+      4: { desc: "Wechsel bilden sich ab 2 Karten (Mindestdifferenz 2); der Faktor startet bei ×1,35.", wMinLen: 2, wMinDiff: 2, wFactorStart: 1.35 },
+    },
+  },
+  E_RPM: {
+    id: "E_RPM", cat: "E", name: "Drehzahl", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Einmal pro Segment darf eine Karte zu zwei Treppen gehören.", drehSeg: 1 },
+      2: { desc: "Je Treppe darf eine Karte zu einer weiteren Treppe gehören.",  drehSeg: 1 },
+      3: { desc: "Bis zu zwei Karten pro Segment dürfen zu zwei Treppen gehören.", drehSeg: 2 },
+      4: { desc: "Jede Karte darf gleichzeitig zu zwei Treppen gehören.",         drehSeg: INF },
+    },
+  },
+  E_LOSS: {
+    id: "E_LOSS", cat: "E", name: "Kontrollverlust", upgradeType: REPLACEMENT,
+    // Anker auf „geraden" Positionen (10er-Raster). III/IV: jede Segment-Endposition; IV zusätzlich ×1,35.
+    tiers: {
+      1: { desc: "Die Positionen 20 und 40 sind Anker (siegreicher Anker ×1,25).",       anchor: { at: (p) => (p + 1) % 20 === 0, factor: ANKER, value: 0 } },
+      2: { desc: "Die Positionen 10, 20, 30 und 40 sind Anker.",                          anchor: { at: (p) => (p + 1) % 10 === 0, factor: ANKER, value: 0 } },
+      3: { desc: "Jede Segment-Endposition ist ein Anker.",                               anchor: { at: (p) => (p + 1) % 5 === 0, factor: ANKER, value: 0 } },
+      4: { desc: "Jede Segment-Endposition ist ein ×1,35-Anker.",                         anchor: { at: (p) => (p + 1) % 5 === 0, factor: 1.35, value: 0 } },
+    },
+  },
+  E_QUICKSHOT: {
+    id: "E_QUICKSHOT", cat: "E", name: "Schnellschuss", upgradeType: REPLACEMENT,
+    // Anker auf „ungeraden" Positionen (5er-Versatz). IV: jede fünfte Position ×1,35 und +2 Wert.
+    tiers: {
+      1: { desc: "Die Positionen 5 und 25 sind Anker (siegreicher Anker ×1,25).", anchor: { at: (p) => (p - 4) % 20 === 0, factor: ANKER, value: 0 } },
+      2: { desc: "Die Positionen 5, 15, 25 und 35 sind Anker.",                    anchor: { at: (p) => (p - 4) % 10 === 0, factor: ANKER, value: 0 } },
+      3: { desc: "Jede fünfte Position (5, 10, … 40) ist ein Anker.",              anchor: { at: (p) => (p + 1) % 5 === 0, factor: ANKER, value: 0 } },
+      4: { desc: "Jede fünfte Position ist ein ×1,35-Anker und erhält +2 Wert.",   anchor: { at: (p) => (p + 1) % 5 === 0, factor: 1.35, value: 2 } },
+    },
+  },
+  E_SEGMENT: {
+    id: "E_SEGMENT", cat: "E", name: "Segmentarbeit", upgradeType: REPLACEMENT,
+    tiers: {
+      1: { desc: "Eine Segmentgrenze ist offen; Formationen dürfen sie überschreiten.", openBoundaries: 1 },
+      2: { desc: "Zwei Segmentgrenzen sind offen.",                                      openBoundaries: 2 },
+      3: { desc: "Alle Segmentgrenzen sind offen.",                                      openBoundaries: INF },
+      4: { desc: "Alle Segmentgrenzen sind offen; Formationen laufen ohne Einschränkung weiter.", openBoundaries: INF },
+    },
+  },
+};
+
 export const FAMILY_DEFS = {
   ...D_FAMILIES,
   ...B_FAMILIES,
   ...A_FAMILIES,
   ...C_FAMILIES,
+  ...E_FAMILIES,
 };
 
 export const FAMILY_LIST = Object.values(FAMILY_DEFS);

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -616,6 +616,17 @@ export function activeTierDefs(familyTiers = {}) {
   return out;
 }
 
+// Wie activeTierDefs, aber mit familyId je Eintrag — für engine-/formationsseitige Marker, die die Familie
+// KENNEN müssen (relay/triumph über isRole(familyId), segmentLow-Gate, jokerRole/bridgeRole in computeFormations).
+export function activeFamilyEntries(familyTiers = {}) {
+  const out = [];
+  for (const [id, tier] of Object.entries(familyTiers || {})) {
+    const def = activeTierDef(id, tier);
+    if (def) out.push({ familyId: id, def });
+  }
+  return out;
+}
+
 // Engine-Parameter der aktiven Stufe einer Familie (z. B. misfireStep/weaknessDeficit/suitHalveOnSwitch).
 // undefined, wenn die Familie nicht gehalten wird oder die Stufe den Parameter nicht führt → der Aufrufer
 // (Engine) fällt dann auf seinen Default zurück (Rückwärtskompatibilität zu den flachen D-Perks).

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -653,10 +653,18 @@ export function applyFamilyPick(familyId, targetTier, ctx = {}, rng = Math.rando
   const tierDef = fam.tiers[targetTier] || null;
   let nextDeck = deck, nextRoles = roles;
   if (fam.upgradeType === UPGRADE_TYPES.CUMULATIVE && tierDef && tierDef.onPick && deck) {
-    // Stufen-Paket einmalig aufs Deck (A-/Shop-Karten-Familien). `target` trägt die Spieler-Auswahl
-    // (z. B. Farbe(n)) der Stufen mit `pickTarget`; ohne Ziel-Flow ist es null → diese Stufen sind No-Ops.
+    // Stufen-Paket einmalig aufs Deck (A-/Shop-Karten-Familien, C_SACRIFICE). `target` trägt die Spieler-Auswahl
+    // (Farbe(n) bzw. Karten + order=playerOrder); ohne Ziel-Flow ist es null → diese Stufen sind No-Ops.
     nextDeck = tierDef.onPick(deck, rng, target);
+  } else if (fam.upgradeType === UPGRADE_TYPES.ROLE) {
+    // Rolle (Kat. C): gewählte Ziel-Karten in roles[familyId]. Upgrade BEHÄLT bestehende Ziele, nur die
+    // zusätzlich gewählten kommen dazu (Spec §2.3 Rollen-Upgrade); die aktive Regel/Werte löst die Engine
+    // live über die gehaltene Stufe auf. Ohne target (Upgrade ohne neue Ziele) bleiben die Rollen unverändert.
+    const chosen = (target && target.cards) || [];
+    const prev = (roles && roles[familyId]) || [];
+    const merged = prev.slice();
+    for (const id of chosen) if (!merged.includes(id)) merged.push(id);
+    nextRoles = { ...(roles || {}), [familyId]: merged };
   }
-  // ROLE-Zielauswahl folgt mit Kategorie C (#163) — hier noch reine Rangaktualisierung.
   return { familyTiers: withFamilyTier(familyTiers, familyId, targetTier), deck: nextDeck, roles: nextRoles };
 }

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -757,6 +757,25 @@ export function hasCritFamily(familyTiers) {
   return activeTierDefs(familyTiers).some((def) => !!def.scoreFlatOnCrit);
 }
 
+// Familien, deren Wirkung von Position/Reihenfolge/Nachbarschaft/Formation abhängt — für die Aufstellungshilfe (#166,
+// analog perks.LAYOUT_EXTRA). Kuratiert: die positions-/nachbarschafts-/segment-/formationsbezogenen C-/B-/D-Familien;
+// ALLE E-Formationswerkzeuge kommen über cat==="E" dazu.
+export const LAYOUT_FAMILY_IDS = new Set([
+  "C_VANGUARD", "C_GUARD", "C_RELAY", "C_LEADER", "C_FINISHER", "C_SURVIVOR", "C_JOKER", "C_BRIDGE", // Rollen an Position/Nachbar/Segment/Formation
+  "B_OPENING", "B_TENTH_STRIKE", "B_TIGHT", "B_PERFECT", "B_SUPERIOR",                                // positions-/formationsbezogene Stich-Familien
+  "D_FORMATION_BONUS", "D_CRIT_HARVEST", "D_FULL_HOUSE",                                              // formations-/segmentbezogene Score-Familien
+]);
+export const isLayoutFamily = (id) => LAYOUT_FAMILY_IDS.has(id) || FAMILY_DEFS[id]?.cat === "E";
+// Gehaltene Layout-Familien mit Anzeige-Daten (Name + römische Stufe + Beschreibung der aktiven Stufe).
+export function layoutFamilies(familyTiers) {
+  const out = [];
+  for (const [id, tier] of Object.entries(familyTiers || {})) {
+    const fam = FAMILY_DEFS[id];
+    if (fam && tier && isLayoutFamily(id)) out.push({ id, name: fam.name, tier, desc: (fam.tiers[tier] || {}).desc || "" });
+  }
+  return out;
+}
+
 /* Familien-Pick anwenden (Spec §2.4 applyFamilyPick). Reine Funktion: nimmt den relevanten Run-State-
    Ausschnitt und liefert das Patch { familyTiers, deck, roles }.
    - REPLACEMENT (Kat. B/C-Regel/D/E): NUR der Familienrang ändert sich; die aktive Regel löst die Engine

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -236,6 +236,14 @@ export function activeTierDefs(familyTiers = {}) {
   return out;
 }
 
+// Engine-Parameter der aktiven Stufe einer Familie (z. B. misfireStep/weaknessDeficit/suitHalveOnSwitch).
+// undefined, wenn die Familie nicht gehalten wird oder die Stufe den Parameter nicht führt → der Aufrufer
+// (Engine) fällt dann auf seinen Default zurück (Rückwärtskompatibilität zu den flachen D-Perks).
+export function familyTierParam(familyTiers, familyId, key) {
+  const def = activeTierDef(familyId, (familyTiers || {})[familyId]);
+  return def ? def[key] : undefined;
+}
+
 // Summe eines additiven Hooks (cardBonus/scoreFlat/scoreFlatOnCrit) über die aktiven Stufen-Defs.
 export function familySumHook(familyTiers, name, ctx) {
   let t = 0;

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -1,4 +1,6 @@
 import { UPGRADE_TYPES, withFamilyTier } from "./rarity.js";
+import { shuffle } from "./deck.js";
+import { SUIT_ORDER } from "./constants.js";
 
 /* ============================================================
    FAMILIEN-REGISTRY (Rarität-Umbau #163, Spec docs/rarity-system.md §3.2).
@@ -21,7 +23,7 @@ import { UPGRADE_TYPES, withFamilyTier } from "./rarity.js";
    (Resolver unten). Reine Logik — kein Math.random / Date.
    ============================================================ */
 
-const { REPLACEMENT } = UPGRADE_TYPES;
+const { REPLACEMENT, CUMULATIVE } = UPGRADE_TYPES;
 
 // ---- D · Score (Spec §3.2 D) — allesamt Regelersetzung (nur die höchste Stufe ist aktiv). ----
 // Kontextfelder je Sieg (aus der Engine): winValue, margin, winStreak, wins, hasFormation, lastResult,
@@ -320,9 +322,140 @@ const B_FAMILIES = {
   },
 };
 
+// ---- A · Deck (Spec §3.2 A) — KUMULATIVER Pick-Effekt: jede gewählte Stufe führt EINMALIG ihr Deck-Paket
+//      aus (tierDef.onPick, angewandt in applyFamilyPick), frühere Boni bleiben; im Build wird nur der höchste
+//      Rang angezeigt. Reine Deck-Mods (kein per-Stich-Hook) — Werte werden dauerhaft angehoben/gesenkt.
+//      onPick(deck, rng, target) → neues Deck. `pickTarget` markiert Stufen mit Spieler-Auswahl (Farbe(n));
+//      der Familien-Ziel-Flow (PICK_FAMILY → Ziel-Phase → CONFIRM) folgt mit Kategorie C. Ohne `target`
+//      lassen diese Stufen das Deck unverändert (defensiv — solange der Flow noch nicht existiert).
+const bumpWhere = (deck, pred, delta) =>
+  deck.map((c) => (pred(c) ? { ...c, value: Math.max(0, c.value + delta) } : c));
+// #71-Muster: die n Karten mit höchstem (dir="desc") bzw. niedrigstem (dir="asc") AKTUELLEN Wert je +delta.
+// Stabiler Sort (Ties nach Index) → deterministisch, kein rng.
+const bumpTopN = (deck, n, delta, dir) => {
+  const order = deck.map((_, i) => i).sort((a, b) =>
+    dir === "desc" ? deck[b].value - deck[a].value : deck[a].value - deck[b].value);
+  const pick = new Set(order.slice(0, n));
+  return deck.map((c, i) => (pick.has(i) ? { ...c, value: c.value + delta } : c));
+};
+// n zufällige Karten, die pred erfüllen, je +delta (deterministisch über injizierten rng).
+const bumpRandomWhere = (deck, pred, n, delta, rng) => {
+  const idx = deck.map((c, i) => [c, i]).filter(([c]) => pred(c)).map(([, i]) => i);
+  const chosen = new Set(shuffle(idx, rng).slice(0, n));
+  return deck.map((c, i) => (chosen.has(i) ? { ...c, value: Math.max(0, c.value + delta) } : c));
+};
+// Häufigkeit je AKTUELLEM Wert (A_CONDENSE — mehrfach vorkommende Wertgruppen).
+const valueCounts = (deck) => { const cnt = {}; for (const c of deck) cnt[c.value] = (cnt[c.value] || 0) + 1; return cnt; };
+// Farbduell: Gewinnerfarbe +up, Verliererfarbe +down (down negativ), alles auf >= 0 geklemmt.
+const suitDuel = (deck, up, down, upDelta, downDelta) =>
+  deck.map((c) => (c.suit === up ? { ...c, value: Math.max(0, c.value + upDelta) }
+    : c.suit === down ? { ...c, value: Math.max(0, c.value + downDelta) } : c));
+const randomSuit = (rng) => SUIT_ORDER[Math.floor(rng() * SUIT_ORDER.length)];
+
+const A_FAMILIES = {
+  A_WEAK_STRONG: {
+    id: "A_WEAK_STRONG", cat: "A", name: "Schwache Karten sind stark", upgradeType: CUMULATIVE,
+    // Stufen gehen vom ursprünglichen Wert 5 abwärts; je schwächer die Karten, desto höher der Bonus (Spec §3.3).
+    tiers: {
+      1: { desc: "Alle ursprünglichen 5er erhalten dauerhaft +1 Wert.", onPick: (d) => bumpWhere(d, (c) => c.baseRank === 5, 1) },
+      2: { desc: "Alle ursprünglichen 4er erhalten dauerhaft +2 Wert.", onPick: (d) => bumpWhere(d, (c) => c.baseRank === 4, 2) },
+      3: { desc: "Alle ursprünglichen 3er erhalten dauerhaft +3 Wert.", onPick: (d) => bumpWhere(d, (c) => c.baseRank === 3, 3) },
+      4: { desc: "Alle ursprünglichen 1er und 2er erhalten dauerhaft +4 Wert.", onPick: (d) => bumpWhere(d, (c) => c.baseRank <= 2, 4) },
+    },
+  },
+  A_EVEN: {
+    id: "A_EVEN", cat: "A", name: "Gerade Stärke", upgradeType: CUMULATIVE,
+    tiers: {
+      1: { desc: "Vier zufällige gerade Karten erhalten dauerhaft +1 Wert.", onPick: (d, rng) => bumpRandomWhere(d, (c) => c.value % 2 === 0, 4, 1, rng) },
+      2: { desc: "Alle ursprünglichen 2er und 8er erhalten dauerhaft +1 Wert.", onPick: (d) => bumpWhere(d, (c) => c.baseRank === 2 || c.baseRank === 8, 1) },
+      3: { desc: "Alle ursprünglichen 4er und 6er erhalten dauerhaft +1 Wert.", onPick: (d) => bumpWhere(d, (c) => c.baseRank === 4 || c.baseRank === 6, 1) },
+      4: { desc: "Alle geraden Karten erhalten zusätzlich +1 Wert.", onPick: (d) => bumpWhere(d, (c) => c.value % 2 === 0, 1) },
+    },
+  },
+  A_ODD: {
+    id: "A_ODD", cat: "A", name: "Ungerade Stärke", upgradeType: CUMULATIVE,
+    tiers: {
+      1: { desc: "Vier zufällige ungerade Karten erhalten dauerhaft +1 Wert.", onPick: (d, rng) => bumpRandomWhere(d, (c) => c.value % 2 === 1, 4, 1, rng) },
+      2: { desc: "Alle ursprünglichen 3er und 7er erhalten dauerhaft +1 Wert.", onPick: (d) => bumpWhere(d, (c) => c.baseRank === 3 || c.baseRank === 7, 1) },
+      3: { desc: "Alle ursprünglichen 1er und 9er erhalten dauerhaft +1 Wert.", onPick: (d) => bumpWhere(d, (c) => c.baseRank === 1 || c.baseRank === 9, 1) },
+      4: { desc: "Alle ungeraden Karten erhalten zusätzlich +1 Wert.", onPick: (d) => bumpWhere(d, (c) => c.value % 2 === 1, 1) },
+    },
+  },
+  A_SUIT_BOOST: {
+    id: "A_SUIT_BOOST", cat: "A", name: "Farbverstärkung", upgradeType: CUMULATIVE,
+    // III/IV: Spieler wählt die Farbe (pickTarget). I/II: zufällige Farbe.
+    tiers: {
+      1: { desc: "Eine zufällige Farbe: vier zufällige Karten erhalten dauerhaft +1 Wert.", onPick: (d, rng) => { const s = randomSuit(rng); return bumpRandomWhere(d, (c) => c.suit === s, 4, 1, rng); } },
+      2: { desc: "Eine zufällige Farbe: alle Karten erhalten dauerhaft +1 Wert.", onPick: (d, rng) => { const s = randomSuit(rng); return bumpWhere(d, (c) => c.suit === s, 1); } },
+      3: { desc: "Wähle eine Farbe: alle Karten dieser Farbe erhalten dauerhaft +1 Wert.", pickTarget: { suits: 1 }, onPick: (d, _rng, target) => (target?.suits?.[0] ? bumpWhere(d, (c) => c.suit === target.suits[0], 1) : d) },
+      4: { desc: "Wähle eine Farbe: alle Karten dieser Farbe erhalten dauerhaft +2 Wert.", pickTarget: { suits: 1 }, onPick: (d, _rng, target) => (target?.suits?.[0] ? bumpWhere(d, (c) => c.suit === target.suits[0], 2) : d) },
+    },
+  },
+  A_SMALL_BIG: {
+    id: "A_SMALL_BIG", cat: "A", name: "Kleine ganz groß", upgradeType: CUMULATIVE,
+    // „1–3er" = ursprünglicher Wert (baseRank), bleibt über spätere Boni hinweg konstant.
+    tiers: {
+      1: { desc: "Zwei zufällige ursprüngliche 1–3er erhalten dauerhaft je +3 Wert.", onPick: (d, rng) => bumpRandomWhere(d, (c) => c.baseRank >= 1 && c.baseRank <= 3, 2, 3, rng) },
+      2: { desc: "Drei zufällige ursprüngliche 1–3er erhalten dauerhaft je +4 Wert.", onPick: (d, rng) => bumpRandomWhere(d, (c) => c.baseRank >= 1 && c.baseRank <= 3, 3, 4, rng) },
+      3: { desc: "Vier zufällige ursprüngliche 1–3er erhalten dauerhaft je +5 Wert.", onPick: (d, rng) => bumpRandomWhere(d, (c) => c.baseRank >= 1 && c.baseRank <= 3, 4, 5, rng) },
+      4: { desc: "Alle ursprünglichen 1–3er erhalten dauerhaft +3 Wert.", onPick: (d) => bumpWhere(d, (c) => c.baseRank >= 1 && c.baseRank <= 3, 3) },
+    },
+  },
+  A_MIDRANGE: {
+    id: "A_MIDRANGE", cat: "A", name: "Mittelklasse", upgradeType: CUMULATIVE,
+    // Prüfung des AKTUELLEN Werts erfolgt jeweils beim Pick.
+    tiers: {
+      1: { desc: "Drei zufällige Karten mit aktuellem Wert 4–7 erhalten dauerhaft +1 Wert.", onPick: (d, rng) => bumpRandomWhere(d, (c) => c.value >= 4 && c.value <= 7, 3, 1, rng) },
+      2: { desc: "Fünf zufällige Karten mit aktuellem Wert 4–7 erhalten dauerhaft +1 Wert.", onPick: (d, rng) => bumpRandomWhere(d, (c) => c.value >= 4 && c.value <= 7, 5, 1, rng) },
+      3: { desc: "Alle Karten mit aktuellem Wert 4–7 erhalten dauerhaft +1 Wert.", onPick: (d) => bumpWhere(d, (c) => c.value >= 4 && c.value <= 7, 1) },
+      4: { desc: "Alle Karten mit aktuellem Wert 3–8 erhalten dauerhaft +1 Wert.", onPick: (d) => bumpWhere(d, (c) => c.value >= 3 && c.value <= 8, 1) },
+    },
+  },
+  A_TOP: {
+    id: "A_TOP", cat: "A", name: "Spitzenförderung", upgradeType: CUMULATIVE,
+    // Rangliste wird bei jedem Pick neu über den aktuellen Wert bestimmt.
+    tiers: {
+      1: { desc: "Die zwei aktuell höchsten Karten erhalten dauerhaft je +2 Wert.", onPick: (d) => bumpTopN(d, 2, 2, "desc") },
+      2: { desc: "Die drei aktuell höchsten Karten erhalten dauerhaft je +3 Wert.", onPick: (d) => bumpTopN(d, 3, 3, "desc") },
+      3: { desc: "Die vier aktuell höchsten Karten erhalten dauerhaft je +4 Wert.", onPick: (d) => bumpTopN(d, 4, 4, "desc") },
+      4: { desc: "Die fünf aktuell höchsten Karten erhalten dauerhaft je +5 Wert.", onPick: (d) => bumpTopN(d, 5, 5, "desc") },
+    },
+  },
+  A_BOTTOM: {
+    id: "A_BOTTOM", cat: "A", name: "Nachzügler", upgradeType: CUMULATIVE,
+    tiers: {
+      1: { desc: "Die zwei aktuell niedrigsten Karten erhalten dauerhaft je +3 Wert.", onPick: (d) => bumpTopN(d, 2, 3, "asc") },
+      2: { desc: "Die drei aktuell niedrigsten Karten erhalten dauerhaft je +4 Wert.", onPick: (d) => bumpTopN(d, 3, 4, "asc") },
+      3: { desc: "Die vier aktuell niedrigsten Karten erhalten dauerhaft je +5 Wert.", onPick: (d) => bumpTopN(d, 4, 5, "asc") },
+      4: { desc: "Die fünf aktuell niedrigsten Karten erhalten dauerhaft je +6 Wert.", onPick: (d) => bumpTopN(d, 5, 6, "asc") },
+    },
+  },
+  A_SUIT_DUEL: {
+    id: "A_SUIT_DUEL", cat: "A", name: "Farbduell", upgradeType: CUMULATIVE,
+    // Jede Stufe führt ihren Tausch dauerhaft aus (Gewinnerfarbe hoch, Verliererfarbe −1). III/IV: Spieler wählt.
+    tiers: {
+      1: { desc: "Eine zufällige Farbe erhält dauerhaft +1 Wert, eine andere zufällige Farbe −1 Wert.", onPick: (d, rng) => { const s = shuffle(SUIT_ORDER, rng); return suitDuel(d, s[0], s[1], 1, -1); } },
+      2: { desc: "Eine zufällige Farbe erhält dauerhaft +2 Wert, eine andere zufällige Farbe −1 Wert.", onPick: (d, rng) => { const s = shuffle(SUIT_ORDER, rng); return suitDuel(d, s[0], s[1], 2, -1); } },
+      3: { desc: "Wähle die Gewinnerfarbe (+3 Wert); eine andere Farbe verliert zufällig −1 Wert.", pickTarget: { suits: 1 }, onPick: (d, rng, target) => { const up = target?.suits?.[0]; if (!up) return d; const down = shuffle(SUIT_ORDER.filter((s) => s !== up), rng)[0]; return suitDuel(d, up, down, 3, -1); } },
+      4: { desc: "Wähle Gewinner- und Verliererfarbe: +4 Wert / −1 Wert.", pickTarget: { suits: 2 }, onPick: (d, _rng, target) => { const [up, down] = target?.suits || []; return up && down ? suitDuel(d, up, down, 4, -1) : d; } },
+    },
+  },
+  A_CONDENSE: {
+    id: "A_CONDENSE", cat: "A", name: "Verdichtung", upgradeType: CUMULATIVE,
+    // Deckzustand (Häufigkeit je aktuellem Wert) wird beim Pick geprüft.
+    tiers: {
+      1: { desc: "Zwei zufällige Karten aus mehrfach vorkommenden Wertgruppen erhalten dauerhaft +1 Wert.", onPick: (d, rng) => { const cnt = valueCounts(d); return bumpRandomWhere(d, (c) => cnt[c.value] > 1, 2, 1, rng); } },
+      2: { desc: "Vier zufällige Karten aus mehrfach vorkommenden Wertgruppen erhalten dauerhaft +1 Wert.", onPick: (d, rng) => { const cnt = valueCounts(d); return bumpRandomWhere(d, (c) => cnt[c.value] > 1, 4, 1, rng); } },
+      3: { desc: "Alle Karten aus Wertgruppen mit mindestens 3 Vorkommen erhalten dauerhaft +1 Wert.", onPick: (d) => { const cnt = valueCounts(d); return bumpWhere(d, (c) => cnt[c.value] >= 3, 1); } },
+      4: { desc: "Alle Karten aus mehrfach vorkommenden Wertgruppen erhalten dauerhaft +1 Wert.", onPick: (d) => { const cnt = valueCounts(d); return bumpWhere(d, (c) => cnt[c.value] >= 2, 1); } },
+    },
+  },
+};
+
 export const FAMILY_DEFS = {
   ...D_FAMILIES,
   ...B_FAMILIES,
+  ...A_FAMILIES,
 };
 
 export const FAMILY_LIST = Object.values(FAMILY_DEFS);
@@ -380,13 +513,15 @@ export function familyProdHook(familyTiers, name, ctx) {
    - ROLE (Kat. C-Rollen, #163): Rollenziele/-regel steigen; der Ziel-Flow folgt mit den C-Familien.
    Der aufrufende Reducer bleibt frei von Registry-Wissen. */
 export function applyFamilyPick(familyId, targetTier, ctx = {}, rng = Math.random) {
-  const { familyTiers = {}, deck = null, roles = null } = ctx;
+  const { familyTiers = {}, deck = null, roles = null, target = null } = ctx;
   const fam = FAMILY_DEFS[familyId];
   if (!fam || !targetTier) return { familyTiers, deck, roles }; // ungültige Familie/Stufe → No-Op
   const tierDef = fam.tiers[targetTier] || null;
   let nextDeck = deck, nextRoles = roles;
   if (fam.upgradeType === UPGRADE_TYPES.CUMULATIVE && tierDef && tierDef.onPick && deck) {
-    nextDeck = tierDef.onPick(deck, rng); // Stufen-Paket einmalig aufs Deck (A-/Shop-Karten-Familien)
+    // Stufen-Paket einmalig aufs Deck (A-/Shop-Karten-Familien). `target` trägt die Spieler-Auswahl
+    // (z. B. Farbe(n)) der Stufen mit `pickTarget`; ohne Ziel-Flow ist es null → diese Stufen sind No-Ops.
+    nextDeck = tierDef.onPick(deck, rng, target);
   }
   // ROLE-Zielauswahl folgt mit Kategorie C (#163) — hier noch reine Rangaktualisierung.
   return { familyTiers: withFamilyTier(familyTiers, familyId, targetTier), deck: nextDeck, roles: nextRoles };

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -23,7 +23,7 @@ import { SUIT_ORDER } from "./constants.js";
    (Resolver unten). Reine Logik — kein Math.random / Date.
    ============================================================ */
 
-const { REPLACEMENT, CUMULATIVE } = UPGRADE_TYPES;
+const { REPLACEMENT, CUMULATIVE, ROLE } = UPGRADE_TYPES;
 
 // ---- D · Score (Spec §3.2 D) — allesamt Regelersetzung (nur die höchste Stufe ist aktiv). ----
 // Kontextfelder je Sieg (aus der Engine): winValue, margin, winStreak, wins, hasFormation, lastResult,
@@ -452,10 +452,144 @@ const A_FAMILIES = {
   },
 };
 
+// ---- C · Rolle (Spec §3.2 C) — GEMISCHTE Upgrade-Typen: ROLE (Kartenrollen mit Ziel-Auswahl),
+//      REPLACEMENT (C_SURVIVOR, kein Ziel) und CUMULATIVE (C_SACRIFICE, dauerhafte Deck-Mod).
+//      Rollen speichern ihre Ziel-Karten in state.roles[familyId]; die cardBonus-Hooks lesen ctx.isRole(familyId).
+//      Engine-gekoppelte Marker (relay/relayBonus, triumph, segmentLow, jokerRole/jokerMode, bridgeRole/bridgeSpan)
+//      werden in Engine/formations familyTiers-bewusst ausgewertet (Kategorie-C-Wiring, Schritt 2). Ziel-Anzahl je
+//      Stufe über pickTarget.cards; Upgrade behält bestehende Ziele, nur zusätzliche werden neu gewählt (§2.3).
+//      Zusätzliche ctx-Felder (Schritt 2 in der Engine): secondLastResult (C_GUARD IV), segmentLowRank/segmentIndex
+//      (C_SURVIVOR). Reine Daten/Hooks — additiv, bis Kategorie C in MIGRATED_CATS wandert.
+
+// C_SACRIFICE: jede gewählte Karte −loss, ihr direkter Nachfolger (aus target.order = playerOrder) +gain, dauerhaft (>=0).
+const sacrifice = (deck, target, loss, gain) => {
+  const cards = (target && target.cards) || [];
+  const order = target && target.order;
+  if (!cards.length || !order) return deck;
+  const succIds = new Set();
+  for (const id of cards) {
+    const idx = order.findIndex((di) => deck[di] && deck[di].id === id);
+    if (idx >= 0 && idx + 1 < order.length) succIds.add(deck[order[idx + 1]].id);
+  }
+  return deck.map((c) => {
+    let v = c.value;
+    if (cards.includes(c.id)) v -= loss;
+    if (succIds.has(c.id)) v += gain;
+    return { ...c, value: Math.max(0, v) };
+  });
+};
+
+const C_FAMILIES = {
+  C_VANGUARD: {
+    id: "C_VANGUARD", cat: "C", name: "Vorhut", upgradeType: ROLE,
+    tiers: {
+      1: { desc: "Wähle 1 Karte: auf Position 1–5 erhält sie +2 Wert.",  pickTarget: { cards: 1 }, cardBonus: (c) => (c.isRole && c.isRole("C_VANGUARD") && c.posInCycle <= 4 ? 2 : 0) },
+      2: { desc: "Wähle 2 Karten: auf Position 1–5 erhalten sie +3 Wert.", pickTarget: { cards: 2 }, cardBonus: (c) => (c.isRole && c.isRole("C_VANGUARD") && c.posInCycle <= 4 ? 3 : 0) },
+      3: { desc: "Wähle 3 Karten: auf Position 1–5 erhalten sie +4 Wert.", pickTarget: { cards: 3 }, cardBonus: (c) => (c.isRole && c.isRole("C_VANGUARD") && c.posInCycle <= 4 ? 4 : 0) },
+      4: { desc: "Wähle 4 Karten: auf Position 1–10 erhalten sie +4 Wert.", pickTarget: { cards: 4 }, cardBonus: (c) => (c.isRole && c.isRole("C_VANGUARD") && c.posInCycle <= 9 ? 4 : 0) },
+    },
+  },
+  C_TRIUMPH: {
+    id: "C_TRIUMPH", cat: "C", name: "Triumph", upgradeType: ROLE,
+    // triumph: nach einem Sieg der Rollenkarte wird sie armiert; beim nächsten Auftauchen +Bonus (ctx.triumphActive).
+    tiers: {
+      1: { desc: "Wähle 1 Karte: nach einem Sieg erhält sie beim nächsten Auftauchen +2 Wert.",  pickTarget: { cards: 1 }, triumph: true, cardBonus: (c) => (c.triumphActive ? 2 : 0) },
+      2: { desc: "Wähle 2 Karten: nach einem Sieg erhalten sie beim nächsten Auftauchen +2 Wert.", pickTarget: { cards: 2 }, triumph: true, cardBonus: (c) => (c.triumphActive ? 2 : 0) },
+      3: { desc: "Wähle 3 Karten: nach einem Sieg erhalten sie beim nächsten Auftauchen +3 Wert.", pickTarget: { cards: 3 }, triumph: true, cardBonus: (c) => (c.triumphActive ? 3 : 0) },
+      4: { desc: "Wähle 4 Karten: nach einem Sieg erhalten sie beim nächsten Auftauchen +4 Wert.", pickTarget: { cards: 4 }, triumph: true, cardBonus: (c) => (c.triumphActive ? 4 : 0) },
+    },
+  },
+  C_GUARD: {
+    id: "C_GUARD", cat: "C", name: "Leibwache", upgradeType: ROLE,
+    // I–III: verliert der direkte Vorgänger (lastResult="loss"). IV: verliert einer der ZWEI Vorgänger (secondLastResult).
+    tiers: {
+      1: { desc: "Wähle 1 Karte: verliert ihr Vorgänger, erhält sie +3 Wert.",  pickTarget: { cards: 1 }, cardBonus: (c) => (c.isRole && c.isRole("C_GUARD") && c.lastResult === "loss" ? 3 : 0) },
+      2: { desc: "Wähle 2 Karten: verliert ihr Vorgänger, erhalten sie +4 Wert.", pickTarget: { cards: 2 }, cardBonus: (c) => (c.isRole && c.isRole("C_GUARD") && c.lastResult === "loss" ? 4 : 0) },
+      3: { desc: "Wähle 3 Karten: verliert ihr Vorgänger, erhalten sie +5 Wert.", pickTarget: { cards: 3 }, cardBonus: (c) => (c.isRole && c.isRole("C_GUARD") && c.lastResult === "loss" ? 5 : 0) },
+      4: { desc: "Wähle 4 Karten: verliert einer ihrer zwei Vorgänger, erhalten sie +6 Wert.", pickTarget: { cards: 4 }, cardBonus: (c) => (c.isRole && c.isRole("C_GUARD") && (c.lastResult === "loss" || c.secondLastResult === "loss") ? 6 : 0) },
+    },
+  },
+  C_RELAY: {
+    id: "C_RELAY", cat: "C", name: "Staffelläufer", upgradeType: ROLE,
+    // relay: nach einem Sieg der Rollenkarte erhalten die nächsten `relay` Karten je +relayBonus Wert (successorQueue).
+    tiers: {
+      1: { desc: "Wähle 1 Karte: nach ihrem Sieg erhält der direkte Nachfolger +2 Wert.",  pickTarget: { cards: 1 }, relay: 1, relayBonus: 2 },
+      2: { desc: "Wähle 2 Karten: nach ihrem Sieg erhält der direkte Nachfolger +2 Wert.", pickTarget: { cards: 2 }, relay: 1, relayBonus: 2 },
+      3: { desc: "Wähle 3 Karten: nach ihrem Sieg erhält der direkte Nachfolger +3 Wert.", pickTarget: { cards: 3 }, relay: 1, relayBonus: 3 },
+      4: { desc: "Wähle 4 Karten: nach ihrem Sieg erhalten die nächsten zwei Karten je +3 Wert.", pickTarget: { cards: 4 }, relay: 2, relayBonus: 3 },
+    },
+  },
+  C_LEADER: {
+    id: "C_LEADER", cat: "C", name: "Anführer", upgradeType: ROLE,
+    tiers: {
+      1: { desc: "Wähle 1 Karte: nach ihrem Sieg erhält die nächste Karte +2 Wert.",  pickTarget: { cards: 1 }, relay: 1, relayBonus: 2 },
+      2: { desc: "Wähle 1 Karte: nach ihrem Sieg erhalten die nächsten zwei Karten je +2 Wert.", pickTarget: { cards: 1 }, relay: 2, relayBonus: 2 },
+      3: { desc: "Wähle 2 Karten: nach ihrem Sieg erhalten die nächsten zwei Karten je +3 Wert.", pickTarget: { cards: 2 }, relay: 2, relayBonus: 3 },
+      4: { desc: "Wähle 2 Karten: nach ihrem Sieg erhalten die nächsten drei Karten je +4 Wert.", pickTarget: { cards: 2 }, relay: 3, relayBonus: 4 },
+    },
+  },
+  C_FINISHER: {
+    id: "C_FINISHER", cat: "C", name: "Finisher", upgradeType: ROLE,
+    tiers: {
+      1: { desc: "Wähle 1 Karte: auf der letzten Segmentposition erhält sie +3 Wert.",  pickTarget: { cards: 1 }, cardBonus: (c) => (c.isRole && c.isRole("C_FINISHER") && c.posInCycle % 5 === 4 ? 3 : 0) },
+      2: { desc: "Wähle 2 Karten: auf der letzten Segmentposition erhalten sie +4 Wert.", pickTarget: { cards: 2 }, cardBonus: (c) => (c.isRole && c.isRole("C_FINISHER") && c.posInCycle % 5 === 4 ? 4 : 0) },
+      3: { desc: "Wähle 3 Karten: auf der letzten Segmentposition erhalten sie +5 Wert.", pickTarget: { cards: 3 }, cardBonus: (c) => (c.isRole && c.isRole("C_FINISHER") && c.posInCycle % 5 === 4 ? 5 : 0) },
+      4: { desc: "Wähle 4 Karten: auf den letzten zwei Segmentpositionen erhalten sie +5 Wert.", pickTarget: { cards: 4 }, cardBonus: (c) => (c.isRole && c.isRole("C_FINISHER") && (c.posInCycle % 5 === 4 || c.posInCycle % 5 === 3) ? 5 : 0) },
+    },
+  },
+  C_SURVIVOR: {
+    id: "C_SURVIVOR", cat: "C", name: "Überlebensvorteil", upgradeType: REPLACEMENT,
+    // Kein Ziel. Engine liefert je Karte segmentLowRank (0=tiefste, 1=zweittiefste im Segment) + segmentIndex.
+    // §10-Default: „vier zufällige Segmente" (I) → deterministisch die ersten vier Segmente (Pos 1–20), damit kein
+    // per-Run-Zufallszustand nötig ist; II+ deckt alle Segmente ab. `segmentLow`-Marker triggert das Engine-Gate.
+    tiers: {
+      1: { desc: "Die niedrigste Karte der ersten vier Segmente erhält +2 Wert.", segmentLow: true, cardBonus: (c) => (c.segmentIndex < 4 && c.segmentLowRank === 0 ? 2 : 0) },
+      2: { desc: "Die niedrigste Karte jedes Segments erhält +2 Wert.",           segmentLow: true, cardBonus: (c) => (c.segmentLowRank === 0 ? 2 : 0) },
+      3: { desc: "Die zwei niedrigsten Karten jedes Segments erhalten +3 Wert.",  segmentLow: true, cardBonus: (c) => (c.segmentLowRank <= 1 ? 3 : 0) },
+      4: { desc: "Die zwei niedrigsten Karten jedes Segments erhalten +5 Wert.",  segmentLow: true, cardBonus: (c) => (c.segmentLowRank <= 1 ? 5 : 0) },
+    },
+  },
+  C_JOKER: {
+    id: "C_JOKER", cat: "C", name: "Joker", upgradeType: ROLE,
+    // jokerRole: die Rollenkarte darf für einen Farbblock eine andere Farbe annehmen. jokerMode je Stufe:
+    // "pred" = Vorgängerfarbe (I/II), "predOrSucc" = Vorgänger- ODER Nachfolgerfarbe (III), "free" = beliebig (IV).
+    // Auswertung in computeFormations (familyTiers-bewusst, Schritt 2).
+    tiers: {
+      1: { desc: "Wähle 1 Karte: sie zählt für einen Farbblock als Farbe ihres Vorgängers.",  pickTarget: { cards: 1 }, jokerRole: true, jokerMode: "pred" },
+      2: { desc: "Wähle 2 Karten: sie zählen für einen Farbblock als Farbe ihres Vorgängers.", pickTarget: { cards: 2 }, jokerRole: true, jokerMode: "pred" },
+      3: { desc: "Wähle 3 Karten: sie zählen für einen Farbblock als Vorgänger- oder Nachfolgerfarbe.", pickTarget: { cards: 3 }, jokerRole: true, jokerMode: "predOrSucc" },
+      4: { desc: "Wähle 4 Karten: sie zählen für einen Farbblock als beliebige Farbe.", pickTarget: { cards: 4 }, jokerRole: true, jokerMode: "free" },
+    },
+  },
+  C_SACRIFICE: {
+    id: "C_SACRIFICE", cat: "C", name: "Opfergabe", upgradeType: CUMULATIVE,
+    // Kumulativer Pick-Effekt: je gewählter Karte −loss Wert, ihr direkter Nachfolger (in playerOrder) +gain — dauerhaft.
+    // onPick(deck, rng, target) mit target={cards, order} (order = playerOrder, aus dem Reducer). Frühere Opfer bleiben.
+    tiers: {
+      1: { desc: "Wähle 1 Karte: sie verliert dauerhaft 2 Wert, ihr direkter Nachfolger erhält +3 Wert.", pickTarget: { cards: 1 }, onPick: (d, _rng, t) => sacrifice(d, t, 2, 3) },
+      2: { desc: "Wähle 1 Karte: sie verliert dauerhaft 2 Wert, ihr direkter Nachfolger erhält +4 Wert.", pickTarget: { cards: 1 }, onPick: (d, _rng, t) => sacrifice(d, t, 2, 4) },
+      3: { desc: "Wähle 1 Karte: sie verliert dauerhaft 3 Wert, ihr direkter Nachfolger erhält +6 Wert.", pickTarget: { cards: 1 }, onPick: (d, _rng, t) => sacrifice(d, t, 3, 6) },
+      4: { desc: "Wähle 2 Karten: jede verliert dauerhaft 3 Wert, ihr direkter Nachfolger erhält je +7 Wert.", pickTarget: { cards: 2 }, onPick: (d, _rng, t) => sacrifice(d, t, 3, 7) },
+    },
+  },
+  C_BRIDGE: {
+    id: "C_BRIDGE", cat: "C", name: "Bindeglied", upgradeType: ROLE,
+    // bridgeRole: die Rollenkarte darf für eine Treppe abweichen. bridgeSpan je Stufe: 1 (±1, I/II), 2 (±2, III),
+    // 99 (frei zwischen den Nachbarn, IV). Auswertung in computeFormations (familyTiers-bewusst, Schritt 2).
+    tiers: {
+      1: { desc: "Wähle 1 Karte: für eine Treppe darf sie als 1 Wert höher oder niedriger gelten.",  pickTarget: { cards: 1 }, bridgeRole: true, bridgeSpan: 1 },
+      2: { desc: "Wähle 2 Karten: für eine Treppe dürfen sie als 1 Wert höher oder niedriger gelten.", pickTarget: { cards: 2 }, bridgeRole: true, bridgeSpan: 1 },
+      3: { desc: "Wähle 3 Karten: für eine Treppe dürfen sie um 1 oder 2 Werte abweichen.",           pickTarget: { cards: 3 }, bridgeRole: true, bridgeSpan: 2 },
+      4: { desc: "Wähle 4 Karten: für eine Treppe dürfen sie jeden Wert zwischen ihren Nachbarn annehmen.", pickTarget: { cards: 4 }, bridgeRole: true, bridgeSpan: 99 },
+    },
+  },
+};
+
 export const FAMILY_DEFS = {
   ...D_FAMILIES,
   ...B_FAMILIES,
   ...A_FAMILIES,
+  ...C_FAMILIES,
 };
 
 export const FAMILY_LIST = Object.values(FAMILY_DEFS);

--- a/src/game/families.js
+++ b/src/game/families.js
@@ -751,6 +751,12 @@ export function familyProdHook(familyTiers, name, ctx) {
   return m;
 }
 
+// Belohnt eine gehaltene Familie Crits? (steuert die UI-Sichtbarkeit der Crit-Anzeigen, analog perks.hasCritPerk — #166).
+// Die crit-belohnenden D-Familien (D_CRIT_SCORE/D_SHARP_EYE/…) tragen scoreFlatOnCrit auf ihrer aktiven Stufe.
+export function hasCritFamily(familyTiers) {
+  return activeTierDefs(familyTiers).some((def) => !!def.scoreFlatOnCrit);
+}
+
 /* Familien-Pick anwenden (Spec §2.4 applyFamilyPick). Reine Funktion: nimmt den relevanten Run-State-
    Ausschnitt und liefert das Patch { familyTiers, deck, roles }.
    - REPLACEMENT (Kat. B/C-Regel/D/E): NUR der Familienrang ändert sich; die aktive Regel löst die Engine

--- a/src/game/formations.js
+++ b/src/game/formations.js
@@ -274,7 +274,7 @@ export function computeFormations(order, deck, roles = {}, perks = [], skills = 
     (last, ord) => recordEnd(last, "wechsel", wechselFactor(ord)), isJoker);
 
   // Anker (E_LOSS/E_QUICKSHOT, Rarität #167 Kat. E): Positionen + Faktor der gehaltenen Stufe — je siegreicher Anker,
-  // zählt als Formation. §10: E_QUICKSHOT IV „+2 Wert" (anchor.value) folgt mit der Engine/UI (#166); hier greift der Faktor.
+  // zählt als Formation. E_QUICKSHOT IV „+2 Wert" (anchor.value) wird in der Engine auf die Anker-Positionen addiert.
   for (const { def } of activeFamilyEntries(familyTiers)) if (def.anchor)
     for (let pos = 0; pos < n; pos++)
       if (def.anchor.at(pos, n) && !out[pos].formations.some((f) => f.type === "anker")) add(pos, "anker", 1, def.anchor.factor);

--- a/src/game/formations.js
+++ b/src/game/formations.js
@@ -20,6 +20,7 @@
    ============================================================ */
 import { PERMAFROST_VALUE, EISANKER_FACTOR, CRYSTAL_OFFSET, ANCHOR_FORM_FACTOR, FORMATION_CORE_FACTOR } from "./constants.js";
 import { iceFlag, hasPermafrost, hasIceAnchor } from "./skills.js";
+import { activeFamilyEntries } from "./families.js";
 
 export const SEGMENT_SIZE = 5;
 const WECHSEL_MIN_DIFF = 5;   // [#161 FB-5: 4→5 — Wechsel schwerer, größerer Nachbarabstand nötig]
@@ -145,9 +146,9 @@ function markWechsel(val, valSets, n, minLen, canExtendSeg, assign, minDiff = WE
 }
 
 /* Berechnet für jede Position { mult, formations: [{ type, ordinal, factor }] }.
-   `order` = Ziehreihenfolge, `deck` = Karten, `roles` = Kartenrollen (C8/C10),
-   `perks` = gehaltene Perks (für die E-Werkzeuge). */
-export function computeFormations(order, deck, roles = {}, perks = [], skills = [], anchors = [], pe = {}) {
+   `order` = Ziehreihenfolge, `deck` = Karten, `roles` = Kartenrollen (flach C8/C10 UND Familien C_JOKER/C_BRIDGE),
+   `perks` = gehaltene Perks (für die E-Werkzeuge), `familyTiers` = Familienrang je Familie (Rarität #167). */
+export function computeFormations(order, deck, roles = {}, perks = [], skills = [], anchors = [], pe = {}, familyTiers = {}) {
   const n = order.length;
   const cards = order.map((di) => deck[di]);
   const has = (id) => perks.includes(id);
@@ -164,9 +165,19 @@ export function computeFormations(order, deck, roles = {}, perks = [], skills = 
   const wildSkip = iceFlag(skills, "wildFarbblockSkip");    // Frostbrücke: transparent im Farbblock
   // Permafrost: +2 Dauerwert auf eingefrorenen Karten (echter Wert; im Kampf gespiegelt in engine.js).
   const val = cards.map((c, k) => c.value + (permafrost && frozen[k] ? PERMAFROST_VALUE : 0));
-  const jokerIds = new Set(roles.C8 || []);
-  const bridgeIds = new Set(roles.C10 || []);
-  // Joker (C8): effektive Farbe = die des direkten Vorgängers (verkettet).
+  // Familien-Rollen (Rarität #167 Kat. C): Joker (C_JOKER) + Bindeglied (C_BRIDGE) aus den gehaltenen Familien-Stufen.
+  // §10-Näherung Joker: jokerMode "pred" (I/II) = Vorgängerfarbe wie flach C8; "predOrSucc"/"free" (III/IV) = Farbblock-
+  // Wildcard (der paarweise Scanner kann die Vorgänger-oder-Nachfolger-Regel nicht abbilden, ohne verschiedenfarbige Blöcke
+  // falsch zu verschmelzen; nach oben genähert). Bindeglied-Span: 1 (I/II) / 2 (III) / 99 (frei, IV).
+  const famJokerPred = new Set(), famJokerFree = new Set(), famBridgeSpan = {};
+  for (const { familyId, def } of activeFamilyEntries(familyTiers)) {
+    const ids = roles[familyId] || [];
+    if (def.jokerRole) for (const id of ids) (def.jokerMode === "pred" ? famJokerPred : famJokerFree).add(id);
+    if (def.bridgeRole) for (const id of ids) famBridgeSpan[id] = Math.max(famBridgeSpan[id] || 0, def.bridgeSpan || 1);
+  }
+  const jokerIds = new Set([...(roles.C8 || []), ...famJokerPred]); // Vorgängerfarbe-Joker (flach C8 + Familie C_JOKER I/II)
+  const bridgeIds = new Set(roles.C10 || []);                       // flache C10 (Span 1); Familien-Span über famBridgeSpan
+  // Joker: effektive Farbe = die des direkten Vorgängers (verkettet).
   const effSuit = cards.map((c) => c.suit);
   for (let k = 1; k < n; k++) if (jokerIds.has(cards[k].id)) effSuit[k] = effSuit[k - 1];
   // Farballianz (Shop F4): zwei Farben zählen für Farbblöcke als eine (die zweite wird auf die erste gemappt).
@@ -174,6 +185,7 @@ export function computeFormations(order, deck, roles = {}, perks = [], skills = 
   // Bindeglied (C10, ±1) + Eis: Eisschritt/Kristallform geben ±1, Permafrost-Joker passt überall (großer Flex).
   const bind = cards.map((c, k) => {
     let b = bridgeIds.has(c.id) ? 1 : 0;
+    if (famBridgeSpan[c.id]) b = Math.max(b, famBridgeSpan[c.id]); // Familie C_BRIDGE: Span je Stufe (1/2/99)
     if (frozen[k] && (wildStep || wildCrystal)) b = Math.max(b, CRYSTAL_OFFSET);
     if (frozen[k] && permafrost) b = Math.max(b, 99); // Joker: fügt sich in jede Treppe
     return b;
@@ -211,8 +223,9 @@ export function computeFormations(order, deck, roles = {}, perks = [], skills = 
     (pos, ord) => add(pos, "wiederholung", ord, wiederholungFactor(ord, repBonus)), () => false,
     (last, ord) => recordEnd(last, "wiederholung", wiederholungFactor(ord, repBonus)), isJoker);
 
-  // Farbblock: Permafrost-Joker matcht jede Farbe; Frostbrücke macht eingefrorene Karten transparent (kein Mitglied).
-  const matchSuit = (a, b) => jokerAll[a] || jokerAll[b] || effSuit[a] === effSuit[b];
+  // Farbblock: Permafrost-Joker + freie Familien-Joker (C_JOKER III/IV) matchen jede Farbe; Frostbrücke macht
+  // eingefrorene Karten transparent (kein Mitglied).
+  const matchSuit = (a, b) => jokerAll[a] || jokerAll[b] || famJokerFree.has(cards[a].id) || famJokerFree.has(cards[b].id) || effSuit[a] === effSuit[b];
   const farbSkip = (k) => frozen[k] && wildSkip && !jokerAll[k];
   markRuns(n, 3, matchSuit, has("E2"), canExtendSeg,
     (pos, ord) => add(pos, "farbblock", ord, escalatingFactor(ord, FARBBLOCK_BASE)), farbSkip,

--- a/src/game/formations.js
+++ b/src/game/formations.js
@@ -20,7 +20,7 @@
    ============================================================ */
 import { PERMAFROST_VALUE, EISANKER_FACTOR, CRYSTAL_OFFSET, ANCHOR_FORM_FACTOR, FORMATION_CORE_FACTOR } from "./constants.js";
 import { iceFlag, hasPermafrost, hasIceAnchor } from "./skills.js";
-import { activeFamilyEntries } from "./families.js";
+import { activeFamilyEntries, familyTierParam } from "./families.js";
 
 export const SEGMENT_SIZE = 5;
 const WECHSEL_MIN_DIFF = 5;   // [#161 FB-5: 4→5 — Wechsel schwerer, größerer Nachbarabstand nötig]
@@ -40,7 +40,7 @@ function escalatingFactor(ordinal, base) {
 }
 // Überlappungsbonus je Anzahl Formationen auf einer Karte (#95): 2→×1,5, 3→×2, 4→×3.
 const OVERLAP_BONUS = { 2: 1.5, 3: 2, 4: 3 };
-const FARBBLOCK_BASE = 1.35, TREPPE_BASE = 1.35, WECHSEL_BASE = 1.40, ANKER_FACTOR = 1.25; // [#Pass4: Farbblock 1,30→1,35] [#161 FB-5: Treppe/Wechsel 1,25→1,35/1,40 — schwerer zu bauen, daher stärker belohnt (≥ Farbblock)]
+const FARBBLOCK_BASE = 1.35, TREPPE_BASE = 1.35, WECHSEL_BASE = 1.40; // [#Pass4: Farbblock 1,30→1,35] [#161 FB-5: Treppe/Wechsel 1,25→1,35/1,40 — schwerer zu bauen, daher stärker belohnt (≥ Farbblock)]
 
 // Maximale Läufe über eine Paar-Bedingung, mit optional EINER erlaubten fremden Karte dazwischen (E1/E2).
 // `matches(refPos, k)` prüft, ob Position k zur Formation von refPos gehört. Fremde Karten sind keine Mitglieder.
@@ -48,21 +48,27 @@ const FARBBLOCK_BASE = 1.35, TREPPE_BASE = 1.35, WECHSEL_BASE = 1.40, ANKER_FACT
 // Shop A6 Jokeranker: `isJoker(k)` markiert Positionen, deren Karte bei der Erkennung JEDEN Wert/jede Farbe
 // annehmen darf. Damit ein Joker nicht als Lauf-Referenz „alles absorbiert" (Über-Erzeugung), wird gegen die
 // erste REALE Karte des Laufs verglichen (`anchor`), nie gegen den Joker; ein Lauf zählt nur mit ≥1 realer Karte.
-function markRuns(n, minMembers, matches, allowGap, canExtendSeg, assign, transparent = () => false, onRunEnd = null, isJoker = () => false) {
+// `gap` = { run, seg }: erlaubte fremde Karten je LAUF bzw. je SEGMENT (E_PACE Wiederholung / E_COLORBRIDGE Farbblock,
+// Rarität #167). {0,0} = keine Überbrückung. Infinity = unbegrenzt (Stufe IV: fremde Karte zählt nicht, unterbricht nicht).
+function markRuns(n, minMembers, matches, gap, canExtendSeg, assign, transparent = () => false, onRunEnd = null, isJoker = () => false) {
+  const segGaps = {};
   let i = 0;
   while (i < n) {
     if (transparent(i)) { i++; continue; }        // transparente Karte startet keinen eigenen Lauf
     const members = [i];
-    let j = i, gapUsed = false;
+    let j = i, gapsRun = 0;
     let anchor = isJoker(i) ? -1 : i;             // Vergleichsanker = erste reale Karte (-1 = bisher nur Joker)
     const memberMatch = (k) => isJoker(k) || anchor === -1 || matches(anchor, k); // Joker passt immer; ohne Anker passt alles
     const noteReal = (k) => { if (anchor === -1 && !isJoker(k)) anchor = k; };     // erste reale Karte fixiert den Anker
     while (j + 1 < n && canExtendSeg(j)) {
       if (transparent(j + 1)) { j++; continue; }  // Frostbrücke: überspringen (kein Mitglied, kein Gap-Verbrauch)
       if (memberMatch(j + 1)) { j++; members.push(j); noteReal(j); }
-      else if (allowGap && !gapUsed && j + 2 < n && canExtendSeg(j + 1) && !transparent(j + 2) && memberMatch(j + 2)) {
-        gapUsed = true; j += 2; members.push(j); noteReal(j); // fremde Karte an j+1 überspringen
-      } else break;
+      else {
+        const seg = Math.floor((j + 1) / SEGMENT_SIZE);
+        if (gapsRun < gap.run && (segGaps[seg] || 0) < gap.seg && j + 2 < n && canExtendSeg(j + 1) && !transparent(j + 2) && memberMatch(j + 2)) {
+          gapsRun++; segGaps[seg] = (segGaps[seg] || 0) + 1; j += 2; members.push(j); noteReal(j); // fremde Karte an j+1 überspringen
+        } else break;
+      }
     }
     if (members.length >= minMembers && anchor !== -1) { // Joker erzeugen allein keine Formation
       members.forEach((pos, idx) => assign(pos, idx + 1));
@@ -78,11 +84,16 @@ function markRuns(n, minMembers, matches, allowGap, canExtendSeg, assign, transp
 // Joker (A6): nimmt den minimal-gültigen Zwischenwert (Vorgänger ± dir), sodass die strenge Monotonie hält —
 // echte Wert-Suche statt „passt immer" (verhindert unmögliche Brücken wie 5,Joker,6). `prev` = effektiver Wert
 // des letzten Mitglieds (null = bisher nur Joker; die erste reale Karte fixiert die Kette), `pb` = dessen Bind-Flex.
-function markTreppe(n, val, bind, e3, e4, e6, canExtendSeg, assign, dir = 1, onRunEnd = null, isJoker = () => false) {
+// `e` = { eqRun, eqSeg, revRun, revSeg, drehSeg }: Budgets für Gleichstände (E_GENTLE) und Rückschritte (E_BIGSTEP)
+// je Lauf/Segment; drehSeg = Karten, die je Segment einen zweiten Treppen-Lauf beginnen dürfen (E_RPM). Rarität #167.
+// Alles 0 = klassische strenge Treppe. Infinity = unbegrenzt (Stufe IV — §10-Näherung: „gleich = +1 Schritt" bzw.
+// „Richtung einmal wechseln" als unbegrenzte Gleichstände/Rückschritte).
+function markTreppe(n, val, bind, e, canExtendSeg, assign, dir = 1, onRunEnd = null, isJoker = () => false) {
+  const segEq = {}, segRev = {}, segDreh = {};
   let i = 0;
   while (i < n) {
     const members = [i];
-    let j = i, softUsed = false;
+    let j = i, eqUsed = 0, revUsed = 0;
     let prev = isJoker(i) ? null : val[i], pb = isJoker(i) ? 0 : bind[i], hasReal = !isJoker(i);
     while (j + 1 < n && canExtendSeg(j)) {
       const jj = j + 1;
@@ -94,15 +105,21 @@ function markTreppe(n, val, bind, e3, e4, e6, canExtendSeg, assign, dir = 1, onR
       const step = prev == null ? true                    // nur Joker bisher → diese reale Karte fixiert die Kette
         : (rawGap + span >= 1 && rawGap - span <= MAX_TREPPE_STEP);
       const revBack = prev != null && (dir === 1 ? v < prev : v > prev);
+      const seg = Math.floor(jj / SEGMENT_SIZE);
       if (step) { j = jj; members.push(j); prev = v; pb = b; hasReal = true; }
-      else if (!softUsed && ((e3 && v === prev) || (e4 && revBack))) { softUsed = true; j = jj; members.push(j); prev = v; pb = b; hasReal = true; }
-      else break;
+      else if (v === prev && eqUsed < e.eqRun && (segEq[seg] || 0) < e.eqSeg) {        // E_GENTLE: Gleichstand
+        eqUsed++; segEq[seg] = (segEq[seg] || 0) + 1; j = jj; members.push(j); prev = v; pb = b; hasReal = true;
+      } else if (revBack && revUsed < e.revRun && (segRev[seg] || 0) < e.revSeg) {     // E_BIGSTEP: Rückschritt
+        revUsed++; segRev[seg] = (segRev[seg] || 0) + 1; j = jj; members.push(j); prev = v; pb = b; hasReal = true;
+      } else break;
     }
     if (members.length >= 3 && hasReal) {                  // Joker allein bilden keine Treppe
       members.forEach((pos, idx) => assign(pos, idx + 1));
       if (onRunEnd) onRunEnd(members[members.length - 1], members.length); // F6 Nachhall
     }
-    i = (e6 && j > i) ? j : j + 1;
+    // E_RPM Drehzahl: die letzte Karte darf einen neuen Lauf beginnen (zwei Treppen), begrenzt je Segment über drehSeg.
+    const segJ = Math.floor(j / SEGMENT_SIZE);
+    if (j > i && (segDreh[segJ] || 0) < e.drehSeg) { segDreh[segJ] = (segDreh[segJ] || 0) + 1; i = j; } else i = j + 1;
   }
 }
 
@@ -147,11 +164,11 @@ function markWechsel(val, valSets, n, minLen, canExtendSeg, assign, minDiff = WE
 
 /* Berechnet für jede Position { mult, formations: [{ type, ordinal, factor }] }.
    `order` = Ziehreihenfolge, `deck` = Karten, `roles` = Kartenrollen (Familien C_JOKER/C_BRIDGE unter familyId,
-   plus L-Rollen), `perks` = gehaltene Perks (für die E-Werkzeuge), `familyTiers` = Familienrang je Familie (#167). */
+   plus L-Rollen), `familyTiers` = Familienrang je Familie (#167, u. a. E-Formationswerkzeuge). `perks` wird nicht
+   mehr gelesen (die E-Werkzeuge E1–E9 sind zu Familien migriert) — Parameter bleibt für die Aufrufer-Signatur. */
 export function computeFormations(order, deck, roles = {}, perks = [], skills = [], anchors = [], pe = {}, familyTiers = {}) {
   const n = order.length;
   const cards = order.map((di) => deck[di]);
-  const has = (id) => perks.includes(id);
   // ---- Shop-Formationsitems (§9, permanente Regeländerungen) ----
   const wechselMinDiff = pe.switchMinDifference || WECHSEL_MIN_DIFF; // F2 Enger Wechsel: 5 → 4
   const repBonus = pe.repetitionSecondFactorBonus || 0;              // F3 Verstärkte Wiederholung: 2. Karte +0,10
@@ -188,8 +205,23 @@ export function computeFormations(order, deck, roles = {}, perks = [], skills = 
     if (frozen[k] && permafrost) b = Math.max(b, 99); // Joker: fügt sich in jede Treppe
     return b;
   });
-  const crossSeg = has("E9");
+  // ---- E-Formationsfamilien (Rarität #167 Kat. E, REGELERSETZUNG): Parameter der GEHALTENEN Stufe je Familie
+  //      (familyTierParam; ungehalten → Default = klassische Erkennung ohne E-Werkzeug). Nur die höchste Stufe zählt. ----
+  const eP = (id, key, dflt) => { const v = familyTierParam(familyTiers, id, key); return v === undefined ? dflt : v; };
+  const wiedGap = { run: eP("E_PACE", "gapRun", 0), seg: eP("E_PACE", "gapSeg", 0) };                       // E_PACE: Wiederholung-Gaps
+  const suitGap = { run: eP("E_COLORBRIDGE", "suitGapRun", 0), seg: eP("E_COLORBRIDGE", "suitGapSeg", 0) }; // E_COLORBRIDGE: Farbblock-Gaps
+  const treppeE = { eqRun: eP("E_GENTLE", "eqRun", 0), eqSeg: eP("E_GENTLE", "eqSeg", 0),                   // E_GENTLE: Gleichstände
+                    revRun: eP("E_BIGSTEP", "revRun", 0), revSeg: eP("E_BIGSTEP", "revSeg", 0),             // E_BIGSTEP: Rückschritte
+                    drehSeg: eP("E_RPM", "drehSeg", 0) };                                                   // E_RPM: Doppel-Treppe
+  const wMinLen = eP("E_PENDULUM", "wMinLen", 3);                                                           // E_PENDULUM: Wechsel-Mindestlänge
+  const wMinDiff = Math.min(wechselMinDiff, eP("E_PENDULUM", "wMinDiff", WECHSEL_MIN_DIFF));                // Shop F2 + E_PENDULUM (kleiner = leichter)
+  const wFactorStart = eP("E_PENDULUM", "wFactorStart", 0);                                                // IV: Wechsel-Faktor bereits ab Länge 2
+  // E_SEGMENT: die ersten `eSegOpen` internen Segmentgrenzen öffnen (Infinity = alle → crossSeg). Ergänzt Shop F5.
+  const eSegOpen = eP("E_SEGMENT", "openBoundaries", 0);
+  const crossSeg = eSegOpen === Infinity;
   const openBoundaries = new Set(pe.openSegmentBoundaries || []); // Shop F5: einzeln geöffnete Segmentgrenzen (Position k mit (k+1)%5==0)
+  if (!crossSeg && eSegOpen > 0) for (let k = 0, opened = 0; k < n && opened < eSegOpen; k++)
+    if ((k + 1) % SEGMENT_SIZE === 0) { openBoundaries.add(k); opened++; }
   const canExtendSeg = (k) => crossSeg || ((k + 1) % SEGMENT_SIZE !== 0) || openBoundaries.has(k);
   // Shop A6 Jokeranker (§8): Positionen, deren Karte bei jeder Basisformation den benötigten Wert/die Farbe annehmen darf.
   // Zählt NICHT als eigener Anker (kein ×1,25) und erzeugt allein keine Formation.
@@ -217,7 +249,7 @@ export function computeFormations(order, deck, roles = {}, perks = [], skills = 
   });
   const jokerAll = frozen.map((f) => f && permafrost); // Permafrost: Joker für Wiederholung UND Farbblock
   const matchWied = (a, b) => jokerAll[a] || jokerAll[b] || [...valSetWied[a]].some((v) => valSetWied[b].has(v));
-  markRuns(n, 2, matchWied, has("E1"), canExtendSeg,
+  markRuns(n, 2, matchWied, wiedGap, canExtendSeg,
     (pos, ord) => add(pos, "wiederholung", ord, wiederholungFactor(ord, repBonus)), () => false,
     (last, ord) => recordEnd(last, "wiederholung", wiederholungFactor(ord, repBonus)), isJoker);
 
@@ -225,25 +257,27 @@ export function computeFormations(order, deck, roles = {}, perks = [], skills = 
   // eingefrorene Karten transparent (kein Mitglied).
   const matchSuit = (a, b) => jokerAll[a] || jokerAll[b] || famJokerFree.has(cards[a].id) || famJokerFree.has(cards[b].id) || effSuit[a] === effSuit[b];
   const farbSkip = (k) => frozen[k] && wildSkip && !jokerAll[k];
-  markRuns(n, 3, matchSuit, has("E2"), canExtendSeg,
+  markRuns(n, 3, matchSuit, suitGap, canExtendSeg,
     (pos, ord) => add(pos, "farbblock", ord, escalatingFactor(ord, FARBBLOCK_BASE)), farbSkip,
     (last, ord) => recordEnd(last, "farbblock", escalatingFactor(ord, FARBBLOCK_BASE)), isJoker);
 
   const treppeAssign = (pos, ord) => add(pos, "treppe", ord, escalatingFactor(ord, TREPPE_BASE));
   const treppeEnd = (last, ord) => recordEnd(last, "treppe", escalatingFactor(ord, TREPPE_BASE));
-  markTreppe(n, val, bind, has("E3"), has("E4"), has("E6"), canExtendSeg, treppeAssign, 1, treppeEnd, isJoker);
-  if (descending) markTreppe(n, val, bind, has("E3"), has("E4"), has("E6"), canExtendSeg, treppeAssign, -1, treppeEnd, isJoker); // F1 Abstieg
+  markTreppe(n, val, bind, treppeE, canExtendSeg, treppeAssign, 1, treppeEnd, isJoker);
+  if (descending) markTreppe(n, val, bind, treppeE, canExtendSeg, treppeAssign, -1, treppeEnd, isJoker); // F1 Abstieg
   // Wechsel: Kristallform gibt eingefrorenen Karten ±1-Wertoptionen (Permafrost/Eisschritt gelten hier NICHT).
+  // E_PENDULUM IV: wFactorStart hebt den Wechsel-Faktor bereits ab Länge 2 auf ×1,35 (sonst erst ab der 3. Karte).
   const valSetWechsel = cards.map((c, k) => (frozen[k] && wildCrystal ? [val[k] - 1, val[k], val[k] + 1] : [val[k]]));
-  markWechsel(val, valSetWechsel, n, has("E5") ? 2 : 3, canExtendSeg,
-    (pos, ord) => add(pos, "wechsel", ord, escalatingFactor(ord, WECHSEL_BASE)), wechselMinDiff,
-    (last, ord) => recordEnd(last, "wechsel", escalatingFactor(ord, WECHSEL_BASE)), isJoker);
+  const wechselFactor = (ord) => Math.max(escalatingFactor(ord, WECHSEL_BASE), ord >= 2 && wFactorStart ? wFactorStart : 1);
+  markWechsel(val, valSetWechsel, n, wMinLen, canExtendSeg,
+    (pos, ord) => add(pos, "wechsel", ord, wechselFactor(ord)), wMinDiff,
+    (last, ord) => recordEnd(last, "wechsel", wechselFactor(ord)), isJoker);
 
-  // Anker (E7: Position 10/20/30/40 · E8: Position 5/15/25/35) — je siegreicher Anker ×1,25, zählt als Formation.
-  if (has("E7") || has("E8")) for (let pos = 0; pos < n; pos++) {
-    const p = (pos + 1) % 10;
-    if ((has("E7") && p === 0) || (has("E8") && p === 5)) add(pos, "anker", 1, ANKER_FACTOR);
-  }
+  // Anker (E_LOSS/E_QUICKSHOT, Rarität #167 Kat. E): Positionen + Faktor der gehaltenen Stufe — je siegreicher Anker,
+  // zählt als Formation. §10: E_QUICKSHOT IV „+2 Wert" (anchor.value) folgt mit der Engine/UI (#166); hier greift der Faktor.
+  for (const { def } of activeFamilyEntries(familyTiers)) if (def.anchor)
+    for (let pos = 0; pos < n; pos++)
+      if (def.anchor.at(pos, n) && !out[pos].formations.some((f) => f.type === "anker")) add(pos, "anker", 1, def.anchor.factor);
   // Eisanker (#93 F3): jede eingefrorene Karte zählt auf ihrer Position als Anker ×1,25 (zählt als Formation).
   if (hasIceAnchor(skills)) for (let pos = 0; pos < n; pos++) if (frozen[pos] && !out[pos].formations.some((f) => f.type === "anker")) add(pos, "anker", 1, EISANKER_FACTOR);
   // Formationsanker (Shop §8 A5): jede Anker-Position zählt als Anker ×1,25, falls dort noch kein Anker liegt (E7/E8/Eisanker).

--- a/src/game/formations.js
+++ b/src/game/formations.js
@@ -13,7 +13,7 @@
    - Überlappung: steckt eine Karte in mehreren Formationen, wird ihr Faktor-Produkt zusätzlich
      mit dem Überlappungsbonus multipliziert: 2 Formationen ×1,5 · 3 ×2 · 4 ×3.
 
-   Rollen (§22.6 C): C8 Joker (Farbe = Vorgänger), C10 Bindeglied (Treppe ±1).
+   Rollen-Familien (Rarität #167 Kat. C): C_JOKER (Farbblock-Joker je Stufe), C_BRIDGE (Treppen-Flex je Stufe).
    Werkzeuge (§22.6 E): E1 Wiederholung +1 fremde Karte · E2 Farbblock +1 andersfarbig ·
    E3 Treppe darf 1× gleich · E4 Treppe darf 1× Rückschritt · E5 Wechsel schon ab 2 Karten ·
    E6 Karte in zwei Treppen · E7/E8 Anker · E9 Formationen über Segmentgrenzen.
@@ -146,8 +146,8 @@ function markWechsel(val, valSets, n, minLen, canExtendSeg, assign, minDiff = WE
 }
 
 /* Berechnet für jede Position { mult, formations: [{ type, ordinal, factor }] }.
-   `order` = Ziehreihenfolge, `deck` = Karten, `roles` = Kartenrollen (flach C8/C10 UND Familien C_JOKER/C_BRIDGE),
-   `perks` = gehaltene Perks (für die E-Werkzeuge), `familyTiers` = Familienrang je Familie (Rarität #167). */
+   `order` = Ziehreihenfolge, `deck` = Karten, `roles` = Kartenrollen (Familien C_JOKER/C_BRIDGE unter familyId,
+   plus L-Rollen), `perks` = gehaltene Perks (für die E-Werkzeuge), `familyTiers` = Familienrang je Familie (#167). */
 export function computeFormations(order, deck, roles = {}, perks = [], skills = [], anchors = [], pe = {}, familyTiers = {}) {
   const n = order.length;
   const cards = order.map((di) => deck[di]);
@@ -175,8 +175,7 @@ export function computeFormations(order, deck, roles = {}, perks = [], skills = 
     if (def.jokerRole) for (const id of ids) (def.jokerMode === "pred" ? famJokerPred : famJokerFree).add(id);
     if (def.bridgeRole) for (const id of ids) famBridgeSpan[id] = Math.max(famBridgeSpan[id] || 0, def.bridgeSpan || 1);
   }
-  const jokerIds = new Set([...(roles.C8 || []), ...famJokerPred]); // Vorgängerfarbe-Joker (flach C8 + Familie C_JOKER I/II)
-  const bridgeIds = new Set(roles.C10 || []);                       // flache C10 (Span 1); Familien-Span über famBridgeSpan
+  const jokerIds = famJokerPred; // Vorgängerfarbe-Joker (Familie C_JOKER I/II; flache C8 ist zu #167 migriert)
   // Joker: effektive Farbe = die des direkten Vorgängers (verkettet).
   const effSuit = cards.map((c) => c.suit);
   for (let k = 1; k < n; k++) if (jokerIds.has(cards[k].id)) effSuit[k] = effSuit[k - 1];
@@ -184,8 +183,7 @@ export function computeFormations(order, deck, roles = {}, perks = [], skills = 
   if ((pe.linkedColors || []).length === 2) { const [la, lb] = pe.linkedColors; for (let k = 0; k < n; k++) if (effSuit[k] === lb) effSuit[k] = la; }
   // Bindeglied (C10, ±1) + Eis: Eisschritt/Kristallform geben ±1, Permafrost-Joker passt überall (großer Flex).
   const bind = cards.map((c, k) => {
-    let b = bridgeIds.has(c.id) ? 1 : 0;
-    if (famBridgeSpan[c.id]) b = Math.max(b, famBridgeSpan[c.id]); // Familie C_BRIDGE: Span je Stufe (1/2/99)
+    let b = famBridgeSpan[c.id] || 0; // Familie C_BRIDGE: Span je Stufe (1/2/99); flache C10 ist zu #167 migriert
     if (frozen[k] && (wildStep || wildCrystal)) b = Math.max(b, CRYSTAL_OFFSET);
     if (frozen[k] && permafrost) b = Math.max(b, 99); // Joker: fügt sich in jede Treppe
     return b;

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -14,7 +14,7 @@ import { TIERS, TIER_WEIGHTS, canOfferFamilyTier, familyTierOf } from "./rarity.
      scoreMult(ctx)       -> multiplikativer Score-Faktor bei Sieg
    Kat.-C/E/L-Sonderfälle laufen über Marker/Flags am Perk (needsTarget, relay, triumph, permMod,
    sacrificeMod, jokerRole/bridgeRole, segmentLow/segmentHigh, critValueGain, successorCrit,
-   swapExtremes, repeatPos, randomTarget, extraSwap, winTieAfterLoss) — je an ihrer Definition erklärt.
+   swapExtremes, repeatPos, randomTarget, extraSwap) — je an ihrer Definition erklärt.
    Crit-Chance/-Mult kommen NICHT aus den Perks, sondern aus Stat + Blitz-Skills (Engine).
    rarity: "legendary" markiert Legendaries (Default "common") — Gewicht in buildOffer.
 
@@ -85,12 +85,6 @@ export const PERK_DEFS = {
   A8: { id: "A8", cat: "A", label: "Nachzügler",
         desc: "Die vier aktuell niedrigsten Karten erhalten dauerhaft je +5 Wert.",
         onPick: (d) => bumpTopN(d, 4, 5, "asc") },
-  B6: { id: "B6", cat: "B", label: "Knappe Kiste",
-        desc: "Liegt die gespielte Karte in einer Wiederholung, erhält sie +2 temporären Wert.",
-        cardBonus: (ctx) => (ctx.posForm && ctx.posForm.formations.some((f) => f.type === "wiederholung") ? 2 : 0) },
-  B7: { id: "B7", cat: "B", label: "Durchbruch",
-        desc: "Nach fünf Stichen ohne Sieg erhält die nächste Karte +10 Wert (Sieg setzt zurück, Gleichstand zählt weiter).",
-        cardBonus: (ctx) => ((ctx.sinceWin || 0) >= 5 ? 10 : 0) },
   C6: { id: "C6", cat: "C", label: "Finisher", needsTarget: 2,
         desc: "Wähle zwei Karten. Auf der letzten Position eines Segments erhalten sie +5 Wert.",
         cardBonus: (ctx) => (ctx.isRole && ctx.isRole("C6") && ctx.posInCycle % 5 === 4 ? 5 : 0) },
@@ -116,11 +110,6 @@ export const PERK_DEFS = {
   E8: { id: "E8", cat: "E", label: "Schnellschuss",
         desc: "Die Positionen 5, 15, 25 und 35 sind Anker (siegreicher Anker ×1,25)." },
 
-  // ---- Seltene Perks (#71, Phase 2b) — Ergebnis-/Wert-Historie (neue State-Felder) ----
-  B8: { id: "B8", cat: "B", label: "Revanche",
-        desc: "Nach zwei aufeinanderfolgenden Niederlagen erhält die nächste Karte +7 Wert.",
-        cardBonus: (ctx) => ((ctx.lossStreak || 0) >= 2 ? 7 : 0) },
-
   // ---- C-Rollen mit Formations-/Segment-Bezug (V2 §22.6) ----
   C7: { id: "C7", cat: "C", label: "Überlebensvorteil", segmentLow: true,
         desc: "Die niedrigste Karte jedes Segments erhält +3 Wert.",
@@ -132,15 +121,7 @@ export const PERK_DEFS = {
   C10: { id: "C10", cat: "C", label: "Bindeglied", needsTarget: 2, bridgeRole: true,
         desc: "Wähle zwei Karten. Für eine Treppe dürfen sie als 1 Wert höher oder niedriger gelten." },
 
-  // ---- Seltene Perks (#71, Phase 2f) — Ergebnis-/Wert-Historie (neue State-Felder) ----
-  B9: { id: "B9", cat: "B", label: "Perfekte Folge",
-        desc: "Karten einer Treppe erhalten je nach Position +1, +2, +3, danach +4 temporären Wert.",
-        cardBonus: (ctx) => { const t = ctx.posForm && ctx.posForm.formations.find((f) => f.type === "treppe"); return t ? Math.min(t.ordinal, 4) : 0; } },
-
   // ---- Seltene Perks (#71, Phase 2e) — Serien-/Tempo-/Crit-Mechanik (Engine-Flags + State) ----
-  B10: { id: "B10", cat: "B", label: "Überzahl",
-        desc: "Ist der Dauerwert einer Karte höher als der ihres direkten Vorgängers, erhält sie +3 temporären Wert.",
-        cardBonus: (ctx) => (ctx.predValue != null && ctx.pValueBase > ctx.predValue ? 3 : 0) },
   E9: { id: "E9", cat: "E", label: "Segmentarbeit",
         desc: "Formationen dürfen über Segmentgrenzen hinweg fortgesetzt werden." },
   // Rarität-Umbau (#162, Spec §3.3): E10 ist als Perk DEAKTIVIERT (offerable:false → nie angeboten) und wandert
@@ -148,22 +129,8 @@ export const PERK_DEFS = {
   E10: { id: "E10", cat: "E", label: "Feinjustierung", extraSwap: 1, offerable: false,
         desc: "Jede Formationsphase erhält einen zusätzlichen kostenlosen beliebigen Tausch." },
 
-  // ---- B: Stich-Effekte (Wert-Bonus auf die aktuelle Karte) ----
-  B1: { id: "B1", cat: "B", label: "Gegenangriff",
-        desc: "Nach einem verlorenen Stich erhält die nächste Karte +4 Wert.",
-        cardBonus: (ctx) => (ctx.lostLastTrick ? 4 : 0) },
-  B2: { id: "B2", cat: "B", label: "Momentum",
-        desc: "Nach genau drei Siegen in Folge erhält die nächste Karte +5 Wert.",
-        cardBonus: (ctx) => (ctx.winStreak === 3 ? 5 : 0) }, // §22.6: einmalig bei Serie 3 (Stand VOR dem Stich)
-  B3: { id: "B3", cat: "B", label: "Starker Auftakt",
-        desc: "Die ersten drei Karten jedes Durchlaufs erhalten je +4 Wert.",
-        cardBonus: (ctx) => (ctx.posInCycle <= 2 ? 4 : 0) },
-  B4: { id: "B4", cat: "B", label: "Zehnter Schlag",
-        desc: "Karten auf Position 10, 20, 30 und 40 erhalten +8 Wert.",
-        cardBonus: (ctx) => ((ctx.posInCycle + 1) % 10 === 0 ? 8 : 0) },
-  B5: { id: "B5", cat: "B", label: "Initiative",
-        desc: "Nach einer Niederlage gewinnst du den nächsten Gleichstand.",
-        winTieAfterLoss: true },
+  // ---- B: Stich — vollständig zu Familien migriert (#167, families.js Kategorie B). Die früheren flachen
+  //      B1–B10 sind entfernt; das Angebot bietet B nur noch als aufwertbare Familien (buildPerkOffer). ----
 
   // ---- C: Kartenrollen (V2 §22.6) — meist mit manueller Kartenauswahl (needsTarget) ----
   //      Rollen liegen als Karten-ids in state.roles[perkId]; ctx.isRole(perkId) prüft die aktuelle Karte.
@@ -253,7 +220,7 @@ export const rarityMeta = (id) => RARITY_META[rarityOf(id)];
 // Aufstellungshilfe in Formationsphase & Kartenübersicht (Issue #95). Alle E-Werkzeuge (Kat. E)
 // plus kuratierte B/C/D/L, deren Effekt an Position, direkter Nachbarschaft oder Formation hängt.
 const LAYOUT_EXTRA = new Set([
-  "B3", "B4", "B6", "B9", "B10",          // Auftakt-/Zehner-Positionen · Wiederholung · Treppe · Überzahl (Vorgänger)
+  // B-Stich ist zu Familien migriert (#167) — die positions-/formationsbezogenen B-Familien folgen in der Layout-Hilfe mit #166.
   "C1", "C3", "C4", "C5", "C6", "C7", "C8", "C10", // Positions-/Nachbarschafts-/Segment-Rollen · Joker/Bindeglied (Formation)
   // D-Score ist zu Familien migriert (#167) — die formationsbezogenen D-Familien (Punktebonus/Kritische Ernte)
   // sind noch nicht in der Layout-Hilfe berücksichtigt (folgt mit #166 UI).
@@ -266,7 +233,7 @@ export function layoutPerks(owned) { return (owned || []).filter(isLayoutPerk); 
 
 // Migrierte Kategorien: ihre REGULÄREN (nicht legendären) Perks sind jetzt Familien und kommen über FAMILY_DEFS
 // ins Angebot statt über PERK_DEFS. Wächst mit jeder migrierten Kategorie (aktuell nur D; später +A/B/C/E).
-export const MIGRATED_CATS = new Set(["D"]);
+export const MIGRATED_CATS = new Set(["D", "B"]);
 
 // Ist dieser flache Perk durch eine Familie ersetzt? Nur reguläre Perks migrierter Kategorien — die legendären
 // D-Perks (L4/L5/L6/L10) bleiben flach im Legendär-Pool (Spec §3.1).

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -1,13 +1,10 @@
 import * as C from "./constants.js";
-import { SUIT_ORDER } from "./constants.js";
-import { shuffle } from "./deck.js";
 import { FAMILY_LIST } from "./families.js";
 import { TIERS, TIER_WEIGHTS, canOfferFamilyTier, familyTierOf } from "./rarity.js";
 
 /* ============================================================
    PERK-REGISTRY  — datengetrieben (wie clauses.js in TrickLadder).
    Score-/Wert-Hooks (alle optional), ausgewertet in engine.js:
-     onPick(deck, rng)    -> neues Deck   einmalige Kartenmod beim Pick (Kat. A)
      cardBonus(ctx)       -> Wert-Bonus auf die Spielerkarte DIESES Stichs (Kat. B/C/L)
      scoreFlat(ctx)       -> additiver Score bei Sieg (Kat. D — fließt in die multiplizierte Basis)
      scoreFlatOnCrit(ctx) -> additiver Score NUR bei Crit (Kat. D)
@@ -24,18 +21,6 @@ import { TIERS, TIER_WEIGHTS, canOfferFamilyTier, familyTierOf } from "./rarity.
      suitStreak, recentWinCount, lastWinValue, critFollowArmed, weaknessArmed, misfireScore, rawCrit }
    ============================================================ */
 
-const bumpWhere = (deck, pred, delta) =>
-  deck.map((c) => (pred(c) ? { ...c, value: c.value + delta } : c));
-
-// #71: die n Karten mit dem höchsten (dir="desc") bzw. niedrigsten (dir="asc") aktuellen Wert
-// um delta anheben. Stabiler Sort (Ties nach ursprünglichem Index) → deterministisch, kein rng.
-const bumpTopN = (deck, n, delta, dir) => {
-  const order = deck.map((_, i) => i).sort((a, b) =>
-    dir === "desc" ? deck[b].value - deck[a].value : deck[a].value - deck[b].value);
-  const pick = new Set(order.slice(0, n));
-  return deck.map((c, i) => (pick.has(i) ? { ...c, value: c.value + delta } : c));
-};
-
 // Basis-Siegesserie (#39): IMMER aktiver, gedeckelter Serien-Multiplikator — jede Serie hebt den
 // Score-Mult leicht. Geteilte Quelle für Engine-Score UND Anzeige (baseScoreMultFor → Header-Chip
 // #37 / StatusRail #23) → kein Drift, analog zum Muster von scoreMultFor/critChanceFor (#23/#25).
@@ -50,59 +35,13 @@ export const CATEGORIES = {
 };
 
 export const PERK_DEFS = {
-  // ---- A: Deck-Modifikation (einmalig beim Pick) ----
-  A1: { id: "A1", cat: "A", label: "Starke Fünfen",
-        desc: "Alle Karten mit Wert 5 erhalten dauerhaft +4 Wert.",
-        onPick: (d) => bumpWhere(d, (c) => c.value === 5, 4) },
-  A2: { id: "A2", cat: "A", label: "Gerade Stärke",
-        desc: "Alle Karten mit geradem Wert erhalten dauerhaft +1 Wert.",
-        onPick: (d) => bumpWhere(d, (c) => c.value % 2 === 0, 1) },
-  A3: { id: "A3", cat: "A", label: "Ungerade Stärke",
-        desc: "Alle Karten mit ungeradem Wert erhalten dauerhaft +1 Wert.",
-        onPick: (d) => bumpWhere(d, (c) => c.value % 2 === 1, 1) },
-  A4: { id: "A4", cat: "A", label: "Farbverstärkung",
-        desc: "Alle Karten einer zufälligen Farbe erhalten dauerhaft +2 Wert.",
-        onPick: (d, rng) => {
-          const s = SUIT_ORDER[Math.floor(rng() * SUIT_ORDER.length)];
-          return bumpWhere(d, (c) => c.suit === s, 2);
-        } },
-  A5: { id: "A5", cat: "A", label: "Kleine ganz groß",
-        desc: "Vier zufällige Karten mit ursprünglichem Wert 1–3 erhalten dauerhaft je +5 Wert.",
-        onPick: (d, rng) => {
-          // §22.6: „ursprünglicher Wert" = baseRank (bleibt konstant), nicht der aktuelle Wert.
-          const idx = d.map((c, i) => [c, i]).filter(([c]) => c.baseRank >= 1 && c.baseRank <= 3).map(([, i]) => i);
-          const chosen = new Set(shuffle(idx, rng).slice(0, 4)); // bis zu 4 unterschiedliche Karten
-          return d.map((c, i) => (chosen.has(i) ? { ...c, value: c.value + 5 } : c));
-        } },
-
-  // ---- Neue Normal-Perks (#71) — Anzeige-Gruppe über `cat` (A Deck / B Stich / C Leben) ----
-  A6: { id: "A6", cat: "A", label: "Mittelklasse",
-        desc: "Alle Karten mit aktuellem Wert 4–7 erhalten dauerhaft +1 Wert.",
-        onPick: (d) => bumpWhere(d, (c) => c.value >= 4 && c.value <= 7, 1) },
-  A7: { id: "A7", cat: "A", label: "Spitzenförderung",
-        desc: "Die vier aktuell höchsten Karten erhalten dauerhaft je +4 Wert.",
-        onPick: (d) => bumpTopN(d, 4, 4, "desc") },
-  A8: { id: "A8", cat: "A", label: "Nachzügler",
-        desc: "Die vier aktuell niedrigsten Karten erhalten dauerhaft je +5 Wert.",
-        onPick: (d) => bumpTopN(d, 4, 5, "asc") },
+  // ---- A: Deck — vollständig zu Familien migriert (#167, families.js Kategorie A, KUMULATIV). Die früheren
+  //      flachen A1–A10 sind entfernt; das Angebot bietet A nur noch als aufwertbare Familien (buildPerkOffer). ----
   C6: { id: "C6", cat: "C", label: "Finisher", needsTarget: 2,
         desc: "Wähle zwei Karten. Auf der letzten Position eines Segments erhalten sie +5 Wert.",
         cardBonus: (ctx) => (ctx.isRole && ctx.isRole("C6") && ctx.posInCycle % 5 === 4 ? 5 : 0) },
 
-  // ---- Seltene Perks (#71, Phase 2a) — rarity: "rare"; reine Hooks über bestehende Kontexte ----
-  A9: { id: "A9", cat: "A", label: "Farbduell",
-        desc: "Eine zufällige Farbe erhält dauerhaft +3 Wert, eine andere zufällige Farbe −1 Wert.",
-        onPick: (d, rng) => {
-          const s = shuffle(SUIT_ORDER, rng); const up = s[0], down = s[1];
-          return d.map((c) => (c.suit === up ? { ...c, value: c.value + 3 }
-            : c.suit === down ? { ...c, value: Math.max(0, c.value - 1) } : c));
-        } },
-  A10: { id: "A10", cat: "A", label: "Verdichtung",
-        desc: "Alle Karten, deren aktueller Wert mehrfach im Deck vorkommt, erhalten dauerhaft +1 Wert.",
-        onPick: (d) => {
-          const cnt = {}; for (const c of d) cnt[c.value] = (cnt[c.value] || 0) + 1;
-          return d.map((c) => (cnt[c.value] > 1 ? { ...c, value: c.value + 1 } : c));
-        } },
+  // ---- E-Formationsmarker (V2 §22.6) — reine Marker; Wirkung in computeFormations(perks). ----
   E6: { id: "E6", cat: "E", label: "Drehzahl",
         desc: "Eine einzelne Karte darf gleichzeitig zu zwei unterschiedlichen Treppen gehören." },
   E7: { id: "E7", cat: "E", label: "Kontrollverlust",
@@ -232,8 +171,8 @@ export function layoutPerks(owned) { return (owned || []).filter(isLayoutPerk); 
 /* ---- Familien-Umbau (Rarität #167 §2) ---- */
 
 // Migrierte Kategorien: ihre REGULÄREN (nicht legendären) Perks sind jetzt Familien und kommen über FAMILY_DEFS
-// ins Angebot statt über PERK_DEFS. Wächst mit jeder migrierten Kategorie (aktuell nur D; später +A/B/C/E).
-export const MIGRATED_CATS = new Set(["D", "B"]);
+// ins Angebot statt über PERK_DEFS. Wächst mit jeder migrierten Kategorie (D, B, A; später +C/E).
+export const MIGRATED_CATS = new Set(["D", "B", "A"]);
 
 // Ist dieser flache Perk durch eine Familie ersetzt? Nur reguläre Perks migrierter Kategorien — die legendären
 // D-Perks (L4/L5/L6/L10) bleiben flach im Legendär-Pool (Spec §3.1).

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -265,6 +265,9 @@ export function buildPerkOffer(owned = [], familyTiers = {}, rng = Math.random, 
   let pool = flat.map((p) => ({ perk: p.id, weight: C.RARITY_WEIGHTS[p.rarity || "common"], leg: (p.rarity || "common") === "legendary" }));
   for (const fam of FAMILY_LIST) {
     if (fam.enabled === false) continue;
+    // Nur Familien MIGRIERTER Kategorien anbieten. Eine neu angelegte, aber noch nicht migrierte Familie
+    // (z. B. Kategorie A) läuft sonst PARALLEL zu ihrem noch existierenden flachen Perk ins Angebot (Doppelung).
+    if (!MIGRATED_CATS.has(fam.cat)) continue;
     const cur = familyTierOf(familyTiers, fam.id);
     // FAMILY_DEFS führt `tiers` als OBJEKT {1:def,…} → anbietbare Stufen direkt über TIERS filtern
     // (nicht offerableTiers aus rarity.js, das ein Array erwartet).

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -322,40 +322,6 @@ const LAYOUT_EXTRA = new Set([
 export function isLayoutPerk(id) { return PERK_DEFS[id]?.cat === "E" || LAYOUT_EXTRA.has(id); }
 export function layoutPerks(owned) { return (owned || []).filter(isLayoutPerk); }
 
-// Angebot: bis zu `count` noch nicht besessene Perks, GEWICHTET nach Seltenheit (#33, §10.3).
-// Perk-Auswahl nach jeder Runde: KEINE Level-Gates mehr — alle Seltenheiten sofort möglich, nur gewichtet;
-// höchstens MAX_LEGENDARIES_PER_OFFER Legendaries je Angebot.
-// Deterministisch über den injizierten rng (ein rng()-Zug je Auswahl). Pool leer → weniger Perks.
-export function buildOffer(owned, rng, count, legendaryChance = 0) {
-  let pool = PERK_LIST.filter((p) => !owned.includes(p.id) && p.offerable !== false); // offerable:false = aus dem Pool (E10, #162)
-  const chosen = [];
-  let legendaries = 0;
-  // Expliziter Legendär-Roll (Shop-Spec §10 P5): NUR wenn eine Legendär-Chance übergeben ist. Legendäre werden
-  // dann aus dem gewichteten Zug ausgeschlossen und erscheinen ausschließlich über diesen Wurf (bei Erfolg genau
-  // eines). Ohne Chance (0) bleibt das alte Gewichtsmodell exakt erhalten (kein rng-Drift für Bestandstests).
-  if (legendaryChance > 0) {
-    const legs = pool.filter((p) => p.rarity === "legendary");
-    pool = pool.filter((p) => p.rarity !== "legendary");
-    if (legs.length && count > 0 && rng() < legendaryChance) {
-      chosen.push(legs[Math.floor(rng() * legs.length)].id);
-      legendaries = 1;
-    }
-  }
-  while (chosen.length < count && pool.length > 0) {
-    const weights = pool.map((p) => C.RARITY_WEIGHTS[p.rarity || "common"]);
-    const total = weights.reduce((a, b) => a + b, 0);
-    let r = rng() * total, idx = 0;
-    while (idx < pool.length - 1 && r >= weights[idx]) { r -= weights[idx]; idx += 1; }
-    const pick = pool[idx];
-    chosen.push(pick.id);
-    if ((pick.rarity || "common") === "legendary") legendaries += 1;
-    // Gezogenen raus; ist das Legendary-Limit erreicht, alle weiteren Legendaries aus dem Pool nehmen.
-    pool = pool.filter((p) => p.id !== pick.id
-      && !(legendaries >= C.MAX_LEGENDARIES_PER_OFFER && (p.rarity || "common") === "legendary"));
-  }
-  return chosen;
-}
-
 /* ---- Familien-Umbau (Rarität #167 §2) ---- */
 
 // Migrierte Kategorien: ihre REGULÄREN (nicht legendären) Perks sind jetzt Familien und kommen über FAMILY_DEFS

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -35,11 +35,8 @@ export const CATEGORIES = {
 };
 
 export const PERK_DEFS = {
-  // ---- A: Deck — vollständig zu Familien migriert (#167, families.js Kategorie A, KUMULATIV). Die früheren
-  //      flachen A1–A10 sind entfernt; das Angebot bietet A nur noch als aufwertbare Familien (buildPerkOffer). ----
-  C6: { id: "C6", cat: "C", label: "Finisher", needsTarget: 2,
-        desc: "Wähle zwei Karten. Auf der letzten Position eines Segments erhalten sie +5 Wert.",
-        cardBonus: (ctx) => (ctx.isRole && ctx.isRole("C6") && ctx.posInCycle % 5 === 4 ? 5 : 0) },
+  // ---- A: Deck & C: Rollen — vollständig zu Familien migriert (#167, families.js Kategorien A/C). Die früheren
+  //      flachen A1–A10 bzw. C1–C10 sind entfernt; das Angebot bietet A/C nur noch als Familien (buildPerkOffer). ----
 
   // ---- E-Formationsmarker (V2 §22.6) — reine Marker; Wirkung in computeFormations(perks). ----
   E6: { id: "E6", cat: "E", label: "Drehzahl",
@@ -48,17 +45,6 @@ export const PERK_DEFS = {
         desc: "Die Positionen 10, 20, 30 und 40 sind Anker (siegreicher Anker ×1,25)." },
   E8: { id: "E8", cat: "E", label: "Schnellschuss",
         desc: "Die Positionen 5, 15, 25 und 35 sind Anker (siegreicher Anker ×1,25)." },
-
-  // ---- C-Rollen mit Formations-/Segment-Bezug (V2 §22.6) ----
-  C7: { id: "C7", cat: "C", label: "Überlebensvorteil", segmentLow: true,
-        desc: "Die niedrigste Karte jedes Segments erhält +3 Wert.",
-        cardBonus: (ctx) => (ctx.isSegmentLow ? 3 : 0) }, // Engine markiert die Segment-Tiefsten je Durchlauf
-  C8: { id: "C8", cat: "C", label: "Joker", needsTarget: 2, jokerRole: true,
-        desc: "Wähle zwei Karten. Für einen Farbblock zählen sie als Farbe ihres direkten Vorgängers." },
-  C9: { id: "C9", cat: "C", label: "Opfergabe", needsTarget: 1, sacrificeMod: true,
-        desc: "Wähle eine Karte. Sie verliert dauerhaft 3 Wert; ihr direkter Nachfolger erhält dauerhaft +5 Wert." },
-  C10: { id: "C10", cat: "C", label: "Bindeglied", needsTarget: 2, bridgeRole: true,
-        desc: "Wähle zwei Karten. Für eine Treppe dürfen sie als 1 Wert höher oder niedriger gelten." },
 
   // ---- Seltene Perks (#71, Phase 2e) — Serien-/Tempo-/Crit-Mechanik (Engine-Flags + State) ----
   E9: { id: "E9", cat: "E", label: "Segmentarbeit",
@@ -71,21 +57,9 @@ export const PERK_DEFS = {
   // ---- B: Stich — vollständig zu Familien migriert (#167, families.js Kategorie B). Die früheren flachen
   //      B1–B10 sind entfernt; das Angebot bietet B nur noch als aufwertbare Familien (buildPerkOffer). ----
 
-  // ---- C: Kartenrollen (V2 §22.6) — meist mit manueller Kartenauswahl (needsTarget) ----
-  //      Rollen liegen als Karten-ids in state.roles[perkId]; ctx.isRole(perkId) prüft die aktuelle Karte.
-  C1: { id: "C1", cat: "C", label: "Vorhut", needsTarget: 3,
-        desc: "Wähle drei Karten. Auf Position 1–5 erhalten sie +3 Wert.",
-        cardBonus: (ctx) => (ctx.isRole && ctx.isRole("C1") && ctx.posInCycle <= 4 ? 3 : 0) },
-  C2: { id: "C2", cat: "C", label: "Triumph", needsTarget: 3, triumph: true,
-        desc: "Wähle drei Karten. Nach einem Sieg erhalten sie beim nächsten Auftauchen +2 Wert.",
-        cardBonus: (ctx) => (ctx.triumphActive ? 2 : 0) }, // Engine armiert die Karte nach ihrem Sieg
-  C3: { id: "C3", cat: "C", label: "Leibwache", needsTarget: 2,
-        desc: "Wähle zwei Karten. Verliert ihr Vorgänger, erhalten sie +5 Wert.",
-        cardBonus: (ctx) => (ctx.isRole && ctx.isRole("C3") && ctx.lastResult === "loss" ? 5 : 0) },
-  C4: { id: "C4", cat: "C", label: "Staffelläufer", needsTarget: 3, relay: 1,
-        desc: "Wähle drei Karten. Nach ihrem Sieg erhält der direkte Nachfolger +2 Wert." },
-  C5: { id: "C5", cat: "C", label: "Anführer", needsTarget: 1, relay: 2,
-        desc: "Wähle eine Karte. Nach ihrem Sieg erhalten die nächsten zwei Karten +2 Wert." },
+  // ---- C: Kartenrollen — vollständig zu Familien migriert (#167, families.js Kategorie C, gemischte Upgrade-Typen
+  //      ROLE/REPLACEMENT/CUMULATIVE). Die früheren flachen C1–C10 sind entfernt; das Angebot bietet C nur noch als
+  //      Familien (buildPerkOffer). Rollen liegen jetzt unter state.roles[familyId]; ctx.isRole(familyId) prüft sie. ----
 
   // ---- D: Score — vollständig zu Familien migriert (#167, siehe families.js Kategorie D). Die früheren
   //      flachen D1–D19 sind entfernt; das Angebot bietet D nur noch als aufwertbare Familien (buildPerkOffer). ----
@@ -159,10 +133,9 @@ export const rarityMeta = (id) => RARITY_META[rarityOf(id)];
 // Aufstellungshilfe in Formationsphase & Kartenübersicht (Issue #95). Alle E-Werkzeuge (Kat. E)
 // plus kuratierte B/C/D/L, deren Effekt an Position, direkter Nachbarschaft oder Formation hängt.
 const LAYOUT_EXTRA = new Set([
-  // B-Stich ist zu Familien migriert (#167) — die positions-/formationsbezogenen B-Familien folgen in der Layout-Hilfe mit #166.
-  "C1", "C3", "C4", "C5", "C6", "C7", "C8", "C10", // Positions-/Nachbarschafts-/Segment-Rollen · Joker/Bindeglied (Formation)
-  // D-Score ist zu Familien migriert (#167) — die formationsbezogenen D-Familien (Punktebonus/Kritische Ernte)
-  // sind noch nicht in der Layout-Hilfe berücksichtigt (folgt mit #166 UI).
+  // B-Stich, D-Score UND C-Rollen sind zu Familien migriert (#167) — ihre positions-/formations-/segmentbezogenen
+  // Familien (u. a. Vorhut/Finisher/Joker/Bindeglied/Überlebensvorteil, Punktebonus/Kritische Ernte) sind in der
+  // Aufstellungshilfe noch NICHT berücksichtigt (folgt mit #166 UI, da layoutPerks nur flache `perks` kennt).
   "L3", "L11",                            // Positionen 36–40 · Position 20→40 (L7 „Königsmacher" entfernt, #162)
 ]);
 export function isLayoutPerk(id) { return PERK_DEFS[id]?.cat === "E" || LAYOUT_EXTRA.has(id); }
@@ -171,8 +144,8 @@ export function layoutPerks(owned) { return (owned || []).filter(isLayoutPerk); 
 /* ---- Familien-Umbau (Rarität #167 §2) ---- */
 
 // Migrierte Kategorien: ihre REGULÄREN (nicht legendären) Perks sind jetzt Familien und kommen über FAMILY_DEFS
-// ins Angebot statt über PERK_DEFS. Wächst mit jeder migrierten Kategorie (D, B, A; später +C/E).
-export const MIGRATED_CATS = new Set(["D", "B", "A"]);
+// ins Angebot statt über PERK_DEFS. Wächst mit jeder migrierten Kategorie (D, B, A, C; später +E).
+export const MIGRATED_CATS = new Set(["D", "B", "A", "C"]);
 
 // Ist dieser flache Perk durch eine Familie ersetzt? Nur reguläre Perks migrierter Kategorien — die legendären
 // D-Perks (L4/L5/L6/L10) bleiben flach im Legendär-Pool (Spec §3.1).

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -109,12 +109,6 @@ export const PERK_DEFS = {
           const cnt = {}; for (const c of d) cnt[c.value] = (cnt[c.value] || 0) + 1;
           return d.map((c) => (cnt[c.value] > 1 ? { ...c, value: c.value + 1 } : c));
         } },
-  D10: { id: "D10", cat: "D", label: "Übermacht",
-        desc: "Ein Sieg mit mindestens 8 Wertpunkten Vorsprung gibt +350 Score.",
-        scoreFlat: (ctx) => (ctx.margin >= 8 ? 350 : 0) },
-  D11: { id: "D11", cat: "D", label: "Kritische Ernte",
-        desc: "Ein Crit mit einer Karte in mindestens einer aktiven Formation gibt +250 Score.",
-        scoreFlatOnCrit: (ctx) => (ctx.hasFormation ? 250 : 0) },
   E6: { id: "E6", cat: "E", label: "Drehzahl",
         desc: "Eine einzelne Karte darf gleichzeitig zu zwei unterschiedlichen Treppen gehören." },
   E7: { id: "E7", cat: "E", label: "Kontrollverlust",
@@ -126,23 +120,6 @@ export const PERK_DEFS = {
   B8: { id: "B8", cat: "B", label: "Revanche",
         desc: "Nach zwei aufeinanderfolgenden Niederlagen erhält die nächste Karte +7 Wert.",
         cardBonus: (ctx) => ((ctx.lossStreak || 0) >= 2 ? 7 : 0) },
-  D12: { id: "D12", cat: "D", label: "Präzision",
-        desc: "Zwei aufeinanderfolgende Siege mit demselben Kartenwert geben dem zweiten +400 Score.",
-        scoreFlat: (ctx) => (ctx.lastWinValue != null && ctx.winValue === ctx.lastWinValue ? 400 : 0) },
-  D13: { id: "D13", cat: "D", label: "Wechselspiel",
-        desc: "Ein Sieg direkt nach einer Niederlage gibt +200 Score.",
-        scoreFlat: (ctx) => (ctx.lastResult === "loss" ? 200 : 0) },
-
-  // ---- Seltene Perks (#71, Phase 2c) — Crit-Historie (neue Engine-State-Felder) ----
-  D14: { id: "D14", cat: "D", label: "Crit-Folge",
-        desc: "Ein Sieg direkt nach einem Crit gibt +200 Score.",
-        scoreFlat: (ctx) => (ctx.critFollowArmed ? 200 : 0) },
-  D15: { id: "D15", cat: "D", label: "Fehlzündung",
-        desc: "Jeder Sieg ohne Crit lädt +30 Score für den nächsten Crit auf (max +300).",
-        scoreFlatOnCrit: (ctx) => (ctx.misfireScore || 0) },
-  D16: { id: "D16", cat: "D", label: "Schwachstellenanalyse",
-        desc: "Nach einer Niederlage mit mindestens 5 Wertpunkten Abstand gibt der nächste Sieg +300 Score.",
-        scoreFlat: (ctx) => (ctx.weaknessArmed ? 300 : 0) },
 
   // ---- C-Rollen mit Formations-/Segment-Bezug (V2 §22.6) ----
   C7: { id: "C7", cat: "C", label: "Überlebensvorteil", segmentLow: true,
@@ -159,13 +136,6 @@ export const PERK_DEFS = {
   B9: { id: "B9", cat: "B", label: "Perfekte Folge",
         desc: "Karten einer Treppe erhalten je nach Position +1, +2, +3, danach +4 temporären Wert.",
         cardBonus: (ctx) => { const t = ctx.posForm && ctx.posForm.formations.find((f) => f.type === "treppe"); return t ? Math.min(t.ordinal, 4) : 0; } },
-  D17: { id: "D17", cat: "D", label: "Farbserie",
-        desc: "Aufeinanderfolgende Siege derselben Farbe geben jeweils +100 mehr Score (2.→+100, 3.→+200 …), maximal +400.",
-        scoreFlat: (ctx) => Math.min(Math.max(0, ((ctx.suitStreak || 0) - 1) * 100), 400) },
-  D18: { id: "D18", cat: "D", label: "Volles Haus",
-        desc: "Fünf Siege innerhalb desselben Segments geben dem fünften Sieg +750 Score.",
-        // Position ist die letzte im Segment (posInCycle % 5 == 4) UND die vier davor (recentResults) waren Siege.
-        scoreFlat: (ctx) => (ctx.posInCycle % 5 === 4 && (ctx.recentWinCount || 0) >= 4 ? 750 : 0) },
 
   // ---- Seltene Perks (#71, Phase 2e) — Serien-/Tempo-/Crit-Mechanik (Engine-Flags + State) ----
   B10: { id: "B10", cat: "B", label: "Überzahl",
@@ -177,9 +147,6 @@ export const PERK_DEFS = {
   // als Shop-Familie „Feinjustierung" (#164). Definition bleibt vorerst für die extraSwap-Engine/Bestands-Builds.
   E10: { id: "E10", cat: "E", label: "Feinjustierung", extraSwap: 1, offerable: false,
         desc: "Jede Formationsphase erhält einen zusätzlichen kostenlosen beliebigen Tausch." },
-  D19: { id: "D19", cat: "D", label: "Überschusskrit",
-        desc: "Ein Crit über 100 % effektiver Crit-Chance gibt +250 Score.",
-        scoreFlatOnCrit: (ctx) => ((ctx.rawCrit || 0) > 1 ? 250 : 0) },
 
   // ---- B: Stich-Effekte (Wert-Bonus auf die aktuelle Karte) ----
   B1: { id: "B1", cat: "B", label: "Gegenangriff",
@@ -214,36 +181,8 @@ export const PERK_DEFS = {
   C5: { id: "C5", cat: "C", label: "Anführer", needsTarget: 1, relay: 2,
         desc: "Wähle eine Karte. Nach ihrem Sieg erhalten die nächsten zwei Karten +2 Wert." },
 
-  // ---- D: Flat Score (V2 §22.6 — alle additiv; fließen in die multiplizierte Basis, §15) ----
-  //      Crit-Chance/-Mult kommen NICHT mehr aus den Perks, nur noch aus dem Stat + Blitz.
-  //      `scoreFlatOnCrit` zahlt nur bei einem Crit (Engine addiert es in die multiplizierte Basis).
-  D1: { id: "D1", cat: "D", label: "Punktebonus",
-        desc: "Jeder Sieg mit mindestens einer aktiven Formation gibt +75 Score.",
-        scoreFlat: (ctx) => (ctx.hasFormation ? 75 : 0) },
-  D2: { id: "D2", cat: "D", label: "Siegesserie",
-        desc: "Jeder Sieg gibt +25 Score je aktuellem Serienpunkt, maximal +250.",
-        scoreFlat: (ctx) => Math.min(25 * (ctx.winStreak || 0), 250) },
-  D3: { id: "D3", cat: "D", label: "Hohe Karten, hohe Belohnung",
-        desc: "Ein Sieg mit Kartenwert 8 oder höher gibt +125 Score.",
-        scoreFlat: (ctx) => (ctx.winValue >= C.D3_HIGH_MIN ? 125 : 0) },
-  D4: { id: "D4", cat: "D", label: "Außenseitersieg",
-        desc: "Ein Sieg mit Kartenwert 3 oder niedriger gibt +300 Score.",
-        scoreFlat: (ctx) => (ctx.winValue <= C.D4_LOW_MAX ? 300 : 0) },
-  D5: { id: "D5", cat: "D", label: "Zehnter Sieg",
-        desc: "Jeder zehnte gewonnene Stich gibt +750 Score.",
-        scoreFlat: (ctx) => (ctx.wins % 10 === 0 ? 750 : 0) },
-  D6: { id: "D6", cat: "D", label: "Kritische Chance",
-        desc: "Jeder Crit gibt +150 Score.",
-        scoreFlatOnCrit: () => 150 },
-  D7: { id: "D7", cat: "D", label: "Geschärfter Blick",
-        desc: "Ein Crit mit Kartenwert 8 oder höher gibt +300 Score.",
-        scoreFlatOnCrit: (ctx) => (ctx.winValue >= C.D3_HIGH_MIN ? 300 : 0) },
-  D8: { id: "D8", cat: "D", label: "Kritisches Momentum",
-        desc: "Jeder Crit innerhalb einer laufenden Siegesserie (ab Serie 2) gibt +200 Score.",
-        scoreFlatOnCrit: (ctx) => ((ctx.winStreak || 0) >= 2 ? 200 : 0) },
-  D9: { id: "D9", cat: "D", label: "Perfekter Rhythmus",
-        desc: "Jeder fünfte gewonnene Stich gibt +300 Score.",
-        scoreFlat: (ctx) => (ctx.wins % 5 === 0 ? 300 : 0) },
+  // ---- D: Score — vollständig zu Familien migriert (#167, siehe families.js Kategorie D). Die früheren
+  //      flachen D1–D19 sind entfernt; das Angebot bietet D nur noch als aufwertbare Familien (buildPerkOffer). ----
 
   // ---- E: Formationswerkzeuge (V2 §22.6) — reine Marker; die Wirkung steckt in computeFormations(perks). ----
   E1: { id: "E1", cat: "E", label: "Schrittmacher",
@@ -316,7 +255,8 @@ export const rarityMeta = (id) => RARITY_META[rarityOf(id)];
 const LAYOUT_EXTRA = new Set([
   "B3", "B4", "B6", "B9", "B10",          // Auftakt-/Zehner-Positionen · Wiederholung · Treppe · Überzahl (Vorgänger)
   "C1", "C3", "C4", "C5", "C6", "C7", "C8", "C10", // Positions-/Nachbarschafts-/Segment-Rollen · Joker/Bindeglied (Formation)
-  "D1", "D11",                            // Formations-Sieg / Crit in Formation
+  // D-Score ist zu Familien migriert (#167) — die formationsbezogenen D-Familien (Punktebonus/Kritische Ernte)
+  // sind noch nicht in der Layout-Hilfe berücksichtigt (folgt mit #166 UI).
   "L3", "L11",                            // Positionen 36–40 · Position 20→40 (L7 „Königsmacher" entfernt, #162)
 ]);
 export function isLayoutPerk(id) { return PERK_DEFS[id]?.cat === "E" || LAYOUT_EXTRA.has(id); }

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -1,6 +1,8 @@
 import * as C from "./constants.js";
 import { SUIT_ORDER } from "./constants.js";
 import { shuffle } from "./deck.js";
+import { FAMILY_LIST } from "./families.js";
+import { TIERS, TIER_WEIGHTS, canOfferFamilyTier, familyTierOf } from "./rarity.js";
 
 /* ============================================================
    PERK-REGISTRY  — datengetrieben (wie clauses.js in TrickLadder).
@@ -350,6 +352,69 @@ export function buildOffer(owned, rng, count, legendaryChance = 0) {
     // Gezogenen raus; ist das Legendary-Limit erreicht, alle weiteren Legendaries aus dem Pool nehmen.
     pool = pool.filter((p) => p.id !== pick.id
       && !(legendaries >= C.MAX_LEGENDARIES_PER_OFFER && (p.rarity || "common") === "legendary"));
+  }
+  return chosen;
+}
+
+/* ---- Familien-Umbau (Rarität #167 §2) ---- */
+
+// Migrierte Kategorien: ihre REGULÄREN (nicht legendären) Perks sind jetzt Familien und kommen über FAMILY_DEFS
+// ins Angebot statt über PERK_DEFS. Wächst mit jeder migrierten Kategorie (aktuell nur D; später +A/B/C/E).
+export const MIGRATED_CATS = new Set(["D"]);
+
+// Ist dieser flache Perk durch eine Familie ersetzt? Nur reguläre Perks migrierter Kategorien — die legendären
+// D-Perks (L4/L5/L6/L10) bleiben flach im Legendär-Pool (Spec §3.1).
+export function isMigratedPerk(p) {
+  return !!p && MIGRATED_CATS.has(p.cat) && (p.rarity || "common") !== "legendary";
+}
+
+/* Vereinheitlichtes Perk-Angebot (Spec §2): mischt die noch flachen Perks (A/B/C/E + Legendäre) mit den FAMILIEN
+   der migrierten Kategorien (D). Ein Angebotseintrag ist ENTWEDER ein perkId-String (flach) ODER `{ familyId, tier }`
+   (Familie auf einer anbietbaren Zielstufe). Familien-Stufen sind nach TIER_WEIGHTS gewichtet, flache Perks nach
+   RARITY_WEIGHTS; der explizite Legendär-Wurf (P5) bleibt wie in buildOffer. Deterministisch über den injizierten
+   rng. `owned` = flache Perk-ids; `familyTiers` = aktueller Rang je Familie. */
+export function buildPerkOffer(owned = [], familyTiers = {}, rng = Math.random, count = C.PERKS_OFFERED, legendaryChance = 0) {
+  // Flacher Legacy-Pool: nicht besessen, offerable, NICHT migriert (reguläre D-Perks raus; Legendäre bleiben).
+  let flat = PERK_LIST.filter((p) => !owned.includes(p.id) && p.offerable !== false && !isMigratedPerk(p));
+  const chosen = [];
+  let legendaries = 0;
+  // Expliziter Legendär-Wurf (Shop-Spec §10 P5) — identisch zu buildOffer: nur bei übergebener Chance, dann genau
+  // eines aus dem gewichteten Zug ausgeschlossen. Ohne Chance bleibt das Gewichtsmodell (Legendäre gewichtet im Pool).
+  if (legendaryChance > 0) {
+    const legs = flat.filter((p) => p.rarity === "legendary");
+    flat = flat.filter((p) => p.rarity !== "legendary");
+    if (legs.length && count > 0 && rng() < legendaryChance) {
+      chosen.push(legs[Math.floor(rng() * legs.length)].id);
+      legendaries = 1;
+    }
+  }
+  // Kandidatenpool: flache Perks (Gewicht = RARITY_WEIGHTS) + Familien-Stufen (Gewicht = TIER_WEIGHTS[tier]).
+  let pool = flat.map((p) => ({ perk: p.id, weight: C.RARITY_WEIGHTS[p.rarity || "common"], leg: (p.rarity || "common") === "legendary" }));
+  for (const fam of FAMILY_LIST) {
+    if (fam.enabled === false) continue;
+    const cur = familyTierOf(familyTiers, fam.id);
+    // FAMILY_DEFS führt `tiers` als OBJEKT {1:def,…} → anbietbare Stufen direkt über TIERS filtern
+    // (nicht offerableTiers aus rarity.js, das ein Array erwartet).
+    for (const t of TIERS) {
+      if (fam.tiers[t] && canOfferFamilyTier(cur, t)) pool.push({ familyId: fam.id, tier: t, weight: TIER_WEIGHTS[t] || 0 });
+    }
+  }
+  // count VERSCHIEDENE Einheiten ziehen (eine Familie bzw. ein Perk höchstens einmal je Angebot, Spec §15).
+  while (chosen.length < count && pool.length > 0) {
+    const total = pool.reduce((a, x) => a + x.weight, 0);
+    if (total <= 0) break;
+    let r = rng() * total, i = 0;
+    while (i < pool.length - 1 && r >= pool[i].weight) { r -= pool[i].weight; i += 1; }
+    const pick = pool[i];
+    if (pick.familyId) {
+      chosen.push({ familyId: pick.familyId, tier: pick.tier });
+      pool = pool.filter((x) => x.familyId !== pick.familyId); // alle Stufen dieser Familie raus
+    } else {
+      chosen.push(pick.perk);
+      if (pick.leg) legendaries += 1;
+      pool = pool.filter((x) => x.perk !== pick.perk
+        && !(legendaries >= C.MAX_LEGENDARIES_PER_OFFER && x.leg)); // Legendär-Limit je Angebot
+    }
   }
   return chosen;
 }

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -38,19 +38,10 @@ export const PERK_DEFS = {
   // ---- A: Deck & C: Rollen — vollständig zu Familien migriert (#167, families.js Kategorien A/C). Die früheren
   //      flachen A1–A10 bzw. C1–C10 sind entfernt; das Angebot bietet A/C nur noch als Familien (buildPerkOffer). ----
 
-  // ---- E-Formationsmarker (V2 §22.6) — reine Marker; Wirkung in computeFormations(perks). ----
-  E6: { id: "E6", cat: "E", label: "Drehzahl",
-        desc: "Eine einzelne Karte darf gleichzeitig zu zwei unterschiedlichen Treppen gehören." },
-  E7: { id: "E7", cat: "E", label: "Kontrollverlust",
-        desc: "Die Positionen 10, 20, 30 und 40 sind Anker (siegreicher Anker ×1,25)." },
-  E8: { id: "E8", cat: "E", label: "Schnellschuss",
-        desc: "Die Positionen 5, 15, 25 und 35 sind Anker (siegreicher Anker ×1,25)." },
-
-  // ---- Seltene Perks (#71, Phase 2e) — Serien-/Tempo-/Crit-Mechanik (Engine-Flags + State) ----
-  E9: { id: "E9", cat: "E", label: "Segmentarbeit",
-        desc: "Formationen dürfen über Segmentgrenzen hinweg fortgesetzt werden." },
-  // Rarität-Umbau (#162, Spec §3.3): E10 ist als Perk DEAKTIVIERT (offerable:false → nie angeboten) und wandert
-  // als Shop-Familie „Feinjustierung" (#164). Definition bleibt vorerst für die extraSwap-Engine/Bestands-Builds.
+  // ---- E: Formationswerkzeuge — E1–E9 vollständig zu Familien migriert (#167, families.js Kategorie E). Ihre
+  //      Wirkung steckt jetzt in computeFormations (familyTiers-bewusst). E10 „Feinjustierung" bleibt als Perk
+  //      DEAKTIVIERT (offerable:false → nie angeboten) und wandert als Shop-Familie (#164); Def bleibt für die
+  //      extraSwap-Engine/Bestands-Builds. ----
   E10: { id: "E10", cat: "E", label: "Feinjustierung", extraSwap: 1, offerable: false,
         desc: "Jede Formationsphase erhält einen zusätzlichen kostenlosen beliebigen Tausch." },
 
@@ -63,18 +54,6 @@ export const PERK_DEFS = {
 
   // ---- D: Score — vollständig zu Familien migriert (#167, siehe families.js Kategorie D). Die früheren
   //      flachen D1–D19 sind entfernt; das Angebot bietet D nur noch als aufwertbare Familien (buildPerkOffer). ----
-
-  // ---- E: Formationswerkzeuge (V2 §22.6) — reine Marker; die Wirkung steckt in computeFormations(perks). ----
-  E1: { id: "E1", cat: "E", label: "Schrittmacher",
-        desc: "Eine Wiederholung darf genau eine fremde Karte zwischen zwei gleichen Werten enthalten." },
-  E2: { id: "E2", cat: "E", label: "Farbbrücke",
-        desc: "Eine einzelne andersfarbige Karte unterbricht einen Farbblock nicht (sie zählt nicht zur Formation)." },
-  E3: { id: "E3", cat: "E", label: "Sanfter Anstieg",
-        desc: "Eine Treppe darf einmal zwei gleiche Werte hintereinander enthalten." },
-  E4: { id: "E4", cat: "E", label: "Großer Schritt",
-        desc: "Eine Treppe darf einmal einen Rückschritt enthalten." },
-  E5: { id: "E5", cat: "E", label: "Pendelwerk",
-        desc: "Ein Wechsel löst bereits ab zwei Karten aus (Differenz weiterhin ≥4)." },
 
   // ---- Legendär (#33): mächtig, aber mit Nachteil. rarity "legendary" → Gewicht 8 & Level-Gate ≥5
   //      (buildOffer). Nutzen bestehende Kategorien (A–E) plus die neuen Legendär-Hooks oben. ----
@@ -145,7 +124,7 @@ export function layoutPerks(owned) { return (owned || []).filter(isLayoutPerk); 
 
 // Migrierte Kategorien: ihre REGULÄREN (nicht legendären) Perks sind jetzt Familien und kommen über FAMILY_DEFS
 // ins Angebot statt über PERK_DEFS. Wächst mit jeder migrierten Kategorie (D, B, A, C; später +E).
-export const MIGRATED_CATS = new Set(["D", "B", "A", "C"]);
+export const MIGRATED_CATS = new Set(["D", "B", "A", "C", "E"]);
 
 // Ist dieser flache Perk durch eine Familie ersetzt? Nur reguläre Perks migrierter Kategorien — die legendären
 // D-Perks (L4/L5/L6/L10) bleiben flach im Legendär-Pool (Spec §3.1).

--- a/src/game/perks.js
+++ b/src/game/perks.js
@@ -171,7 +171,9 @@ export const PERK_DEFS = {
         cardBonus: (ctx) => (ctx.predValue != null && ctx.pValueBase > ctx.predValue ? 3 : 0) },
   E9: { id: "E9", cat: "E", label: "Segmentarbeit",
         desc: "Formationen dürfen über Segmentgrenzen hinweg fortgesetzt werden." },
-  E10: { id: "E10", cat: "E", label: "Feinjustierung", extraSwap: 1,
+  // Rarität-Umbau (#162, Spec §3.3): E10 ist als Perk DEAKTIVIERT (offerable:false → nie angeboten) und wandert
+  // als Shop-Familie „Feinjustierung" (#164). Definition bleibt vorerst für die extraSwap-Engine/Bestands-Builds.
+  E10: { id: "E10", cat: "E", label: "Feinjustierung", extraSwap: 1, offerable: false,
         desc: "Jede Formationsphase erhält einen zusätzlichen kostenlosen beliebigen Tausch." },
   D19: { id: "D19", cat: "D", label: "Überschusskrit",
         desc: "Ein Crit über 100 % effektiver Crit-Chance gibt +250 Score.",
@@ -274,9 +276,7 @@ export const PERK_DEFS = {
         // wird additiv zum Crit-Faktor (harmoniert mit D19 „Überschusskrit"). Kein Wert-Snowball → entsnowballt.
         critChance: (ctx) => 0.05 * (ctx.winStreak || 0),
         critMultBonus: (ctx) => Math.min(Math.max(0, (ctx.rawCrit || 0) - 1), 1) },
-  L7: { id: "L7", cat: "A", rarity: "legendary", label: "Königsmacher", segmentHigh: true,
-        desc: "Die höchste Karte jedes Segments erhält +5 Wert.",
-        cardBonus: (ctx) => (ctx.isSegmentHigh ? 5 : 0) },
+  // L7 „Königsmacher" ersatzlos entfernt (Rarität-Umbau #162, Spec §3.3/§7/§9 — nicht mehr im Pool/Angebot).
   L8: { id: "L8", cat: "A", rarity: "legendary", label: "Schicksalsmaschine", swapExtremes: true,
         desc: "Nach jedem Durchlauf tauschen die erfolgreichste und die erfolgloseste Karte ihre Werte." },
   L9: { id: "L9", cat: "A", rarity: "legendary", label: "Blutvertrag", needsTarget: 4,
@@ -315,7 +315,7 @@ const LAYOUT_EXTRA = new Set([
   "B3", "B4", "B6", "B9", "B10",          // Auftakt-/Zehner-Positionen · Wiederholung · Treppe · Überzahl (Vorgänger)
   "C1", "C3", "C4", "C5", "C6", "C7", "C8", "C10", // Positions-/Nachbarschafts-/Segment-Rollen · Joker/Bindeglied (Formation)
   "D1", "D11",                            // Formations-Sieg / Crit in Formation
-  "L3", "L7", "L11",                      // Positionen 36–40 · Segment-Höchste · Position 20→40
+  "L3", "L11",                            // Positionen 36–40 · Position 20→40 (L7 „Königsmacher" entfernt, #162)
 ]);
 export function isLayoutPerk(id) { return PERK_DEFS[id]?.cat === "E" || LAYOUT_EXTRA.has(id); }
 export function layoutPerks(owned) { return (owned || []).filter(isLayoutPerk); }
@@ -325,7 +325,7 @@ export function layoutPerks(owned) { return (owned || []).filter(isLayoutPerk); 
 // höchstens MAX_LEGENDARIES_PER_OFFER Legendaries je Angebot.
 // Deterministisch über den injizierten rng (ein rng()-Zug je Auswahl). Pool leer → weniger Perks.
 export function buildOffer(owned, rng, count, legendaryChance = 0) {
-  let pool = PERK_LIST.filter((p) => !owned.includes(p.id));
+  let pool = PERK_LIST.filter((p) => !owned.includes(p.id) && p.offerable !== false); // offerable:false = aus dem Pool (E10, #162)
   const chosen = [];
   let legendaries = 0;
   // Expliziter Legendär-Roll (Shop-Spec §10 P5): NUR wenn eine Legendär-Chance übergeben ist. Legendäre werden

--- a/src/game/rarity.js
+++ b/src/game/rarity.js
@@ -1,0 +1,87 @@
+/* ============================================================
+   RARITÄTSSYSTEM — Fundament (Epic #167 / Sub-Issue #162, Spec docs/rarity-system.md).
+   Vier reguläre Stufen (I–IV) als Datenmodell + familien-/stufenbewusste Angebotslogik.
+   ADDITIVE Schicht: dieses Modul bricht das bestehende flache Perk-/Shop-System NICHT — die
+   eigentliche Umstellung der Registries (Perks #163 / Shop #164) baut hierauf auf.
+
+   Begriffe (Spec §1/§2):
+   - Familie: Perk oder Shop-Item als aufwertbare Einheit mit bis zu vier regulären Stufen.
+   - Rang/Stufe im Run: 0 (nicht besessen) | 1 | 2 | 3 | 4. Pro Familie genau einer.
+   - Angebot: nur Stufen ECHT ÜBER dem aktuellen Rang (canOfferFamilyTier); Stufe IV schließt ab.
+   - Legendäre bleiben AUSSERHALB dieses Systems (eigener Legendär-Wurf, unverändert).
+
+   Interne Bezeichnung Stufe IV = "epic" (technisch sauber); die sichtbare deutsche Bezeichnung
+   bleibt "Rar" (Spec §10). Drop-Gewichte + Preise sind Tuning-Konstanten.
+   ============================================================ */
+
+export const TIERS = [1, 2, 3, 4];
+
+// Stufen-Metadaten (Spec §1 + §8). `rarity` = interner Schlüssel, `label` = sichtbarer deutscher Name,
+// `color` = UI-Farbe (I Grau · II Grün · III Blau · IV Lila), `price` = Shoppreis der Zielstufe.
+export const TIER_META = {
+  1: { tier: 1, rarity: "normal",   label: "Normal",       color: "#8a8a95", price: 8 },
+  2: { tier: 2, rarity: "uncommon", label: "Ungewöhnlich", color: "#4ade80", price: 12 },
+  3: { tier: 3, rarity: "rare",     label: "Selten",       color: "#5a8ade", price: 18 },
+  4: { tier: 4, rarity: "epic",     label: "Rar",          color: "#a855f7", price: 30 },
+};
+
+// Römische Stufe direkt hinter dem Familiennamen (Spec §8: „Momentum III").
+export const ROMAN = { 1: "I", 2: "II", 3: "III", 4: "IV" };
+
+// Drop-Gewichte je Stufe (Spec §10, offen → tunebar). Höhere Stufen seltener. [TUNING]
+export const TIER_WEIGHTS = { 1: 100, 2: 46, 3: 20, 4: 8 };
+
+export const tierMeta   = (tier) => TIER_META[tier] || null;
+export const priceOfTier = (tier) => TIER_META[tier]?.price ?? 0;
+export const romanOf    = (tier) => ROMAN[tier] || String(tier);
+export const rarityKeyOf = (tier) => TIER_META[tier]?.rarity || null;
+export const tierColor  = (tier) => TIER_META[tier]?.color || "#8a8a95";
+// Sichtbares Etikett „Name III" (Spec §8). Leere/0-Stufe → nur der Name.
+export const tierLabel  = (name, tier) => (tier ? `${name} ${romanOf(tier)}` : name);
+
+/* Angebotsfilter (Spec §2.4): eine Stufe darf nur angeboten werden, wenn sie ECHT über dem
+   aktuellen Familienrang liegt. currentTier 0 = Familie noch nicht besessen. */
+export function canOfferFamilyTier(currentTier, offeredTier) {
+  return offeredTier > (currentTier || 0);
+}
+
+// Anbietbare Stufen einer Familie beim aktuellen Rang (leer, sobald IV erreicht → Familie abgeschlossen).
+export function offerableTiers(family, currentTier) {
+  return (family?.tiers || TIERS).filter((t) => canOfferFamilyTier(currentTier, t));
+}
+
+/* Familienzustand: { [familyId]: currentTier }. Reine Helfer (immutabel). */
+export const familyTierOf = (familyTiers, id) => (familyTiers || {})[id] || 0;
+export const withFamilyTier = (familyTiers, id, tier) => ({ ...(familyTiers || {}), [id]: tier });
+export const familyComplete = (familyTiers, id) => familyTierOf(familyTiers, id) >= 4;
+
+/* Familien-/stufenbewusstes Angebot (Spec §2): bis zu `count` VERSCHIEDENE Familien; jede erscheint
+   auf genau EINER anbietbaren Stufe, gewichtet nach TIER_WEIGHTS[tier]. Legendäre laufen NICHT hierüber.
+   Deterministisch über den injizierten rng (ein rng()-Zug je gewählter Familie) — kein Math.random hier.
+   `families`: [{ id, tiers?: number[], enabled?: boolean }]. `familyTiers`: aktueller Rang je Familie.
+   Rückgabe: [{ familyId, tier }] (leer, wenn kein anbietbares Paar existiert). */
+export function buildFamilyOffer(families = [], familyTiers = {}, rng = Math.random, count = 3) {
+  let pool = [];
+  for (const f of families) {
+    if (!f || f.enabled === false) continue;
+    const cur = familyTierOf(familyTiers, f.id);
+    for (const t of offerableTiers(f, cur)) pool.push({ id: f.id, tier: t, weight: TIER_WEIGHTS[t] || 0 });
+  }
+  const chosen = [];
+  while (chosen.length < count && pool.length > 0) {
+    const total = pool.reduce((a, x) => a + x.weight, 0);
+    if (total <= 0) break;
+    let r = rng() * total, i = 0;
+    while (i < pool.length - 1 && r >= pool[i].weight) { r -= pool[i].weight; i += 1; }
+    const pick = pool[i];
+    chosen.push({ familyId: pick.id, tier: pick.tier });
+    pool = pool.filter((x) => x.id !== pick.id); // eine Familie höchstens einmal je Angebot (Spec §15)
+  }
+  return chosen;
+}
+
+/* Upgrade-Verhalten (Spec §2.3) — Marker-Konstanten für die Familien-Definitionen (#163/#164):
+   - replacement: nur die Regel der höchsten gehaltenen Stufe ist aktiv (keine parallelen Trigger).
+   - cumulative:  jede tatsächlich gewählte Stufe führt EINMAL ihr Paket aus; Deckänderungen bleiben.
+   - role:        Zielkarten behalten ihre Rolle; Zahlen/Regeln steigen, zusätzliche Ziele neu wählen. */
+export const UPGRADE_TYPES = { REPLACEMENT: "replacement", CUMULATIVE: "cumulative", ROLE: "role" };

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -51,6 +51,7 @@ export function initialState(rng = Math.random) {
     sinceWin: 0, // #71 Durchbruch: aufeinanderfolgende Stiche ohne Sieg
     lossStreak: 0, lastWinValue: null, // #71 Rares: Revanche / Präzision
     critFollowArmed: false, weaknessArmed: false, // #71 Crit-Historie: Crit-Folge (D14) / Schwachstellenanalyse (D16)
+    weaknessBig: false, // Rarität #167: D_WEAKNESS IV — rüstende Niederlage mit großem Abstand (→ +900 statt +600)
     misfireScore: 0, // V2 §22.6 D15: Score-Ladung (Fehlzündung)
     winSuit: null, winSuitStreak: 0, recentResults: [], // #71 Historie: Farbserie / Volles Haus
     // Stat-System (V2 §22.3): akkumulierte Summen, additiv/ohne Caps.

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -1,5 +1,5 @@
 import { buildDeck, shuffledOrder, shuffle } from "./deck.js";
-import { PERK_DEFS, buildOffer } from "./perks.js";
+import { PERK_DEFS, buildPerkOffer } from "./perks.js";
 import { familyDef, applyFamilyPick } from "./families.js";
 import { archetypeOf, initLightning, initHeat, heatMaxFor, heatConsumerCount, maxChargeFor, chargeConsumerCount,
   frozenTargetFor, frozenCount, freezeCards, unfreezeAll, hasColdFront, hasFrostTrail, buildSkillOffer } from "./skills.js";
@@ -277,6 +277,8 @@ export function reducer(state, action) {
       if (state.phase !== "levelup") return state;
       const { familyId, tier, rng } = action;
       if (!familyDef(familyId) || !tier) return state;
+      // Angebotsvalidierung (Spec §2.4): die Familie+Zielstufe muss im aktuellen Angebot stehen (analog PICK_PERK).
+      if (!state.offer || !state.offer.some((e) => e && e.familyId === familyId && e.tier === tier)) return state;
       const { familyTiers, deck, roles } = applyFamilyPick(
         familyId, tier, { familyTiers: state.familyTiers, deck: state.deck, roles: state.roles }, rng);
       return { ...state, familyTiers, deck, roles, offer: null, phase: "play" };
@@ -367,7 +369,7 @@ export function reducer(state, action) {
     // Skill-Angebot ablehnen → stattdessen ein Perk-Angebot für diese Runde (nie „verschwendet").
     case "DECLINE_SKILL": {
       if (state.phase !== "levelup" || !state.skillOffer) return state;
-      const off = buildOffer(state.perks, action.rng, PERKS_OFFERED, perkLegendaryChance(state.shop));
+      const off = buildPerkOffer(state.perks, state.familyTiers, action.rng, PERKS_OFFERED, perkLegendaryChance(state.shop));
       const fate = !!(state.shop && state.shop.fateControl);         // P-L1: gratis Reroll gilt fürs neue Perk-Angebot
       return off.length > 0
         ? { ...state, skillOffer: null, offer: off, freePerkReroll: fate, freeSkillReroll: false } // → Perk-Auswahl
@@ -389,7 +391,7 @@ export function reducer(state, action) {
       const free = !!state.freePerkReroll;
       const tokens = (state.shop && state.shop.perkRerolls) || 0;
       if (!free && tokens <= 0) return state;                        // keine Ressource → wirkungslos
-      const offer = buildOffer(state.perks, action.rng, PERKS_OFFERED, perkLegendaryChance(state.shop));
+      const offer = buildPerkOffer(state.perks, state.familyTiers, action.rng, PERKS_OFFERED, perkLegendaryChance(state.shop));
       const shop = free ? state.shop : { ...state.shop, perkRerolls: tokens - 1 };
       return { ...state, offer, shop, freePerkReroll: free ? false : state.freePerkReroll };
     }

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -1,5 +1,6 @@
 import { buildDeck, shuffledOrder, shuffle } from "./deck.js";
 import { PERK_DEFS, buildOffer } from "./perks.js";
+import { familyDef, applyFamilyPick } from "./families.js";
 import { archetypeOf, initLightning, initHeat, heatMaxFor, heatConsumerCount, maxChargeFor, chargeConsumerCount,
   frozenTargetFor, frozenCount, freezeCards, unfreezeAll, hasColdFront, hasFrostTrail, buildSkillOffer } from "./skills.js";
 import { STAT_DEFS, STAT_IDS } from "./stats.js";
@@ -59,6 +60,9 @@ export function initialState(rng = Math.random) {
     roles: {}, targetPerk: null, successorQueue: [], triumphArmed: [], // Kartenrollen (V2 §22.6 C): Rollen-ids, aktive Zielauswahl, Nachfolger-/Triumph-State
     l4Boost: {}, l5Used: [], l8Wins: {}, chainArmed: false, pos20Bonus: 0, // Legendaries (V2 §22.6 L)
     perks: [], offer: null,
+    // Raritätssystem (Epic #167, Spec §2.1): Familienrang je Familie { [familyId]: 1|2|3|4 }. Läuft ADDITIV
+    // neben `perks` (flache Legendäre) — die Engine löst aktive Familien-Stufen über activeTierDefs auf.
+    familyTiers: {},
     // Planung (Shop-Spec §10): gratis Neuwurf je Auswahl aus P-L1 Schicksalskontrolle — beim Anbieten
     // eines Perk-/Skill-Angebots gesetzt (wenn fateControl aktiv), beim Neuwurf zuerst verbraucht (vor Tokens).
     freePerkReroll: false, freeSkillReroll: false,
@@ -261,6 +265,19 @@ export function reducer(state, action) {
       return { ...state, deck, perks, roles, offer: null,
                phase: goTarget ? "target" : "play",
                targetPerk: goTarget ? perkId : null };
+    }
+
+    // Familien-Pick (Rarität-Umbau #167, Spec §2.4): eine Familie auf eine Zielstufe (I–IV) heben/erwerben.
+    // Läuft ADDITIV neben PICK_PERK; applyFamilyPick liefert das Patch (familyTiers, deck, roles) — bei
+    // REPLACEMENT (Kat. D) nur der Rang, CUMULATIVE führt ihr Deck-Paket aus. Die Angebotsvalidierung
+    // (Familie+Stufe im Angebot, Ziel-Flow bei ROLE) folgt mit buildFamilyOffer (#163 Schritt 3).
+    case "PICK_FAMILY": {
+      if (state.phase !== "levelup") return state;
+      const { familyId, tier, rng } = action;
+      if (!familyDef(familyId) || !tier) return state;
+      const { familyTiers, deck, roles } = applyFamilyPick(
+        familyId, tier, { familyTiers: state.familyTiers, deck: state.deck, roles: state.roles }, rng);
+      return { ...state, familyTiers, deck, roles, offer: null, phase: "play" };
     }
 
     // Zielauswahl bestätigen (V2 §22.6 C): genau needsTarget Karten → Rolle setzen (C9 = dauerhafte Wertmod).

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -262,13 +262,13 @@ export function reducer(state, action) {
       if (!state.offer || !state.offer.includes(perkId)) return state;
       const def = PERK_DEFS[perkId];
       const perks = [...state.perks, perkId];
-      let deck = def.onPick ? def.onPick(state.deck, rng) : state.deck; // Kat.-A-Mods sofort dauerhaft
+      // Kat. A (Deck-Mods beim Pick) ist zu Familien migriert (#167) → flache Perks verändern das Deck nicht mehr.
       // L5 Jackpot & Co.: zufällige Kartenrolle sofort setzen (kein manueller Ziel-Schritt).
       let roles = state.roles;
       if (def.randomTarget) roles = { ...(state.roles || {}), [perkId]: shuffle(state.deck.map((c) => c.id), rng).slice(0, def.randomTarget) };
       // Perks mit manueller Kartenauswahl öffnen die Zielauswahl (§22.5); sonst weiter.
       const goTarget = !!def.needsTarget;
-      return { ...state, deck, perks, roles, offer: null,
+      return { ...state, perks, roles, offer: null,
                phase: goTarget ? "target" : "play",
                targetPerk: goTarget ? perkId : null };
     }

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -65,6 +65,10 @@ export function initialState(rng = Math.random) {
     // Raritätssystem (Epic #167, Spec §2.1): Familienrang je Familie { [familyId]: 1|2|3|4 }. Läuft ADDITIV
     // neben `perks` (flache Legendäre) — die Engine löst aktive Familien-Stufen über activeTierDefs auf.
     familyTiers: {},
+    // Familien-Ziel-Auswahl (Rarität #167, Kat. A ab #163): aktive Farb-/Ziel-Auswahl beim Pick einer Stufe mit
+    // `pickTarget` (z. B. A_SUIT_BOOST III/IV, A_SUIT_DUEL III/IV). null = keine offene Auswahl. Kategorie C nutzt
+    // denselben Fluss später für Karten-Ziele (Rollen).
+    familyTarget: null,
     // Planung (Shop-Spec §10): gratis Neuwurf je Auswahl aus P-L1 Schicksalskontrolle — beim Anbieten
     // eines Perk-/Skill-Angebots gesetzt (wenn fateControl aktiv), beim Neuwurf zuerst verbraucht (vor Tokens).
     freePerkReroll: false, freeSkillReroll: false,
@@ -276,12 +280,43 @@ export function reducer(state, action) {
     case "PICK_FAMILY": {
       if (state.phase !== "levelup") return state;
       const { familyId, tier, rng } = action;
-      if (!familyDef(familyId) || !tier) return state;
+      const fam = familyDef(familyId);
+      if (!fam || !tier) return state;
       // Angebotsvalidierung (Spec §2.4): die Familie+Zielstufe muss im aktuellen Angebot stehen (analog PICK_PERK).
       if (!state.offer || !state.offer.some((e) => e && e.familyId === familyId && e.tier === tier)) return state;
+      // Ziel-Stufe (pickTarget, z. B. A_SUIT_BOOST III/IV): erst Farb-/Ziel-Auswahl öffnen; die eigentliche
+      // Anwendung (applyFamilyPick mit target) folgt bei FAMILY_TARGET_CONFIRM. Angebot ist damit verbraucht.
+      if (fam.tiers[tier] && fam.tiers[tier].pickTarget) {
+        return { ...state, offer: null, phase: "family-target", familyTarget: { familyId, tier, suits: [] } };
+      }
       const { familyTiers, deck, roles } = applyFamilyPick(
         familyId, tier, { familyTiers: state.familyTiers, deck: state.deck, roles: state.roles }, rng);
       return { ...state, familyTiers, deck, roles, offer: null, phase: "play" };
+    }
+
+    // ---- Familien-Ziel-Auswahl (Rarität #167, Spec §2.3/§2.4) — Farb-/Ziel-Auswahl für pickTarget-Stufen.
+    //      Generisch gehalten, damit Kategorie C denselben Fluss für Karten-Ziele (Rollen) mitnutzt. ----
+    case "FAMILY_TARGET_SUIT": {
+      if (state.phase !== "family-target" || !state.familyTarget) return state;
+      const ft = state.familyTarget;
+      const need = familyDef(ft.familyId)?.tiers?.[ft.tier]?.pickTarget?.suits || 0;
+      if (!need || !C.SUIT_ORDER.includes(action.suit)) return state;
+      let suits = ft.suits.slice();
+      if (suits.includes(action.suit)) suits = suits.filter((s) => s !== action.suit);   // abwählen
+      else if (suits.length < need) suits.push(action.suit);                              // hinzufügen (Reihenfolge = Gewinner→Verlierer)
+      else if (need === 1) suits = [action.suit];                                         // Einzelwahl: umschalten
+      else return state;                                                                  // Limit erreicht → ignorieren
+      return { ...state, familyTarget: { ...ft, suits } };
+    }
+    case "FAMILY_TARGET_CONFIRM": {
+      if (state.phase !== "family-target" || !state.familyTarget) return state;
+      const ft = state.familyTarget;
+      const spec = familyDef(ft.familyId)?.tiers?.[ft.tier]?.pickTarget || {};
+      if (spec.suits && ft.suits.length !== spec.suits) return state;                     // genau N Farben nötig
+      const target = { suits: ft.suits };
+      const { familyTiers, deck, roles } = applyFamilyPick(
+        ft.familyId, ft.tier, { familyTiers: state.familyTiers, deck: state.deck, roles: state.roles, target }, action.rng);
+      return { ...state, familyTiers, deck, roles, phase: "play", familyTarget: null };
     }
 
     // Zielauswahl bestätigen (V2 §22.6 C): genau needsTarget Karten → Rolle setzen (C9 = dauerhafte Wertmod).

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -52,6 +52,7 @@ export function initialState(rng = Math.random) {
     lossStreak: 0, lastWinValue: null, // #71 Rares: Revanche / Präzision
     critFollowArmed: false, weaknessArmed: false, // #71 Crit-Historie: Crit-Folge (D14) / Schwachstellenanalyse (D16)
     weaknessBig: false, // Rarität #167: D_WEAKNESS IV — rüstende Niederlage mit großem Abstand (→ +900 statt +600)
+    interplayStored: 0, // Rarität #167: D_INTERPLAY IV — in Niederlagen gebankter Score, beim nächsten Sieg als Flat ausgezahlt
     misfireScore: 0, // V2 §22.6 D15: Score-Ladung (Fehlzündung)
     winSuit: null, winSuitStreak: 0, recentResults: [], // #71 Historie: Farbserie / Volles Haus
     // Stat-System (V2 §22.3): akkumulierte Summen, additiv/ohne Caps.

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -1,6 +1,7 @@
 import { buildDeck, shuffledOrder, shuffle } from "./deck.js";
 import { PERK_DEFS, buildPerkOffer } from "./perks.js";
 import { familyDef, applyFamilyPick } from "./families.js";
+import { UPGRADE_TYPES } from "./rarity.js";
 import { archetypeOf, initLightning, initHeat, heatMaxFor, heatConsumerCount, maxChargeFor, chargeConsumerCount,
   frozenTargetFor, frozenCount, freezeCards, unfreezeAll, hasColdFront, hasFrostTrail, buildSkillOffer } from "./skills.js";
 import { STAT_DEFS, STAT_IDS } from "./stats.js";
@@ -284,39 +285,60 @@ export function reducer(state, action) {
       if (!fam || !tier) return state;
       // Angebotsvalidierung (Spec §2.4): die Familie+Zielstufe muss im aktuellen Angebot stehen (analog PICK_PERK).
       if (!state.offer || !state.offer.some((e) => e && e.familyId === familyId && e.tier === tier)) return state;
-      // Ziel-Stufe (pickTarget, z. B. A_SUIT_BOOST III/IV): erst Farb-/Ziel-Auswahl öffnen; die eigentliche
-      // Anwendung (applyFamilyPick mit target) folgt bei FAMILY_TARGET_CONFIRM. Angebot ist damit verbraucht.
-      if (fam.tiers[tier] && fam.tiers[tier].pickTarget) {
-        return { ...state, offer: null, phase: "family-target", familyTarget: { familyId, tier, suits: [] } };
-      }
-      const { familyTiers, deck, roles } = applyFamilyPick(
-        familyId, tier, { familyTiers: state.familyTiers, deck: state.deck, roles: state.roles }, rng);
-      return { ...state, familyTiers, deck, roles, offer: null, phase: "play" };
+      const applyNow = () => {
+        const { familyTiers, deck, roles } = applyFamilyPick(
+          familyId, tier, { familyTiers: state.familyTiers, deck: state.deck, roles: state.roles }, rng);
+        return { ...state, familyTiers, deck, roles, offer: null, phase: "play" };
+      };
+      const pt = fam.tiers[tier] && fam.tiers[tier].pickTarget;
+      if (!pt) return applyNow();                                                          // kein Ziel → direkt anwenden
+      // Farb-Ziel (A_SUIT_BOOST/A_SUIT_DUEL): immer die volle Anzahl frisch wählen.
+      if (pt.suits) return { ...state, offer: null, phase: "family-target", familyTarget: { familyId, tier, kind: "suits", need: pt.suits, suits: [], cards: [] } };
+      // Karten-Ziel: ROLE wählt nur die ZUSÄTZLICHEN Ziele (Stufe-Ziel − bereits gehaltene, Spec §2.3);
+      // CUMULATIVE (C_SACRIFICE) wählt die volle Anzahl. need 0 (Upgrade ohne neue Ziele) → direkt anwenden.
+      const held = fam.upgradeType === UPGRADE_TYPES.ROLE ? ((state.roles || {})[familyId] || []).length : 0;
+      const need = Math.max(0, pt.cards - held);
+      if (need === 0) return applyNow();
+      return { ...state, offer: null, phase: "family-target", familyTarget: { familyId, tier, kind: "cards", need, suits: [], cards: [] } };
     }
 
-    // ---- Familien-Ziel-Auswahl (Rarität #167, Spec §2.3/§2.4) — Farb-/Ziel-Auswahl für pickTarget-Stufen.
-    //      Generisch gehalten, damit Kategorie C denselben Fluss für Karten-Ziele (Rollen) mitnutzt. ----
+    // ---- Familien-Ziel-Auswahl (Rarität #167, Spec §2.3/§2.4) — Farb- ODER Karten-Ziel für pickTarget-Stufen.
+    //      `familyTarget = { familyId, tier, kind:"suits"|"cards", need, suits, cards }`. Kategorie C nutzt den
+    //      Karten-Modus für Rollen-Ziele; A den Farb-Modus. ----
     case "FAMILY_TARGET_SUIT": {
-      if (state.phase !== "family-target" || !state.familyTarget) return state;
+      if (state.phase !== "family-target" || !state.familyTarget || state.familyTarget.kind !== "suits") return state;
       const ft = state.familyTarget;
-      const need = familyDef(ft.familyId)?.tiers?.[ft.tier]?.pickTarget?.suits || 0;
-      if (!need || !C.SUIT_ORDER.includes(action.suit)) return state;
+      if (!C.SUIT_ORDER.includes(action.suit)) return state;
       let suits = ft.suits.slice();
       if (suits.includes(action.suit)) suits = suits.filter((s) => s !== action.suit);   // abwählen
-      else if (suits.length < need) suits.push(action.suit);                              // hinzufügen (Reihenfolge = Gewinner→Verlierer)
-      else if (need === 1) suits = [action.suit];                                         // Einzelwahl: umschalten
+      else if (suits.length < ft.need) suits.push(action.suit);                           // hinzufügen (Reihenfolge = Gewinner→Verlierer)
+      else if (ft.need === 1) suits = [action.suit];                                      // Einzelwahl: umschalten
       else return state;                                                                  // Limit erreicht → ignorieren
       return { ...state, familyTarget: { ...ft, suits } };
+    }
+    case "FAMILY_TARGET_CARD": {
+      if (state.phase !== "family-target" || !state.familyTarget || state.familyTarget.kind !== "cards") return state;
+      const ft = state.familyTarget;
+      if (!state.deck.some((c) => c.id === action.cardId)) return state;                  // Karte muss existieren
+      // Bereits als Rolle DIESER Familie gehaltene Karten sind kein gültiges Zusatz-Ziel (Rollen-Upgrade).
+      if (((state.roles || {})[ft.familyId] || []).includes(action.cardId)) return state;
+      let cards = ft.cards.slice();
+      if (cards.includes(action.cardId)) cards = cards.filter((id) => id !== action.cardId); // abwählen
+      else if (cards.length < ft.need) cards.push(action.cardId);                            // hinzufügen
+      else return state;                                                                     // Limit erreicht
+      return { ...state, familyTarget: { ...ft, cards } };
     }
     case "FAMILY_TARGET_CONFIRM": {
       if (state.phase !== "family-target" || !state.familyTarget) return state;
       const ft = state.familyTarget;
-      const spec = familyDef(ft.familyId)?.tiers?.[ft.tier]?.pickTarget || {};
-      if (spec.suits && ft.suits.length !== spec.suits) return state;                     // genau N Farben nötig
-      const target = { suits: ft.suits };
+      const sel = ft.kind === "cards" ? ft.cards : ft.suits;
+      if (sel.length !== ft.need) return state;                                            // genau `need` Ziele nötig
+      const target = { suits: ft.suits, cards: ft.cards, order: state.playerOrder };
       const { familyTiers, deck, roles } = applyFamilyPick(
         ft.familyId, ft.tier, { familyTiers: state.familyTiers, deck: state.deck, roles: state.roles, target }, action.rng);
-      return { ...state, familyTiers, deck, roles, phase: "play", familyTarget: null };
+      // Rollen/Deck können die Formationserkennung ändern (C_JOKER/C_BRIDGE, C_SACRIFICE-Deckmod) → neu berechnen (wie CONFIRM_TARGET).
+      const formations = computeFormations(state.playerOrder, deck, roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {});
+      return { ...state, familyTiers, deck, roles, formations, phase: "play", familyTarget: null };
     }
 
     // Zielauswahl bestätigen (V2 §22.6 C): genau needsTarget Karten → Rolle setzen (C9 = dauerhafte Wertmod).

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -135,7 +135,7 @@ export function reducer(state, action) {
       newShop.purchaseLog = [...(shop.purchaseLog || []), purchaseLogEntry(def, offer.price, state.cycle)]; // #127
       // Formationen neu berechnen — F-Items (§9) ändern die Erkennung permanent.
       const deck2 = patch.deck || state.deck;
-      const formations2 = computeFormations(state.playerOrder, deck2, state.roles, state.perks, state.skills, newShop.anchors, newShop.permanentEffects);
+      const formations2 = computeFormations(state.playerOrder, deck2, state.roles, state.perks, state.skills, newShop.anchors, newShop.permanentEffects, state.familyTiers);
       return { ...merged, deck: deck2, formations: formations2, shop: newShop };
     }
 
@@ -250,7 +250,7 @@ export function reducer(state, action) {
       if (def.repeatable === false) newShop.boughtNonRepeatableIds = [...(shop.boughtNonRepeatableIds || []), def.id];
       newShop.purchaseLog = [...(shop.purchaseLog || []), purchaseLogEntry(def, offer.price, state.cycle, target)]; // #127
       // Formationen mit den (evtl. neuen) Ankern neu berechnen — A5 Formationsanker wirkt sofort.
-      const formations = computeFormations(state.playerOrder, deck, state.roles, state.perks, state.skills, newShop.anchors, newShop.permanentEffects);
+      const formations = computeFormations(state.playerOrder, deck, state.roles, state.perks, state.skills, newShop.anchors, newShop.permanentEffects, state.familyTiers);
       return { ...merged, deck, formations, phase: "shop", shopTarget: null, shop: newShop };
     }
 
@@ -337,7 +337,7 @@ export function reducer(state, action) {
       const { familyTiers, deck, roles } = applyFamilyPick(
         ft.familyId, ft.tier, { familyTiers: state.familyTiers, deck: state.deck, roles: state.roles, target }, action.rng);
       // Rollen/Deck können die Formationserkennung ändern (C_JOKER/C_BRIDGE, C_SACRIFICE-Deckmod) → neu berechnen (wie CONFIRM_TARGET).
-      const formations = computeFormations(state.playerOrder, deck, roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {});
+      const formations = computeFormations(state.playerOrder, deck, roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {}, familyTiers);
       return { ...state, familyTiers, deck, roles, formations, phase: "play", familyTarget: null };
     }
 
@@ -359,7 +359,7 @@ export function reducer(state, action) {
         deck = def.permMod(state.deck, state.playerOrder, ids);
       }
       const roles = { ...(state.roles || {}), [state.targetPerk]: ids };
-      return { ...state, deck, roles, formations: computeFormations(state.playerOrder, deck, roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {}), phase: "play", targetPerk: null };
+      return { ...state, deck, roles, formations: computeFormations(state.playerOrder, deck, roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {}, state.familyTiers), phase: "play", targetPerk: null };
     }
 
     // Stat-Auswahl (V2 §22.3): der gewählte Stat addiert seinen Step auf das zugehörige Summenfeld.
@@ -419,7 +419,7 @@ export function reducer(state, action) {
         frostbitePending = []; frostbiteActive = [];
       }
       // Formationen neu berechnen: eingefrorene Karten + Eis-Skills beeinflussen die Erkennung (Wildcards/Anker).
-      const formations = computeFormations(state.playerOrder, deck, state.roles, state.perks, skills, state.shop?.anchors || [], state.shop?.permanentEffects || {});
+      const formations = computeFormations(state.playerOrder, deck, state.roles, state.perks, skills, state.shop?.anchors || [], state.shop?.permanentEffects || {}, state.familyTiers);
       return { ...state, skills, activeArchetypes, lightning, heat, deck, iceTemp, frostSwapsUsed, frostbitePending, frostbiteActive, formations, phase: "play", skillOffer: null };
     }
 
@@ -483,7 +483,7 @@ export function reducer(state, action) {
       if (!isFree && (state.formationEnergy || 0) <= 0) return state; // bezahlter Tausch braucht Energie
       const order = state.playerOrder.slice();
       [order[i], order[j]] = [order[j], order[i]];
-      return { ...state, playerOrder: order, formations: computeFormations(order, state.deck, state.roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {}),
+      return { ...state, playerOrder: order, formations: computeFormations(order, state.deck, state.roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {}, state.familyTiers),
                formationEnergy: isFree ? state.formationEnergy : state.formationEnergy - 1,
                formationSwaps: [...(state.formationSwaps || []), { i, j, free: isFree, frozenId: freeFrozenId }],
                frostSwapsUsed: isFree ? [...used, freeFrozenId] : used };
@@ -496,7 +496,7 @@ export function reducer(state, action) {
       const order = state.playerOrder.slice();
       [order[last.i], order[last.j]] = [order[last.j], order[last.i]];
       const frostSwapsUsed = last.free ? (state.frostSwapsUsed || []).filter((id) => id !== last.frozenId) : (state.frostSwapsUsed || []);
-      return { ...state, playerOrder: order, formations: computeFormations(order, state.deck, state.roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {}),
+      return { ...state, playerOrder: order, formations: computeFormations(order, state.deck, state.roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {}, state.familyTiers),
                formationEnergy: last.free ? state.formationEnergy : state.formationEnergy + 1, formationSwaps: swaps, frostSwapsUsed };
     }
     // Alle Tausche der Phase zurücknehmen → Ausgangsreihenfolge + volle Energie + freie Frosttausche zurück.
@@ -505,7 +505,7 @@ export function reducer(state, action) {
       const order = state.playerOrder.slice();
       const swaps = state.formationSwaps || [];
       for (let k = swaps.length - 1; k >= 0; k--) { const { i, j } = swaps[k]; [order[i], order[j]] = [order[j], order[i]]; }
-      return { ...state, playerOrder: order, formations: computeFormations(order, state.deck, state.roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {}),
+      return { ...state, playerOrder: order, formations: computeFormations(order, state.deck, state.roles, state.perks, state.skills, state.shop?.anchors || [], state.shop?.permanentEffects || {}, state.familyTiers),
                formationEnergy: C.FORMATION_ENERGY + (state.perks || []).reduce((t, id) => t + (PERK_DEFS[id].extraSwap || 0), 0),
                formationSwaps: [], frostSwapsUsed: [] };
     }

--- a/src/game/reducer.js
+++ b/src/game/reducer.js
@@ -341,7 +341,8 @@ export function reducer(state, action) {
       return { ...state, familyTiers, deck, roles, formations, phase: "play", familyTarget: null };
     }
 
-    // Zielauswahl bestätigen (V2 §22.6 C): genau needsTarget Karten → Rolle setzen (C9 = dauerhafte Wertmod).
+    // Zielauswahl bestätigen (V2 §22.6): genau needsTarget Karten → Rolle setzen bzw. dauerhafte Wertmod (L1/L9).
+    // C-Rollen (inkl. C9 Opfergabe) sind zu Familien migriert (#167) → laufen über den Familien-Ziel-Fluss, nicht hier.
     case "CONFIRM_TARGET": {
       if (state.phase !== "target" || !state.targetPerk) return state;
       const def = PERK_DEFS[state.targetPerk];
@@ -349,13 +350,7 @@ export function reducer(state, action) {
       const ids = (action.cardIds || []).slice(0, need);
       if (ids.length !== need || new Set(ids).size !== need) return state; // genau N unterschiedliche Karten
       let deck = state.deck;
-      if (def.sacrificeMod) { // C9 Opfergabe: gewählte Karte −3, ihr direkter Nachfolger (aktuelle Reihenfolge) +5 — dauerhaft.
-        const idx = state.playerOrder.findIndex((di) => state.deck[di].id === ids[0]);
-        const succId = idx >= 0 && idx + 1 < state.playerOrder.length ? state.deck[state.playerOrder[idx + 1]].id : null;
-        deck = state.deck.map((c) =>
-          c.id === ids[0] ? { ...c, value: Math.max(0, c.value - 3) }
-          : c.id === succId ? { ...c, value: c.value + 5 } : c);
-      } else if (def.permMod) { // L1 Überladung / L9 Blutvertrag: dauerhafte Wertmods der gewählten Karten.
+      if (def.permMod) { // L1 Überladung / L9 Blutvertrag: dauerhafte Wertmods der gewählten Karten.
         deck = def.permMod(state.deck, state.playerOrder, ids);
       }
       const roles = { ...(state.roles || {}), [state.targetPerk]: ids };

--- a/src/ui/BuildPanel.jsx
+++ b/src/ui/BuildPanel.jsx
@@ -3,15 +3,16 @@ import { PerkList, SkillList } from "./BuildSummary.jsx";
 /* Build-Übersicht unter dem Battlefield: links die gewählten Perks, rechts die Skills
    (Blitz-Archetyp). Beide anklickbar → Beschreibung. Deck-Histogramm sitzt als eigener
    „Chronik"-Block ganz unten (#28). */
-export function BuildPanel({ perks, skills = [] }) {
+export function BuildPanel({ perks, skills = [], familyTiers = {} }) {
+  const famCount = Object.values(familyTiers).filter((t) => t > 0).length;
   return (
     <div className="rounded-xl p-4 as-panel" style={{ background: "#17171c", border: "1px solid #26262e" }}>
       <div className="grid sm:grid-cols-2 gap-4">
         <div>
           <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">
-            Perks — {perks.length}
+            Perks — {perks.length + famCount}
           </div>
-          <PerkList perks={perks} empty="Noch keine Perks. Nach jeder Runde wählst du einen dazu." />
+          <PerkList perks={perks} familyTiers={familyTiers} empty="Noch keine Perks. Nach jeder Runde wählst du einen dazu." />
         </div>
         <div className="sm:border-l sm:pl-4" style={{ borderColor: "#26262e" }}>
           <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">

--- a/src/ui/BuildSummary.jsx
+++ b/src/ui/BuildSummary.jsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { PERK_DEFS, CATEGORIES, rarityOf, RARITY_META } from "../game/perks.js";
+import { familyDef } from "../game/families.js";
+import { tierMeta, romanOf } from "../game/rarity.js";
 import { SKILL_DEFS, ARCHETYPE_META, archetypeOf } from "../game/skills.js";
 import { SUIT_ORDER, suitColor, suitName } from "../game/constants.js";
 
@@ -8,13 +10,31 @@ const ac = (id) => ARCHETYPE_META[archetypeOf(id)] || { label: "Skill", icon: "�
 
 /* Gemeinsame Build-Kontext-Bausteine (#22): geteilt von BuildPanel und PerkSelect. */
 
-/* Aktive Perks je Kategorie, anklickbar → Beschreibung (#1). Klick löst keine Auswahl aus. */
-export function PerkList({ perks, empty = "Noch keine Perks." }) {
-  const [openPerk, setOpenPerk] = useState(null);
+/* Aktive Perks & Familien je Kategorie, anklickbar → Beschreibung (#1). Klick löst keine Auswahl aus.
+   Rarität #167: `familyTiers` mischt gehaltene Familien (Name + römische Stufe, Stufenfarbe) unter die flachen Perks. */
+export function PerkList({ perks, familyTiers = {}, empty = "Noch keine Perks." }) {
+  const [open, setOpen] = useState(null); // { kind: "perk"|"family", id }
+  const isOpen = (kind, id) => open && open.kind === kind && open.id === id;
+  const toggle = (kind, id) => setOpen(isOpen(kind, id) ? null : { kind, id });
+  // Kombinierte Einträge je Kategorie: flache Perks + gehaltene Familien (Rang > 0).
+  const heldFams = Object.entries(familyTiers).filter(([, t]) => t > 0);
   const byCat = {};
-  for (const id of perks) (byCat[PERK_DEFS[id].cat] ||= []).push(id);
-  const open = openPerk && perks.includes(openPerk) ? PERK_DEFS[openPerk] : null;
-  if (perks.length === 0) return <div className="text-sm opacity-40">{empty}</div>;
+  for (const id of perks) (byCat[PERK_DEFS[id].cat] ||= []).push({ kind: "perk", id });
+  for (const [fid, tier] of heldFams) { const f = familyDef(fid); if (f) (byCat[f.cat] ||= []).push({ kind: "family", id: fid, tier }); }
+  const total = perks.length + heldFams.length;
+  if (total === 0) return <div className="text-sm opacity-40">{empty}</div>;
+
+  // Detail-Panel des aufgeklappten Eintrags (Perk oder Familien-Stufe).
+  let detail = null;
+  if (open && open.kind === "perk" && perks.includes(open.id)) {
+    const p = PERK_DEFS[open.id]; const c = CATEGORIES[p.cat].color;
+    detail = { c, cat: CATEGORIES[p.cat].name, name: p.label, desc: p.desc };
+  } else if (open && open.kind === "family") {
+    const f = familyDef(open.id); const tier = familyTiers[open.id];
+    if (f && tier) { const c = (tierMeta(tier) || {}).color || CATEGORIES[f.cat].color;
+      detail = { c, cat: CATEGORIES[f.cat].name, name: `${f.name} ${romanOf(tier)}`, desc: (f.tiers[tier] || {}).desc || "" }; }
+  }
+
   return (
     <div>
       <div className="grid gap-2">
@@ -22,32 +42,44 @@ export function PerkList({ perks, empty = "Noch keine Perks." }) {
           <div key={c} className="flex flex-wrap items-center gap-1.5">
             <span className="text-[10px] px-1.5 py-0.5 rounded font-bold"
               style={{ background: `${CATEGORIES[c].color}22`, color: CATEGORIES[c].color }}>{CATEGORIES[c].name}</span>
-            {byCat[c].map((id) => {
-              const active = openPerk === id;
-              const rar = rarityOf(id);
+            {byCat[c].map((it) => {
+              const active = isOpen(it.kind, it.id);
+              if (it.kind === "family") {
+                // Familie: Stufenfarbe (grau/grün/blau/lila) + „Name II".
+                const f = familyDef(it.id); const col = (tierMeta(it.tier) || {}).color || CATEGORIES[c].color;
+                return (
+                  <button key={`fam:${it.id}`} type="button" onClick={() => toggle("family", it.id)}
+                    className="text-xs px-2 py-0.5 rounded transition-all"
+                    style={{ background: active ? `${col}33` : "#22222b", color: col,
+                             outline: active ? `1px solid ${col}` : `1px solid ${col}88` }}>
+                    {f.name} {romanOf(it.tier)}
+                  </button>
+                );
+              }
+              const rar = rarityOf(it.id);
               const rm = RARITY_META[rar];
               const special = rar !== "common"; // selten/legendär: Raritäts-Farbe + Marke
               return (
-                <button key={id} type="button" onClick={() => setOpenPerk(active ? null : id)}
+                <button key={`perk:${it.id}`} type="button" onClick={() => toggle("perk", it.id)}
                   className="text-xs px-2 py-0.5 rounded transition-all"
                   style={{ background: active ? `${CATEGORIES[c].color}33` : "#22222b",
                            color: special ? rm.color : undefined,
                            outline: active ? `1px solid ${CATEGORIES[c].color}` : (special ? `1px solid ${rm.color}88` : "none") }}>
-                  {rm.mark ? `${rm.mark} ` : ""}{PERK_DEFS[id].label}
+                  {rm.mark ? `${rm.mark} ` : ""}{PERK_DEFS[it.id].label}
                 </button>
               );
             })}
           </div>
         ))}
       </div>
-      {open && (
-        <div className="mt-2 rounded-lg p-3 text-sm" style={{ background: "#1e1e26", border: `1px solid ${CATEGORIES[open.cat].color}55` }}>
+      {detail && (
+        <div className="mt-2 rounded-lg p-3 text-sm" style={{ background: "#1e1e26", border: `1px solid ${detail.c}55` }}>
           <div className="flex items-center gap-2 mb-1">
             <span className="text-[10px] px-1.5 py-0.5 rounded font-bold"
-              style={{ background: `${CATEGORIES[open.cat].color}22`, color: CATEGORIES[open.cat].color }}>{CATEGORIES[open.cat].name}</span>
-            <span className="font-bold" style={{ color: CATEGORIES[open.cat].color }}>{open.label}</span>
+              style={{ background: `${detail.c}22`, color: detail.c }}>{detail.cat}</span>
+            <span className="font-bold" style={{ color: detail.c }}>{detail.name}</span>
           </div>
-          <div className="opacity-80 leading-snug">{open.desc}</div>
+          <div className="opacity-80 leading-snug">{detail.desc}</div>
         </div>
       )}
     </div>

--- a/src/ui/CardDetail.jsx
+++ b/src/ui/CardDetail.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { suitName, suitColor } from "../game/constants.js";
 import { PERK_DEFS } from "../game/perks.js";
+import { familyDef } from "../game/families.js";
 
 // Anzeigenamen der Formationstypen (lang) für die Detailzeile.
 const FORM_NAME = { wiederholung: "Wiederholung", farbblock: "Farbblock", treppe: "Treppe", wechsel: "Wechsel", anker: "Anker" };
@@ -20,9 +21,10 @@ export function CardDetail({ card, pos, posForm, roles }) {
   const permBoost = card.baseRank != null ? card.value - card.baseRank : 0;
   const forms = (posForm && posForm.formations) || [];
   const ion = card.ionStacks || 0;
+  // Rollen-Chips: flacher Perk (PERK_DEFS) ODER Familie (FAMILY_DEFS, Kat. C) → Name als Label.
   const roleEntries = Object.entries(roles || {})
     .filter(([, ids]) => (ids || []).includes(card.id))
-    .map(([pid]) => ({ pid, label: PERK_DEFS[pid]?.label || pid, desc: PERK_DEFS[pid]?.desc || "" }));
+    .map(([pid]) => ({ pid, label: PERK_DEFS[pid]?.label || familyDef(pid)?.name || pid, desc: PERK_DEFS[pid]?.desc || "" }));
 
   const Chip = ({ children, c }) => (
     <span className="px-1.5 py-0.5 rounded text-[11px]" style={{ background: (c || "#8a8a92") + "22", color: c || "#c8c8ce" }}>{children}</span>

--- a/src/ui/CardGrid.jsx
+++ b/src/ui/CardGrid.jsx
@@ -1,5 +1,6 @@
 import { suitColor } from "../game/constants.js";
 import { PERK_DEFS } from "../game/perks.js";
+import { familyDef } from "../game/families.js";
 import { SEGMENT_SIZE } from "../game/formations.js";
 import { anchorTypeAt, linkedPartnerOf } from "../game/shop.js";
 import { formationBorder } from "./formationStyle.js";
@@ -26,7 +27,8 @@ function CardTile({ card, pos, posForm, roleIds = [], selected, onClick, anchorT
   // #112: „picked" (gold) hat Vorrang vor „selected" (weiß) vor Formations-/Farbrand.
   const borderColor = picked ? "#d4a63a" : selected ? "#ffffff" : fb.color || col + "55";
   const borderStyle = fb.dashed && !selected && !picked ? "dashed" : "solid";
-  const roleTitle = roleIds.length ? roleIds.map((p) => PERK_DEFS[p]?.label || p).join(", ") : undefined;
+  // Rollen-Label: flacher Perk (PERK_DEFS) ODER Familie (FAMILY_DEFS, Rarität #167 Kat. C) → sonst die rohe id.
+  const roleTitle = roleIds.length ? roleIds.map((p) => PERK_DEFS[p]?.label || familyDef(p)?.name || p).join(", ") : undefined;
   // #119: belegte Position (Shop-Anker) → dicker silberner AUSSENring via Outline+Offset — separat vom
   // inneren Auswahl-/Formationsrahmen und dessen Glow, damit beide gleichzeitig lesbar bleiben.
   const anchorRing = anchorType ? { outline: "2.5px solid #cdd6e0", outlineOffset: "2px" } : null;

--- a/src/ui/ChronikOverview.jsx
+++ b/src/ui/ChronikOverview.jsx
@@ -57,7 +57,7 @@ export function ChronikOverview({ state, onClose }) {
           {/* Info-Panel (rechts auf Desktop, sonst darunter) */}
           <div className="md:flex-1 md:min-w-0 mt-3 md:mt-0 grid gap-3 content-start">
             <CardDetail card={selPos != null ? cards[selPos] : null} pos={selPos} posForm={selPos != null ? formations[selPos] : null} roles={state.roles} />
-            <LayoutPerks perks={state.perks} />
+            <LayoutPerks perks={state.perks} familyTiers={state.familyTiers} />
             {anchors.length > 0 && (
               <div className="text-[11px] rounded-lg p-2.5" style={{ background: "#17171c", border: "1px solid #26262e" }}>
                 <div className="uppercase tracking-wide opacity-50 mb-1">Anker</div>

--- a/src/ui/FamilyTargetSelect.jsx
+++ b/src/ui/FamilyTargetSelect.jsx
@@ -3,61 +3,79 @@ import { familyDef } from "../game/families.js";
 import { tierMeta, romanOf } from "../game/rarity.js";
 import { CATEGORIES } from "../game/perks.js";
 import { DeckHistogram } from "./BuildSummary.jsx";
+import { CardGrid } from "./CardGrid.jsx";
 
-/* Familien-Ziel-Auswahl (Rarität #167, Spec §2.3/§2.4) — öffnet nach dem Pick einer Stufe mit `pickTarget`
-   (Kat. A: A_SUIT_BOOST III/IV = 1 Farbe, A_SUIT_DUEL III/IV = 1 bzw. 2 Farben, Reihenfolge Gewinner→Verlierer).
-   Wähle die geforderten Farben, dann bestätigen; erst dann wendet der Reducer applyFamilyPick mit dem Ziel an.
-   Kein Abbrechen (wie die Rollen-Zielauswahl TargetSelect) — die Familie ist mit dem Pick bereits gewählt.
-   Bewusst generisch (Farb-Ziele); Kategorie C nutzt denselben Fluss später für Karten-Ziele. */
-export function FamilyTargetSelect({ state, onSuit, onConfirm }) {
+/* Familien-Ziel-Auswahl (Rarität #167, Spec §2.3/§2.4) — öffnet nach dem Pick einer Stufe mit `pickTarget`.
+   Zwei Modi (state.familyTarget.kind):
+   - "suits" (Kat. A: A_SUIT_BOOST III/IV = 1 Farbe, A_SUIT_DUEL III/IV = 1 bzw. 2 Farben, Reihenfolge Gewinner→Verlierer)
+   - "cards" (Kat. C: Rollen-Ziele bzw. C_SACRIFICE — `need` Karten im geteilten CardGrid wählen). Beim ROLLEN-Upgrade
+     werden nur die ZUSÄTZLICHEN Ziele gewählt; bereits gehaltene Rollenkarten sind ausgegraut (Spec §2.3).
+   Kein Abbrechen (wie die Rollen-Zielauswahl TargetSelect) — die Familie ist mit dem Pick bereits gewählt. */
+export function FamilyTargetSelect({ state, onSuit, onCard, onConfirm }) {
   const ft = state.familyTarget || {};
   const fam = familyDef(ft.familyId) || {};
   const tierDef = (fam.tiers && fam.tiers[ft.tier]) || {};
-  const spec = tierDef.pickTarget || {};
-  const need = spec.suits || 0;
-  const suits = ft.suits || [];
   const cat = CATEGORIES[fam.cat] || { name: "", color: "#8a8a95" };
   const tm = tierMeta(ft.tier) || { color: "#8a8a95", label: "" };
-  const ordered = need > 1; // Reihenfolge relevant (erste = Gewinner, zweite = Verlierer)
-  const ready = need > 0 && suits.length === need;
+  const need = ft.need || 0;
+  const isCards = ft.kind === "cards";
+  const ordered = ft.kind === "suits" && need > 1; // Reihenfolge relevant (erste = Gewinner, zweite = Verlierer)
+  const sel = isCards ? (ft.cards || []) : (ft.suits || []);
+  const ready = need > 0 && sel.length === need;
+
+  const deck = state.deck || [];
+  const order = state.playerOrder || [];
+  const cards = order.map((di) => deck[di]);
+  const heldIds = new Set((state.roles && state.roles[ft.familyId]) || []); // bereits gehaltene Rollenkarten (Upgrade)
+  const disabledPos = order.map((di, pos) => (heldIds.has(deck[di].id) ? pos : -1)).filter((p) => p >= 0);
 
   return (
     <div className="fixed inset-0 overlay-root z-30 flex items-center justify-center p-3" style={{ background: "#0c0c10ee", backdropFilter: "blur(2px)" }}>
-      <div className="w-full max-w-2xl rounded-2xl p-5 max-h-[95dvh] overflow-y-auto overlay-card" style={{ background: "#15151b", border: `1px solid ${tm.color}55` }}>
+      <div className="w-full max-w-4xl rounded-2xl p-5 max-h-[95dvh] overflow-y-auto overlay-card" style={{ background: "#15151b", border: `1px solid ${tm.color}55` }}>
         <div className="text-center mb-1">
           <div className="text-xs uppercase tracking-widest" style={{ color: tm.color }}>{cat.name} · {tm.label}</div>
           <h2 className="text-xl font-bold mt-1">{fam.name} {romanOf(ft.tier)}</h2>
           <p className="text-xs opacity-60 mt-1 max-w-xl mx-auto leading-snug">{tierDef.desc}</p>
         </div>
 
-        <div className="mt-4">
-          <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">
-            {ordered ? "Reihenfolge: erste Farbe = Gewinner (+), zweite = Verlierer (−)" : `Wähle ${need === 1 ? "eine Farbe" : `${need} Farben`}`}
+        {isCards ? (
+          <div className="mt-4">
+            <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">
+              Wähle {need} {need === 1 ? "Karte" : "Karten"}{heldIds.size > 0 ? ` (${heldIds.size} bereits als Rolle gebunden)` : ""}
+            </div>
+            <CardGrid cards={cards} formations={state.formations} roles={state.roles}
+              anchors={state.shop?.anchors || []} pe={state.shop?.permanentEffects || {}}
+              pickedIds={sel} disabledPos={disabledPos} onTilePick={(pos, c) => onCard(c.id)} />
           </div>
-          <div className="flex gap-2 flex-wrap">
-            {SUIT_ORDER.map((su) => {
-              const idx = suits.indexOf(su);
-              const on = idx >= 0;
-              return (
-                <button key={su} onClick={() => onSuit(su)}
-                  className="px-4 py-2 rounded-lg text-sm font-bold transition-all"
-                  style={{ background: on ? suitColor(su) : `${suitColor(su)}22`, color: on ? "#141419" : suitColor(su), border: `2px solid ${suitColor(su)}` }}>
-                  {ordered && on && <span className="mr-1 opacity-80">{idx + 1}.</span>}
-                  {suitName(su)}
-                </button>
-              );
-            })}
+        ) : (
+          <div className="mt-4">
+            <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">
+              {ordered ? "Reihenfolge: erste Farbe = Gewinner (+), zweite = Verlierer (−)" : `Wähle ${need === 1 ? "eine Farbe" : `${need} Farben`}`}
+            </div>
+            <div className="flex gap-2 flex-wrap">
+              {SUIT_ORDER.map((su) => {
+                const idx = sel.indexOf(su);
+                const on = idx >= 0;
+                return (
+                  <button key={su} onClick={() => onSuit(su)}
+                    className="px-4 py-2 rounded-lg text-sm font-bold transition-all"
+                    style={{ background: on ? suitColor(su) : `${suitColor(su)}22`, color: on ? "#141419" : suitColor(su), border: `2px solid ${suitColor(su)}` }}>
+                    {ordered && on && <span className="mr-1 opacity-80">{idx + 1}.</span>}
+                    {suitName(su)}
+                  </button>
+                );
+              })}
+            </div>
+            {/* Deck-Kontext (nur Farb-Modus): aktuelle Werte je Farbe — hilft, die stärkste bzw. schwächste Farbe zu wählen. */}
+            <div className="mt-4">
+              <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">Deck-Werte je Farbe</div>
+              <DeckHistogram deck={state.deck} />
+            </div>
           </div>
-        </div>
-
-        {/* Deck-Kontext: aktuelle Werte je Farbe — hilft, die stärkste bzw. schwächste Farbe zu wählen. */}
-        <div className="mt-4">
-          <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">Deck-Werte je Farbe</div>
-          <DeckHistogram deck={state.deck} />
-        </div>
+        )}
 
         <div className="flex items-center justify-between mt-5">
-          <span className="text-xs opacity-60 tabular-nums">{suits.length} / {need} gewählt</span>
+          <span className="text-xs opacity-60 tabular-nums">{sel.length} / {need} gewählt</span>
           <button onClick={() => ready && onConfirm()} disabled={!ready}
             className="px-5 py-2.5 rounded-lg font-bold text-sm transition-all hover:brightness-110"
             style={{ background: ready ? tm.color : "#2a2a33", color: ready ? "#141419" : "#8a8a92", cursor: ready ? "pointer" : "default" }}>

--- a/src/ui/FamilyTargetSelect.jsx
+++ b/src/ui/FamilyTargetSelect.jsx
@@ -1,0 +1,70 @@
+import { suitColor, suitName, SUIT_ORDER } from "../game/constants.js";
+import { familyDef } from "../game/families.js";
+import { tierMeta, romanOf } from "../game/rarity.js";
+import { CATEGORIES } from "../game/perks.js";
+import { DeckHistogram } from "./BuildSummary.jsx";
+
+/* Familien-Ziel-Auswahl (Rarität #167, Spec §2.3/§2.4) — öffnet nach dem Pick einer Stufe mit `pickTarget`
+   (Kat. A: A_SUIT_BOOST III/IV = 1 Farbe, A_SUIT_DUEL III/IV = 1 bzw. 2 Farben, Reihenfolge Gewinner→Verlierer).
+   Wähle die geforderten Farben, dann bestätigen; erst dann wendet der Reducer applyFamilyPick mit dem Ziel an.
+   Kein Abbrechen (wie die Rollen-Zielauswahl TargetSelect) — die Familie ist mit dem Pick bereits gewählt.
+   Bewusst generisch (Farb-Ziele); Kategorie C nutzt denselben Fluss später für Karten-Ziele. */
+export function FamilyTargetSelect({ state, onSuit, onConfirm }) {
+  const ft = state.familyTarget || {};
+  const fam = familyDef(ft.familyId) || {};
+  const tierDef = (fam.tiers && fam.tiers[ft.tier]) || {};
+  const spec = tierDef.pickTarget || {};
+  const need = spec.suits || 0;
+  const suits = ft.suits || [];
+  const cat = CATEGORIES[fam.cat] || { name: "", color: "#8a8a95" };
+  const tm = tierMeta(ft.tier) || { color: "#8a8a95", label: "" };
+  const ordered = need > 1; // Reihenfolge relevant (erste = Gewinner, zweite = Verlierer)
+  const ready = need > 0 && suits.length === need;
+
+  return (
+    <div className="fixed inset-0 overlay-root z-30 flex items-center justify-center p-3" style={{ background: "#0c0c10ee", backdropFilter: "blur(2px)" }}>
+      <div className="w-full max-w-2xl rounded-2xl p-5 max-h-[95dvh] overflow-y-auto overlay-card" style={{ background: "#15151b", border: `1px solid ${tm.color}55` }}>
+        <div className="text-center mb-1">
+          <div className="text-xs uppercase tracking-widest" style={{ color: tm.color }}>{cat.name} · {tm.label}</div>
+          <h2 className="text-xl font-bold mt-1">{fam.name} {romanOf(ft.tier)}</h2>
+          <p className="text-xs opacity-60 mt-1 max-w-xl mx-auto leading-snug">{tierDef.desc}</p>
+        </div>
+
+        <div className="mt-4">
+          <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">
+            {ordered ? "Reihenfolge: erste Farbe = Gewinner (+), zweite = Verlierer (−)" : `Wähle ${need === 1 ? "eine Farbe" : `${need} Farben`}`}
+          </div>
+          <div className="flex gap-2 flex-wrap">
+            {SUIT_ORDER.map((su) => {
+              const idx = suits.indexOf(su);
+              const on = idx >= 0;
+              return (
+                <button key={su} onClick={() => onSuit(su)}
+                  className="px-4 py-2 rounded-lg text-sm font-bold transition-all"
+                  style={{ background: on ? suitColor(su) : `${suitColor(su)}22`, color: on ? "#141419" : suitColor(su), border: `2px solid ${suitColor(su)}` }}>
+                  {ordered && on && <span className="mr-1 opacity-80">{idx + 1}.</span>}
+                  {suitName(su)}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Deck-Kontext: aktuelle Werte je Farbe — hilft, die stärkste bzw. schwächste Farbe zu wählen. */}
+        <div className="mt-4">
+          <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">Deck-Werte je Farbe</div>
+          <DeckHistogram deck={state.deck} />
+        </div>
+
+        <div className="flex items-center justify-between mt-5">
+          <span className="text-xs opacity-60 tabular-nums">{suits.length} / {need} gewählt</span>
+          <button onClick={() => ready && onConfirm()} disabled={!ready}
+            className="px-5 py-2.5 rounded-lg font-bold text-sm transition-all hover:brightness-110"
+            style={{ background: ready ? tm.color : "#2a2a33", color: ready ? "#141419" : "#8a8a92", cursor: ready ? "pointer" : "default" }}>
+            Bestätigen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/FormationPhase.jsx
+++ b/src/ui/FormationPhase.jsx
@@ -121,7 +121,7 @@ export function FormationPhase({ state, onSwap, onUndo, onReset, onConfirm }) {
           {/* Info-Panel (rechts auf Desktop, sonst darunter) */}
           <div className="md:flex-1 md:min-w-0 mt-3 md:mt-0 grid gap-3 content-start">
             <CardDetail card={sel != null ? cards[sel] : null} pos={sel} posForm={sel != null ? formations[sel] : null} roles={state.roles} />
-            <LayoutPerks perks={state.perks} />
+            <LayoutPerks perks={state.perks} familyTiers={state.familyTiers} />
             {/* Kurz-Erklärung der Formationen mit Kürzel (#95.7). #103: nur Kürzel + Name grün,
                 Beschreibung (nach dem „—") in Standard-Textfarbe → bessere Lesbarkeit. */}
             <div className="grid grid-cols-1 gap-y-0.5 text-xs sm:text-[13px] leading-snug font-medium">

--- a/src/ui/LayoutPerks.jsx
+++ b/src/ui/LayoutPerks.jsx
@@ -1,16 +1,25 @@
 import { PERK_DEFS, layoutPerks, rarityMeta } from "../game/perks.js";
+import { layoutFamilies } from "../game/families.js";
+import { tierColor, romanOf } from "../game/rarity.js";
 
-/* Aufstellungshilfe (Issue #95): listet die gehaltenen Perks, deren Wirkung von Position/Reihenfolge
-   oder Formations-Zugehörigkeit abhängt — damit man beim Aufstellen weiß, worauf es ankommt.
-   Genutzt in Formationsphase UND Chronik-Kartenübersicht. */
-export function LayoutPerks({ perks }) {
+/* Aufstellungshilfe (Issue #95 / #166): listet die gehaltenen Perks UND Familien, deren Wirkung von Position/
+   Reihenfolge/Nachbarschaft oder Formations-Zugehörigkeit abhängt — damit man beim Aufstellen weiß, worauf es
+   ankommt. Genutzt in Formationsphase UND Chronik-Kartenübersicht. */
+export function LayoutPerks({ perks, familyTiers = {} }) {
   const ids = layoutPerks(perks);
-  if (!ids.length) return null;
+  const fams = layoutFamilies(familyTiers); // Rarität #167: position-/formationsbezogene Familien (C/E + kuratierte B/D)
+  if (!ids.length && !fams.length) return null;
   return (
     <div className="rounded-lg px-3 py-2" style={{ background: "#1b1b22", border: "1px solid #5ab87a55" }}>
       {/* #104: Panel als aktiv/informativ kennzeichnen — grüner Akzent (Aufstellungs-Kontext) statt grau-in-grau. */}
       <div className="text-[10px] uppercase tracking-wide mb-1 font-semibold" style={{ color: "#5ab87a" }}>Positions- &amp; Formations-Perks</div>
       <div className="grid gap-0.5">
+        {fams.map((f) => (
+          <div key={f.id} className="text-[11px] leading-snug">
+            <span className="font-bold" style={{ color: tierColor(f.tier) }}>{f.name} {romanOf(f.tier)}</span>
+            <span className="opacity-55"> — {f.desc}</span>
+          </div>
+        ))}
         {ids.map((id) => (
           <div key={id} className="text-[11px] leading-snug">
             <span className="font-bold" style={{ color: rarityMeta(id).color }}>{PERK_DEFS[id].label}</span>

--- a/src/ui/PerkSelect.jsx
+++ b/src/ui/PerkSelect.jsx
@@ -1,4 +1,6 @@
 import { PERK_DEFS, CATEGORIES, rarityOf, RARITY_META, critChanceRawFor, hasCritPerk, baseScoreMultFor } from "../game/perks.js";
+import { familyDef } from "../game/families.js";
+import { tierMeta, romanOf, familyTierOf } from "../game/rarity.js";
 import { lightningCritRaw } from "../game/skills.js";
 import { PERK_DECLINE_COINS } from "../game/constants.js";
 import { PerkList, DeckHistogram } from "./BuildSummary.jsx";
@@ -10,6 +12,29 @@ import perkMascot from "../assets/mascots/perk.gif";
 // Legendär-Akzent: durchgehend gold (Rahmen, Ring, Badge, Titel) — Teil des Grau/Grün/Gold-Schemas (#71).
 const LEG_GOLD = "#d4a63a";
 const fmtMult = (x) => x.toFixed(2).replace(".", ",");
+
+/* Ein Angebotseintrag → einheitliches Anzeige-Modell (Rarität #167 §8). Familie {familyId,tier} zeigt den
+   Familiennamen mit römischer Stufe, die Stufenfarbe (grau/grün/blau/lila) und — bei bereits gehaltener
+   niedrigerer Stufe — ein Upgrade-Badge mit „gehaltener Rang → Zielrang". Flacher Perk-String bleibt wie #71. */
+function offerView(entry, familyTiers = {}) {
+  if (entry && typeof entry === "object" && entry.familyId) {
+    const fam = familyDef(entry.familyId);
+    const t = entry.tier;
+    const tm = tierMeta(t) || { color: "#8a8a95", label: "" };
+    const held = familyTierOf(familyTiers, entry.familyId); // 0 = neu, sonst gehaltener Rang
+    return {
+      key: `${entry.familyId}:${t}`, entry, isFamily: true, cat: CATEGORIES[fam.cat],
+      accent: tm.color, tierLabel: tm.label, tier: t, held, upgrade: held > 0,
+      name: `${fam.name} ${romanOf(t)}`, desc: (fam.tiers[t] || {}).desc || "",
+      glow: t >= 3, // Selten/Rar erhalten einen dezenten Farbschein
+    };
+  }
+  const p = PERK_DEFS[entry];
+  const rar = rarityOf(entry);
+  const rm = RARITY_META[rar];
+  return { key: entry, entry, isFamily: false, cat: CATEGORIES[p.cat], accent: rm.color, rar, rm,
+           leg: rar === "legendary", name: p.label, desc: p.desc };
+}
 
 /* Level-Up-Auswahl (§7.8): pausiert das Spiel, bietet PERKS_OFFERED Optionen.
    Zeigt zusätzlich den Build-Kontext (aktive Perks + Deck-Histogramm, #22) und die Kern-Stats (#40). */
@@ -50,37 +75,50 @@ export function PerkSelect({ offer, onPick, onReroll, onDecline, perks = [], dec
         </div>
 
         <div className="grid sm:grid-cols-3 gap-3 mt-5">
-          {offer.map((id) => {
-            const p = PERK_DEFS[id];
-            const cat = CATEGORIES[p.cat];
-            const rar = rarityOf(id);
-            const rm = RARITY_META[rar];
-            const leg = rar === "legendary";
+          {offer.map((entry) => {
+            const v = offerView(entry, state.familyTiers);
+            const cat = v.cat;
             return (
               <button
-                key={id}
-                onClick={() => onPick(id)}
+                key={v.key}
+                onClick={() => onPick(v.entry)}
                 className="text-left rounded-xl p-4 h-full flex flex-col gap-2 transition-all hover:-translate-y-0.5"
                 style={{ background: "#20202a",
-                         // Rahmen = Seltenheit: grau (normal) / grün (selten) / gold (legendär).
-                         border: `1px solid ${rm.color}${rar === "common" ? "55" : ""}`,
-                         boxShadow: leg ? `0 0 0 1px ${LEG_GOLD}66, 0 0 16px ${LEG_GOLD}33`
-                                  : rar === "rare" ? `0 0 12px ${rm.color}22` : undefined }}
+                         // Familie: Rahmen = Stufenfarbe (grau/grün/blau/lila). Flach: Seltenheit (grau/grün/gold).
+                         border: `1px solid ${v.accent}${(v.isFamily ? v.tier === 1 : v.rar === "common") ? "55" : ""}`,
+                         boxShadow: (!v.isFamily && v.leg) ? `0 0 0 1px ${LEG_GOLD}66, 0 0 16px ${LEG_GOLD}33`
+                                  : (v.isFamily ? v.glow : v.rar === "rare") ? `0 0 12px ${v.accent}22` : undefined }}
               >
                 <div className="flex flex-wrap items-center gap-1.5">
                   <span className="text-[10px] px-1.5 py-0.5 rounded font-bold"
                     style={{ background: `${cat.color}22`, color: cat.color }}>
                     {cat.name}
                   </span>
-                  {rm.badge && (
-                    <span className="text-[10px] px-1.5 py-0.5 rounded font-bold tracking-wide"
-                      style={{ background: `${rm.color}1f`, color: rm.color, border: `1px solid ${rm.color}88` }}>
-                      {rm.badge}
-                    </span>
+                  {v.isFamily ? (
+                    <>
+                      {/* Stufen-Badge (Seltenheit der Zielstufe) in der Stufenfarbe. */}
+                      <span className="text-[10px] px-1.5 py-0.5 rounded font-bold tracking-wide"
+                        style={{ background: `${v.accent}1f`, color: v.accent, border: `1px solid ${v.accent}88` }}>
+                        {v.tierLabel}
+                      </span>
+                      {v.upgrade && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded font-bold tracking-wide"
+                          style={{ background: `${v.accent}14`, color: v.accent, border: `1px dashed ${v.accent}88` }}>
+                          ⬆ UPGRADE · {romanOf(v.held)}→{romanOf(v.tier)}
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    v.rm.badge && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded font-bold tracking-wide"
+                        style={{ background: `${v.rm.color}1f`, color: v.rm.color, border: `1px solid ${v.rm.color}88` }}>
+                        {v.rm.badge}
+                      </span>
+                    )
                   )}
                 </div>
-                <div className="font-bold" style={{ color: leg ? LEG_GOLD : cat.color }}>{p.label}</div>
-                <div className="text-sm opacity-75 leading-snug">{p.desc}</div>
+                <div className="font-bold" style={{ color: (!v.isFamily && v.leg) ? LEG_GOLD : v.isFamily ? v.accent : cat.color }}>{v.name}</div>
+                <div className="text-sm opacity-75 leading-snug">{v.desc}</div>
               </button>
             );
           })}
@@ -112,9 +150,10 @@ export function PerkSelect({ offer, onPick, onReroll, onDecline, perks = [], dec
         <div className="mt-5 pt-4 border-t grid sm:grid-cols-2 gap-4" style={{ borderColor: "#2a2a33" }}>
           <div>
             <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">
-              Dein Build — {perks.length} Perk{perks.length === 1 ? "" : "s"}
+              {(() => { const n = perks.length + Object.values(state.familyTiers || {}).filter((t) => t > 0).length;
+                return `Dein Build — ${n} Perk${n === 1 ? "" : "s"}`; })()}
             </div>
-            <PerkList perks={perks} empty="Noch keine Perks gewählt." />
+            <PerkList perks={perks} familyTiers={state.familyTiers} empty="Noch keine Perks gewählt." />
           </div>
           <div>
             <div className="text-[11px] uppercase tracking-wide opacity-50 mb-2">Deck-Werte je Farbe</div>

--- a/src/ui/PerkSelect.jsx
+++ b/src/ui/PerkSelect.jsx
@@ -1,5 +1,5 @@
 import { PERK_DEFS, CATEGORIES, rarityOf, RARITY_META, critChanceRawFor, hasCritPerk, baseScoreMultFor } from "../game/perks.js";
-import { familyDef } from "../game/families.js";
+import { familyDef, hasCritFamily } from "../game/families.js";
 import { tierMeta, romanOf, familyTierOf } from "../game/rarity.js";
 import { lightningCritRaw } from "../game/skills.js";
 import { PERK_DECLINE_COINS } from "../game/constants.js";
@@ -49,7 +49,7 @@ export function PerkSelect({ offer, onPick, onReroll, onDecline, perks = [], dec
   const critRaw = critChanceRawFor(perks, { winValue: 0, winStreak: winStreak + 1, wins: wins + 1, trickNo, posInCycle: pos }) + lightningCritRaw(lightning, skills) + statCritChance;
   const critPct = Math.round(Math.min(1, Math.max(0, critRaw)) * 100);
   const scoreMult = baseScoreMultFor(perks, { winStreak, wins, trickNo, pos });
-  const showCrit = hasCritPerk(perks) || crits > 0 || !!(lightning && lightning.active) || statCritChance > 0 || statCritMult > 0;
+  const showCrit = hasCritPerk(perks) || hasCritFamily(state.familyTiers) || crits > 0 || !!(lightning && lightning.active) || statCritChance > 0 || statCritMult > 0;
   return (
     <div className="fixed inset-0 overlay-root z-20 flex items-center sm:items-start justify-center p-4 sm:pt-28" style={{ background: "#0c0c1099", backdropFilter: "blur(3px)" }}>
       {/* #130: nicht scrollender Wrapper → Roboter-Maskottchen schaut oben über die Karte hervor (Desktop-Peek);

--- a/src/ui/StatusRail.jsx
+++ b/src/ui/StatusRail.jsx
@@ -2,6 +2,7 @@ import { MAX_CYCLES } from "../game/constants.js";
 import { cycleLenFor } from "../game/shop.js";
 import { summarizeFormations } from "../game/formations.js";
 import { critChanceRawFor, hasCritPerk, critMultiplierFor } from "../game/perks.js";
+import { hasCritFamily } from "../game/families.js";
 import { lightningCritRaw } from "../game/skills.js";
 import { Sparkline } from "./Sparkline.jsx";
 
@@ -25,13 +26,13 @@ function Stat({ label, value, tone }) {
 
 export function StatusRail({ state, currentTraj = [], recordTraj = [] }) {
   const { wins, losses, ties, cycle, trickNo, winStreak, bestStreak, pos, perks, crits, lightning, skills = [],
-          statCritChance = 0, statCritMult = 0, statFormMult = 0, statStreakMult = 0 } = state;
+          familyTiers = {}, statCritChance = 0, statCritMult = 0, statFormMult = 0, statStreakMult = 0 } = state;
   const cycleLen = cycleLenFor(state.shop);  // 40, mit Zeitsegment 45 (§8 A-L1)
   const remaining = cycleLen - pos;          // Karten bis zum nächsten Mischen (#6)
   const decided = wins + losses;            // Gleichstände zählen nicht als entschieden (§4.4)
   const winPct = decided > 0 ? Math.round((wins / decided) * 100) : 0;
   const fmtMult = (x) => x.toFixed(2).replace(".", ",");
-  const showCrit = hasCritPerk(perks) || (crits || 0) > 0 || !!(lightning && lightning.active) || statCritChance > 0 || statCritMult > 0;
+  const showCrit = hasCritPerk(perks) || hasCritFamily(familyTiers) || (crits || 0) > 0 || !!(lightning && lightning.active) || statCritChance > 0 || statCritMult > 0;
   // Live-Crit-Chance des NÄCHSTEN Siegs: analog zum echten Wurf (#19). V2: Perks tragen keine Crit-Chance
   // mehr bei — die Blitz-Crit-Basis (lightning) + der Crit-Chance-Stat fließen additiv ein, dieselbe Rechnung
   // wie die Engine (kein Drift).

--- a/src/ui/StatusRail.jsx
+++ b/src/ui/StatusRail.jsx
@@ -31,14 +31,12 @@ export function StatusRail({ state, currentTraj = [], recordTraj = [] }) {
   const decided = wins + losses;            // Gleichstände zählen nicht als entschieden (§4.4)
   const winPct = decided > 0 ? Math.round((wins / decided) * 100) : 0;
   const fmtMult = (x) => x.toFixed(2).replace(".", ",");
-  const ownsD4 = perks.includes("D4");
   const showCrit = hasCritPerk(perks) || (crits || 0) > 0 || !!(lightning && lightning.active) || statCritChance > 0 || statCritMult > 0;
   // Live-Crit-Chance des NÄCHSTEN Siegs: analog zum echten Wurf (#19). V2: Perks tragen keine Crit-Chance
   // mehr bei — die Blitz-Crit-Basis (lightning) + der Crit-Chance-Stat fließen additiv ein, dieselbe Rechnung
   // wie die Engine (kein Drift).
   const critRaw = critChanceRawFor(perks, { winValue: 0, winStreak: winStreak + 1, wins: wins + 1, trickNo, posInCycle: pos }) + lightningCritRaw(lightning, skills) + statCritChance;
   const critPct = Math.round(Math.min(1, Math.max(0, critRaw)) * 100);
-  const ownsD7 = perks.includes("D7");
   // #123: Formations-Faktor der aktuellen Aufstellung dauerhaft sichtbar (gleiche Quelle wie die
   // Formationsphase → kein Drift). „jetzt" = Faktor der nächsten zu spielenden Position.
   const { count: formCount, maxMult: formMaxMult } = summarizeFormations(state.formations || []);
@@ -72,15 +70,14 @@ export function StatusRail({ state, currentTraj = [], recordTraj = [] }) {
           {nowFormMult > 1.001 && <span><span className="opacity-50">jetzt </span><span style={{ color: "#5ab87a" }}>×{fmtMult(nowFormMult)}</span></span>}
         </div>
       )}
-      {/* Crit (#19/#46). Der Gesamt-Score-Mult steht dauerhaft im Header-Chip (#37). */}
-      {(ownsD4 || showCrit) && (
+      {/* Crit (#19/#46). Der Gesamt-Score-Mult steht dauerhaft im Header-Chip (#37).
+          Frühere D4/D7-Hinweise sind mit der Score-Familien-Migration (#167) entfernt; familienspezifische
+          Crit-/Score-Hinweise folgen mit #166 UI. */}
+      {showCrit && (
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs pt-1 border-t" style={{ borderColor: "#26262e" }}>
-          {ownsD4 && <span className="opacity-45">×3 bei Rang ≤3</span>}
-          {showCrit && (<>
-            <span><span className="opacity-50">Crit-Chance </span><span style={{ color: "#e879f9" }}>{critPct}%</span>{ownsD7 && <span className="opacity-45"> (+35% ≥8)</span>}</span>
-            <span><span className="opacity-50">Crit </span><span style={{ color: perks.includes("L5") ? "#d4a63a" : "#e879f9" }}>×{fmtMult(critMultiplierFor(perks, { rawCrit: critRaw }, statCritMult))}</span>{perks.includes("L5") && <span style={{ color: "#d4a63a" }}> Jackpot</span>}</span>
-            <span><span className="opacity-50">Crits </span><span style={{ color: "#e879f9" }}>{crits || 0}</span></span>
-          </>)}
+          <span><span className="opacity-50">Crit-Chance </span><span style={{ color: "#e879f9" }}>{critPct}%</span></span>
+          <span><span className="opacity-50">Crit </span><span style={{ color: perks.includes("L5") ? "#d4a63a" : "#e879f9" }}>×{fmtMult(critMultiplierFor(perks, { rawCrit: critRaw }, statCritMult))}</span>{perks.includes("L5") && <span style={{ color: "#d4a63a" }}> Jackpot</span>}</span>
+          <span><span className="opacity-50">Crits </span><span style={{ color: "#e879f9" }}>{crits || 0}</span></span>
         </div>
       )}
       {/* Score-Stats (V2 §22.3): Serien-/Formations-Stat, die nicht bereits über die Crit-Zeile sichtbar sind. */}

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -394,15 +394,7 @@ describe("Neue Legendaries — Engine (V2 §22.6 L)", () => {
     expect(resolveTrick(scenario(5, 0, { pos: 34, perks: ["L3"] }), rng).lastTrick.pValue).toBe(5);   // Position 35 → kein Bonus
   });
 
-  it("L7 Königsmacher: die höchste Karte des Segments bekommt +5", () => {
-    const mkL = (arr, suit = "R") => arr.map((v, i) => ({ id: `${suit}${i}`, suit, baseRank: v, value: v }));
-    let s = { ...initialState(makeRng(1)), deck: mkL([5, 9, 6, 7, 8]), oppDeck: mkL([0, 0, 0, 0, 0], "B"),
-              playerOrder: [0, 1, 2, 3, 4], oppOrder: [0, 1, 2, 3, 4], perks: ["L7"] };
-    s = resolveTrick(s, rng);             // pos0 val5 (nicht Höchste) → +0
-    expect(s.lastTrick.pValue).toBe(5);
-    s = resolveTrick(s, rng);             // pos1 val9 (Segment-Höchste) → +5
-    expect(s.lastTrick.pValue).toBe(14);
-  });
+  // L7 „Königsmacher" entfernt (#162, Spec §9) — Test ersatzlos gestrichen; C7 „Überlebensvorteil" deckt segmentLow ab.
 
   it("L8 Schicksalsmaschine: am Durchlauf-Ende tauschen erfolgreichste & erfolgloseste Karte die Werte", () => {
     const deck = Array.from({ length: 40 }, (_, i) => ({ id: `X${i}`, suit: "R", baseRank: 1, value: i === 0 ? 20 : i === 1 ? 3 : 12 }));

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -248,10 +248,7 @@ describe("resolveTrick — Durchlauf-Ende & persistente Reihenfolge (V2)", () =>
 });
 
 describe("Historie-Rares — Engine (#71 Phase 2b)", () => {
-  it("B8 Revanche: nach 2 Niederlagen +7 auf die nächste Karte", () => {
-    expect(resolveTrick(scenario(3, 8, { perks: ["B8"], lossStreak: 2 }), rng).lastTrick.pValue).toBe(10);
-    expect(resolveTrick(scenario(3, 8, { perks: ["B8"], lossStreak: 1 }), rng).lastTrick.pValue).toBe(3);
-  });
+  // B8 Revanche als Familie B_REVENGE (inkl. III Zwei-Karten-Queue) — Tests in families-engine.test.js.
   it("lastWinValue wird nach einem Sieg auf den Siegwert gesetzt (Basis für Familie D_PRECISION)", () => {
     expect(resolveTrick(scenario(9, 0), rng).lastWinValue).toBe(9);
   });
@@ -272,15 +269,7 @@ describe("Crit-Historie-Rares — Engine (#71 Phase 2c)", () => {
 describe("Historie-Rares — Engine (#71 Phase 2f)", () => {
   const mk = (arr, suit = "R") => arr.map((v, i) => ({ id: `${suit}${i}`, suit, baseRank: v, value: v }));
 
-  it("B9 Perfekte Folge: Karten einer Treppe erhalten +1/+2/+3 nach Position", () => {
-    const deck = mk([3, 5, 7, 4]); // 3<5<7 = Treppe (Pos 0–2), die 4 liegt außerhalb
-    const opp = mk([0, 0, 0, 0]);
-    let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: [0, 1, 2, 3], oppOrder: [0, 1, 2, 3], perks: ["B9"] };
-    const pv = [];
-    for (let i = 0; i < 4; i++) { s = resolveTrick(s, rng); pv.push(s.lastTrick.pValue); }
-    expect(pv).toEqual([4, 7, 10, 4]); // Treppen-Ordinal 1,2,3 → +1,+2,+3; Pos 3 keine Treppe → +0
-  });
-
+  // B9 Perfekte Folge als Familie B_PERFECT (Treppen-Ordinal) — Tests in families.test.js/families-engine.test.js.
   it("Farbserie-Zähler (Engine): gleiche Farbe zählt hoch, Farbwechsel beginnt bei 1, Niederlage bricht", () => {
     // winSuit/winSuitStreak sind Engine-Zustand (Basis für Familie D_SUIT_STREAK), unabhängig von einem Perk.
     const deck = [{ id: "a", suit: "R", baseRank: 12, value: 12 }, { id: "b", suit: "R", baseRank: 12, value: 12 }, { id: "c", suit: "B", baseRank: 12, value: 12 }];
@@ -298,23 +287,7 @@ describe("Historie-Rares — Engine (#71 Phase 2f)", () => {
 });
 
 describe("Serien-/Crit-Rares — Engine (#71 Phase 2e)", () => {
-  it("B10 Überzahl: +3 temp Wert, wenn der Dauerwert höher als der des direkten Vorgängers ist", () => {
-    const deck = [
-      { id: "a", suit: "R", baseRank: 4, value: 4 },
-      { id: "b", suit: "R", baseRank: 9, value: 9 },
-      { id: "c", suit: "R", baseRank: 2, value: 2 },
-    ];
-    const opp = [
-      { id: "o0", suit: "R", baseRank: 0, value: 0 },
-      { id: "o1", suit: "R", baseRank: 0, value: 0 },
-      { id: "o2", suit: "R", baseRank: 0, value: 0 },
-    ];
-    let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: [0, 1, 2], oppOrder: [0, 1, 2], perks: ["B10"] };
-    const pv = [];
-    for (let i = 0; i < 3; i++) { s = resolveTrick(s, rng); pv.push(s.lastTrick.pValue); }
-    expect(pv).toEqual([4, 12, 2]); // Pos0 kein Vorgänger; Pos1 (9>4) +3; Pos2 (2<9) +0
-  });
-
+  // B10 Überzahl als Familie B_SUPERIOR (Vergleich Dauerwert vs. Vorgänger) — Tests in families.test.js.
   it("Familie D_OVERCRIT: +Crit-Flat, wenn die Roh-Crit-Chance über 100 % liegt (rawCrit im critCtx)", () => {
     // D_OVERCRIT III: jeder Überschuss-Crit (rawCrit > 1) gibt +500. statCritChance 1,5 → rawCrit 1,5, Crit garantiert.
     const s = resolveTrick(scenario(12, 0, { familyTiers: { D_OVERCRIT: 3 }, statCritChance: 1.5 }), rng);
@@ -355,13 +328,13 @@ describe("Neue Legendaries — Engine (V2 §22.6 L)", () => {
   it("L11 Zeitraffer: Position 40 wiederholt den Wertbonus von Position 20", () => {
     const deck = Array.from({ length: 40 }, (_, i) => ({ id: `X${i}`, suit: "R", baseRank: 5, value: 5 }));
     const opp = Array.from({ length: 40 }, (_, i) => ({ id: `O${i}`, suit: "R", baseRank: 0, value: 0 }));
-    // B4 gibt Position 20 (pos 19) +8; L11 wiederholt das an Position 40 (pos 39).
-    let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: seq40, oppOrder: seq40, pos: 19, perks: ["B4", "L11"] };
-    s = resolveTrick(s, rng); // pos19: B4 +8 → pValue 13, pos20Bonus = 8
-    expect(s.lastTrick.pValue).toBe(13);
-    expect(s.pos20Bonus).toBe(8);
-    s = resolveTrick({ ...s, pos: 39 }, rng); // pos39: B4 +8 + L11-Wiederholung +8 → 5+8+8 = 21
-    expect(s.lastTrick.pValue).toBe(21);
+    // Familie B_TENTH_STRIKE I gibt Position 20 (pos 19) +6; L11 wiederholt das an Position 40 (pos 39).
+    let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: seq40, oppOrder: seq40, pos: 19, perks: ["L11"], familyTiers: { B_TENTH_STRIKE: 1 } };
+    s = resolveTrick(s, rng); // pos19: B_TENTH_STRIKE +6 → pValue 11, pos20Bonus = 6
+    expect(s.lastTrick.pValue).toBe(11);
+    expect(s.pos20Bonus).toBe(6);
+    s = resolveTrick({ ...s, pos: 39 }, rng); // pos39: B_TENTH_STRIKE +6 + L11-Wiederholung +6 → 5+6+6 = 17
+    expect(s.lastTrick.pValue).toBe(17);
   });
 });
 

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -568,62 +568,8 @@ describe("Reaktoren + Geladene Serie — Engine (Stufe C)", () => {
   });
 });
 
-describe("Kartenrollen — Engine (V2 §22.6 C)", () => {
-  const mk = (arr, suit = "R") => arr.map((v, i) => ({ id: `${suit}${i}`, suit, baseRank: v, value: v }));
-  const build = (over) => ({ ...initialState(makeRng(1)), oppDeck: mk([0, 0, 0]), oppOrder: [0, 1, 2], ...over });
-
-  it("C1 Vorhut: Rollen-Karte auf Position ≤4 bekommt +3 Wert", () => {
-    const s = build({ deck: mk([5, 5, 5]), playerOrder: [0, 1, 2], perks: ["C1"], roles: { C1: ["R0"] } });
-    const r = resolveTrick(s, rng); // pos0 = R0 (Rolle), posInCycle 0 → +3
-    expect(r.lastTrick.pValue).toBe(8); // 5 + 3
-  });
-
-  it("C4 Staffelläufer: nach dem Sieg einer Rollen-Karte bekommt die nächste +2", () => {
-    let s = build({ deck: mk([5, 5, 5]), playerOrder: [0, 1, 2], perks: ["C4"], roles: { C4: ["R0"] } });
-    s = resolveTrick(s, rng);          // pos0 R0 gewinnt → Nachfolger armiert
-    expect(s.lastTrick.pValue).toBe(5); // R0 selbst ohne Bonus
-    s = resolveTrick(s, rng);          // pos1 → +2
-    expect(s.lastTrick.pValue).toBe(7); // 5 + 2
-  });
-
-  it("C2 Triumph: Sieg armiert die Karte; dieser Stich noch ohne Bonus", () => {
-    let s = build({ deck: mk([5, 5]), oppDeck: mk([0, 0]), oppOrder: [0, 1], playerOrder: [0, 1], perks: ["C2"], roles: { C2: ["R0"] } });
-    s = resolveTrick(s, rng);
-    expect(s.triumphArmed).toContain("R0");
-    expect(s.lastTrick.pValue).toBe(5);
-  });
-
-  it("C3 Leibwache: nach verlorenem Vorgänger bekommt die Rollen-Karte +5", () => {
-    let s = build({ deck: mk([5, 5]), oppDeck: mk([9, 0], "B"), oppOrder: [0, 1], playerOrder: [0, 1], perks: ["C3"], roles: { C3: ["R1"] } });
-    s = resolveTrick(s, rng);             // pos0 R0: 5 vs 9 → Niederlage
-    expect(s.lastResult).toBe("loss");
-    s = resolveTrick(s, rng);             // pos1 R1 (C3): Vorgänger verlor → +5
-    expect(s.lastTrick.pValue).toBe(10);  // 5 + 5
-  });
-
-  it("C5 Anführer: nach dem Sieg der Rollen-Karte bekommen die nächsten zwei Karten +2", () => {
-    let s = build({ deck: mk([5, 5, 5]), playerOrder: [0, 1, 2], perks: ["C5"], roles: { C5: ["R0"] } });
-    s = resolveTrick(s, rng);             // pos0 R0 (Rolle) gewinnt → nächste 2 armiert
-    expect(s.lastTrick.pValue).toBe(5);
-    s = resolveTrick(s, rng);             // pos1 → +2
-    expect(s.lastTrick.pValue).toBe(7);
-    s = resolveTrick(s, rng);             // pos2 → +2
-    expect(s.lastTrick.pValue).toBe(7);
-  });
-
-  it("C6 Finisher: Rollen-Karte auf der letzten Segment-Position (posInCycle%5==4) bekommt +5", () => {
-    expect(resolveTrick(scenario(5, 0, { pos: 4, perks: ["C6"], roles: { C6: ["X4"] } }), rng).lastTrick.pValue).toBe(10); // 5 + 5
-    expect(resolveTrick(scenario(5, 0, { pos: 3, perks: ["C6"], roles: { C6: ["X3"] } }), rng).lastTrick.pValue).toBe(5);  // andere Position → kein Bonus
-  });
-
-  it("C7 Überlebensvorteil: die niedrigste Karte des Segments bekommt +3", () => {
-    let s = build({ deck: mk([5, 4, 6, 7, 8]), oppDeck: mk([0, 0, 0, 0, 0], "B"), oppOrder: [0, 1, 2, 3, 4], playerOrder: [0, 1, 2, 3, 4], perks: ["C7"] });
-    s = resolveTrick(s, rng);             // pos0 val5 (nicht Tiefste) → +0
-    expect(s.lastTrick.pValue).toBe(5);
-    s = resolveTrick(s, rng);             // pos1 val4 (Segment-Tiefste) → +3
-    expect(s.lastTrick.pValue).toBe(7);
-  });
-});
+// Kartenrollen (Kat. C: Vorhut/Staffelläufer/Triumph/Leibwache/Anführer/Finisher/Überlebensvorteil) sind zu
+// Familien migriert (#167) — die Engine-Verdrahtung ist in test/families-engine.test.js („Kategorie C") geprüft.
 
 describe("Formationswerkzeuge — Engine (V2 §22.6 E)", () => {
   it("E10 Feinjustierung: die Formationsphase startet mit +1 Energie", () => {

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -89,41 +89,14 @@ describe("resolveTrick — Grundausgänge (V2: ohne Leben)", () => {
   });
 });
 
-describe("resolveTrick — Score-Perks (V2: Flat)", () => {
-  it("D1 Punktebonus: +75 nur bei aktiver Formation", () => {
-    expect(resolveTrick(scenario(12, 0, { perks: ["D1"] }), rng).lastTrick.gained).toBeCloseTo(102); // keine Formation → 0
-    const deck = [{ id: "a", suit: "R", baseRank: 12, value: 12 }, { id: "b", suit: "R", baseRank: 12, value: 12 }];
-    const opp = [{ id: "o0", suit: "R", baseRank: 0, value: 0 }, { id: "o1", suit: "R", baseRank: 0, value: 0 }];
-    let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: [0, 1], oppOrder: [0, 1], perks: ["D1"] };
-    s = resolveTrick(s, rng); s = resolveTrick(s, rng); // pos1 = Wiederholung (Formation ×1,25)
-    expect(s.lastTrick.gained).toBeCloseTo((100 + 75) * 1.04 * 1.25);
-  });
-
-  it("D4 Außenseitersieg: +300 Score bei Wert ≤3", () => {
-    expect(resolveTrick(scenario(2, 0, { perks: ["D4"] }), rng).score).toBeCloseTo(408); // (100+300)×1,02
-    expect(resolveTrick(scenario(12, 0, { perks: ["D4"] }), rng).score).toBeCloseTo(102);
-  });
-
-  it("D2 Siegesserie: +25 Flat je Serienpunkt (Serie 1/2/3)", () => {
-    let s = scenario(12, 0, { perks: ["D2"], deck: flatDeck() }); // formationsneutral → isoliert D2
-    s = resolveTrick(s, rng); // (100+25)×1,02 = 127,5
-    s = resolveTrick(s, rng); // (100+50)×1,04 = 156
-    s = resolveTrick(s, rng); // (100+75)×1,06 = 185,5
-    expect(s.score).toBeCloseTo(469);
-  });
-
-  it("D2 Siegesserie: gedeckelt bei +250 (Serie ≥10)", () => {
-    const s = resolveTrick(scenario(12, 0, { perks: ["D2"], winStreak: 19 }), rng);
-    expect(s.winStreak).toBe(20);
-    expect(s.lastTrick.gained).toBeCloseTo(490); // (100+250)×streakBaseMult(20)=1,40 (#100: Cap jetzt +150 %)
-  });
-});
+// D-Score-Perks sind zu Familien migriert (#167) — die Engine-Integration testet test/families-engine.test.js
+// (u. a. D_FORMATION_BONUS mit Formations-Mult und D_STREAK über mehrere Stiche).
 
 describe("resolveTrick — Crit & globale Score-Formel (ohne Tempo)", () => {
-  it("additive Boni (D5) fließen in die Basis und werden mitmultipliziert", () => {
-    // 10. Sieg → D5 +750: (100+750)×streakBaseMult(1)=1,02 = 867
-    const s = resolveTrick(scenario(12, 0, { perks: ["D5"], wins: 9 }), rng);
-    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo(867);
+  it("additive Boni (Familie D_TENTH_WIN) fließen in die Basis und werden mitmultipliziert", () => {
+    // 10. Sieg → D_TENTH_WIN II +800: (100+800)×streakBaseMult(1)=1,02 = 918
+    const s = resolveTrick(scenario(12, 0, { familyTiers: { D_TENTH_WIN: 2 }, wins: 9 }), rng);
+    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo(918);
   });
 
   it("Crit multipliziert den vollen scoreBeforeCrit mit der Basis 1,5", () => {
@@ -279,45 +252,21 @@ describe("Historie-Rares — Engine (#71 Phase 2b)", () => {
     expect(resolveTrick(scenario(3, 8, { perks: ["B8"], lossStreak: 2 }), rng).lastTrick.pValue).toBe(10);
     expect(resolveTrick(scenario(3, 8, { perks: ["B8"], lossStreak: 1 }), rng).lastTrick.pValue).toBe(3);
   });
-  it("D12 Präzision: +400 bei Übereinstimmung mit dem letzten Siegwert; lastWinValue wird gesetzt", () => {
-    expect(resolveTrick(scenario(12, 0, { perks: ["D12"], lastWinValue: 12 }), rng).score).toBeCloseTo(510); // (100+400)×1,02
-    expect(resolveTrick(scenario(12, 0, { perks: ["D12"], lastWinValue: 11 }), rng).score).toBeCloseTo(102);
-    expect(resolveTrick(scenario(9, 0, { perks: ["D12"] }), rng).lastWinValue).toBe(9);
+  it("lastWinValue wird nach einem Sieg auf den Siegwert gesetzt (Basis für Familie D_PRECISION)", () => {
+    expect(resolveTrick(scenario(9, 0), rng).lastWinValue).toBe(9);
   });
-  it("D13 Wechselspiel: +200 bei Sieg direkt nach einer Niederlage", () => {
-    expect(resolveTrick(scenario(12, 0, { perks: ["D13"], lastResult: "loss" }), rng).lastTrick.gained).toBeCloseTo(306); // (100+200)×1,02
-    expect(resolveTrick(scenario(12, 0, { perks: ["D13"], lastResult: "win" }), rng).lastTrick.gained).toBeCloseTo(102);
-  });
+  // D12 Präzision / D13 Wechselspiel als Familien (D_PRECISION / D_INTERPLAY) — Tests in families-engine.test.js.
 });
 
 describe("Crit-Historie-Rares — Engine (#71 Phase 2c)", () => {
   const never = () => 0.99; // Crit-Wurf schlägt nie an → Zustandsübergänge isoliert testbar
 
-  it("D14 Crit-Folge: +200 Score bei Sieg mit gesetztem critFollowArmed", () => {
-    expect(resolveTrick(scenario(12, 0, { perks: ["D14"], critFollowArmed: true }), never).lastTrick.gained).toBeCloseTo(306); // (100+200)×1,02
-    expect(resolveTrick(scenario(12, 0, { perks: ["D14"], critFollowArmed: false }), never).lastTrick.gained).toBeCloseTo(102);
-  });
   it("critFollowArmed: ein Crit rüstet, ein Sieg ohne Crit entrüstet", () => {
     expect(resolveTrick(scenario(12, 0, { statCritChance: 1 }), rng).critFollowArmed).toBe(true);
     expect(resolveTrick(scenario(12, 0, { critFollowArmed: true }), never).critFollowArmed).toBe(false);
   });
-
-  it("D15 Fehlzündung: lädt +30/Sieg-ohne-Crit (max 300); Crit zahlt & setzt zurück", () => {
-    expect(resolveTrick(scenario(12, 0, { misfireScore: 0 }), never).misfireScore).toBe(30);
-    expect(resolveTrick(scenario(12, 0, { misfireScore: 290 }), never).misfireScore).toBe(300); // Deckel
-    const paid = resolveTrick(scenario(12, 0, { perks: ["D15"], statCritChance: 1, misfireScore: 120 }), rng);
-    expect(paid.lastTrick.isCrit).toBe(true);
-    expect(paid.lastTrick.scoreBeforeCrit).toBeCloseTo((100 + 120) * 1.02); // Ladung in der multiplizierten Basis
-    expect(paid.misfireScore).toBe(0); // Crit setzt zurück
-  });
-
-  it("D16 Schwachstellenanalyse: klare Niederlage rüstet, Sieg gibt +300", () => {
-    expect(resolveTrick(scenario(0, 12, { perks: ["D16"] }), never).weaknessArmed).toBe(true);   // Abstand 12 ≥5
-    expect(resolveTrick(scenario(10, 12, { perks: ["D16"] }), never).weaknessArmed).toBe(false); // Abstand 2 <5
-    const win = resolveTrick(scenario(12, 0, { perks: ["D16"], weaknessArmed: true }), never);
-    expect(win.lastTrick.gained).toBeCloseTo(408); // (100+300)×1,02
-    expect(win.weaknessArmed).toBe(false); // Sieg verbraucht
-  });
+  // D14 Crit-Folge / D15 Fehlzündung / D16 Schwachstellenanalyse als Familien (D_CRIT_FOLLOW / D_MISFIRE /
+  // D_WEAKNESS) inkl. Stufen-Parameter — Tests in families-engine.test.js.
 });
 
 describe("Historie-Rares — Engine (#71 Phase 2f)", () => {
@@ -332,27 +281,17 @@ describe("Historie-Rares — Engine (#71 Phase 2f)", () => {
     expect(pv).toEqual([4, 7, 10, 4]); // Treppen-Ordinal 1,2,3 → +1,+2,+3; Pos 3 keine Treppe → +0
   });
 
-  it("D17 Farbserie: gleiche Farbe zählt, Farbwechsel beginnt bei 1, Niederlage bricht", () => {
+  it("Farbserie-Zähler (Engine): gleiche Farbe zählt hoch, Farbwechsel beginnt bei 1, Niederlage bricht", () => {
+    // winSuit/winSuitStreak sind Engine-Zustand (Basis für Familie D_SUIT_STREAK), unabhängig von einem Perk.
     const deck = [{ id: "a", suit: "R", baseRank: 12, value: 12 }, { id: "b", suit: "R", baseRank: 12, value: 12 }, { id: "c", suit: "B", baseRank: 12, value: 12 }];
     const opp = mk([0, 0, 0]);
-    let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: [0, 1, 2], oppOrder: [0, 1, 2], perks: ["D17"] };
+    let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: [0, 1, 2], oppOrder: [0, 1, 2] };
     s = resolveTrick(s, rng); expect(s.winSuitStreak).toBe(1); // R
     s = resolveTrick(s, rng); expect(s.winSuitStreak).toBe(2); // R
     s = resolveTrick(s, rng); expect(s.winSuitStreak).toBe(1); expect(s.winSuit).toBe("B"); // Farbwechsel
-    expect(resolveTrick(scenario(0, 12, { perks: ["D17"], winSuit: "R", winSuitStreak: 3 }), rng).winSuitStreak).toBe(0); // Niederlage bricht
+    expect(resolveTrick(scenario(0, 12, { winSuit: "R", winSuitStreak: 3 }), rng).winSuitStreak).toBe(0); // Niederlage bricht
   });
-  it("D17: 2. Sieg gleicher Farbe gibt +100 Flat", () => {
-    let s = scenario(12, 0, { perks: ["D17"], deck: sameSuitDeck() }); // Farbe R, wechselnde Werte → keine Formation
-    s = resolveTrick(s, rng); // Serie 1 → +0
-    s = resolveTrick(s, rng); // Serie 2 → +100
-    expect(s.lastTrick.gained).toBeCloseTo((100 + 100) * 1.04);
-  });
-
-  it("D18 Volles Haus: 5. Segment-Position mit 4 Vorsiegen → +750", () => {
-    // pos 4 = letzte Position im Segment 0; recentResults 4× win → 5 Siege im Segment.
-    expect(resolveTrick(scenario(12, 0, { perks: ["D18"], pos: 4, recentResults: ["win", "win", "win", "win"] }), rng).lastTrick.gained).toBeCloseTo((100 + 750) * 1.02);
-    expect(resolveTrick(scenario(12, 0, { perks: ["D18"], pos: 3, recentResults: ["win", "win", "win", "win"] }), rng).lastTrick.gained).toBeCloseTo(102); // nicht Segment-Ende
-  });
+  // D17 Farbserie / D18 Volles Haus als Familien (D_SUIT_STREAK / D_FULL_HOUSE) — Score-Tests in families-engine.test.js.
   it("Volles-Haus-Fenster: recentResults hält die letzten 4 Ergebnisse", () => {
     expect(resolveTrick(scenario(12, 0, { recentResults: ["loss", "win", "tie", "win"] }), rng).recentResults).toEqual(["win", "tie", "win", "win"]);
   });
@@ -376,13 +315,13 @@ describe("Serien-/Crit-Rares — Engine (#71 Phase 2e)", () => {
     expect(pv).toEqual([4, 12, 2]); // Pos0 kein Vorgänger; Pos1 (9>4) +3; Pos2 (2<9) +0
   });
 
-  it("D19 Überschusskrit: +250 Crit-Flat, wenn die Roh-Crit-Chance über 100 % liegt", () => {
-    // statCritChance 1,5 → rawCrit 1,5 (>1), Crit garantiert. scoreBase = 100 + 250.
-    const s = resolveTrick(scenario(12, 0, { perks: ["D19"], statCritChance: 1.5 }), rng);
+  it("Familie D_OVERCRIT: +Crit-Flat, wenn die Roh-Crit-Chance über 100 % liegt (rawCrit im critCtx)", () => {
+    // D_OVERCRIT III: jeder Überschuss-Crit (rawCrit > 1) gibt +500. statCritChance 1,5 → rawCrit 1,5, Crit garantiert.
+    const s = resolveTrick(scenario(12, 0, { familyTiers: { D_OVERCRIT: 3 }, statCritChance: 1.5 }), rng);
     expect(s.lastTrick.isCrit).toBe(true);
-    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo((100 + 250) * 1.02);
+    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo((100 + 500) * 1.02);
     // rawCrit genau 1 (nicht >1) → kein Bonus.
-    expect(resolveTrick(scenario(12, 0, { perks: ["D19"], statCritChance: 1 }), rng).lastTrick.scoreBeforeCrit).toBeCloseTo(102);
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_OVERCRIT: 3 }, statCritChance: 1 }), rng).lastTrick.scoreBeforeCrit).toBeCloseTo(102);
   });
 });
 

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -314,16 +314,18 @@ describe("buildPerkOffer — gemischtes Angebot Familien + flache Perks (Schritt
     }
   });
 
-  it("reguläre D-Perks (D1–D19) sind vollständig zu Familien migriert — kein flacher D-Score-Perk mehr", () => {
-    // Nach der Entfernung existiert kein regulärer (nicht-legendärer) cat-D-Perk mehr im flachen Pool;
-    // die D-Legendäre (L4/L5/L6/L10) bleiben flach (isMigratedPerk = false).
+  it("reguläre D- und A-Perks sind vollständig zu Familien migriert — kein flacher regulärer D-/A-Perk mehr", () => {
+    // Nach der Entfernung existiert kein regulärer (nicht-legendärer) cat-D- oder cat-A-Perk mehr im flachen Pool;
+    // die Legendäre bleiben flach (D: L4/L5/L6/L10; A: L1/L3/L8/L9/L11) → isMigratedPerk = false.
     expect(PERK_LIST.some((p) => p.cat === "D" && !isLegendary(p.id))).toBe(false);
-    expect(isMigratedPerk(PERK_DEFS.A1)).toBe(false);
-    expect(isMigratedPerk(PERK_DEFS.L5)).toBe(false);
-    // Über viele Seeds: das Angebot enthält nie einen flachen regulären D-Perk — D erscheint nur als Familie.
+    expect(PERK_LIST.some((p) => p.cat === "A" && !isLegendary(p.id))).toBe(false);
+    expect(isMigratedPerk(PERK_DEFS.C1)).toBe(false); // Kat. C noch nicht migriert
+    expect(isMigratedPerk(PERK_DEFS.L5)).toBe(false); // Legendär bleibt flach
+    expect(isMigratedPerk(PERK_DEFS.L1)).toBe(false); // cat A, aber legendär → bleibt flach
+    // Über viele Seeds: das Angebot enthält nie einen flachen regulären D-/A-Perk — D/A erscheinen nur als Familie.
     for (let seed = 0; seed < 40; seed++) {
       for (const e of buildPerkOffer([], {}, rngS(seed), 3)) {
-        if (!isFam(e)) expect(PERK_DEFS[e].cat === "D" && !isLegendary(e)).toBe(false);
+        if (!isFam(e)) expect(["D", "A"].includes(PERK_DEFS[e].cat) && !isLegendary(e)).toBe(false);
       }
     }
   });
@@ -351,9 +353,9 @@ describe("buildPerkOffer — gemischtes Angebot Familien + flache Perks (Schritt
 
   it("besessene flache Perks werden nicht erneut angeboten", () => {
     for (let seed = 0; seed < 30; seed++) {
-      const off = buildPerkOffer(["A1", "A2"], {}, rngS(seed), 3);
-      expect(off).not.toContain("A1");
-      expect(off).not.toContain("A2");
+      const off = buildPerkOffer(["C1", "E1"], {}, rngS(seed), 3);
+      expect(off).not.toContain("C1");
+      expect(off).not.toContain("E1");
     }
   });
 

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -417,17 +417,17 @@ describe("buildPerkOffer — gemischtes Angebot Familien + flache Perks (Schritt
     }
   });
 
-  it("reguläre D-/A-/C-Perks sind vollständig zu Familien migriert — kein flacher regulärer D-/A-/C-Perk mehr", () => {
-    // Nach der Entfernung existiert kein regulärer (nicht-legendärer) cat-D-/A-/C-Perk mehr im flachen Pool;
-    // die Legendäre bleiben flach (D: L4/L5/L6/L10; A: L1/L3/L8/L9/L11) → isMigratedPerk = false.
+  it("reguläre D-/A-/C-/E-Perks sind vollständig zu Familien migriert — kein flacher regulärer Perk dieser Kat. mehr", () => {
+    // Nach der Entfernung existiert kein regulärer (nicht-legendärer) cat-D-/A-/C-/E-Perk mehr im flachen Pool
+    // (Ausnahme: E10, cat E, aber offerable:false → nie im Angebot). Legendäre bleiben flach → isMigratedPerk = false.
     for (const cat of ["D", "A", "C"]) expect(PERK_LIST.some((p) => p.cat === cat && !isLegendary(p.id))).toBe(false);
-    expect(isMigratedPerk(PERK_DEFS.E1)).toBe(false); // Kat. E noch nicht migriert
-    expect(isMigratedPerk(PERK_DEFS.L5)).toBe(false); // Legendär bleibt flach
+    expect(PERK_LIST.some((p) => p.cat === "E" && !isLegendary(p.id) && p.offerable !== false)).toBe(false); // nur E10 (offerable:false)
+    expect(isMigratedPerk(PERK_DEFS.L2)).toBe(false); // Legendär bleibt flach
     expect(isMigratedPerk(PERK_DEFS.L1)).toBe(false); // cat A, aber legendär → bleibt flach
-    // Über viele Seeds: das Angebot enthält nie einen flachen regulären D-/A-/C-Perk — sie erscheinen nur als Familie.
+    // Über viele Seeds: das Angebot enthält nie einen flachen regulären D-/A-/C-/E-Perk — sie erscheinen nur als Familie.
     for (let seed = 0; seed < 40; seed++) {
       for (const e of buildPerkOffer([], {}, rngS(seed), 3)) {
-        if (!isFam(e)) expect(["D", "A", "C"].includes(PERK_DEFS[e].cat) && !isLegendary(e)).toBe(false);
+        if (!isFam(e)) expect(["D", "A", "C", "E"].includes(PERK_DEFS[e].cat) && !isLegendary(e)).toBe(false);
       }
     }
   });
@@ -453,11 +453,11 @@ describe("buildPerkOffer — gemischtes Angebot Familien + flache Perks (Schritt
     expect(buildPerkOffer(ownedFlat, allIV, rngS(1), 3)).toEqual([]);
   });
 
-  it("besessene flache Perks werden nicht erneut angeboten", () => {
+  it("besessene flache Perks werden nicht erneut angeboten (Legendäre — alle regulären Perks sind Familien)", () => {
     for (let seed = 0; seed < 30; seed++) {
-      const off = buildPerkOffer(["E1", "E2"], {}, rngS(seed), 3);
-      expect(off).not.toContain("E1");
-      expect(off).not.toContain("E2");
+      const off = buildPerkOffer(["L1", "L2"], {}, rngS(seed), 3, 1); // Legendär-Wurf aktiv, aber L1/L2 besessen
+      expect(off).not.toContain("L1");
+      expect(off).not.toContain("L2");
     }
   });
 

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -132,9 +132,15 @@ describe("Engine-Parameter je Stufe (Schritt 2) — engine-gekoppelte D-Familien
     expect(resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_MOMENTUM: 3 }, statCritChance: 1 }), never).winStreak).toBe(1);
   });
 
-  it("D_INTERPLAY IV: eine Niederlage bankt +200 Score (Stufe III nicht)", () => {
-    expect(resolveTrick(scenario(0, 12, { familyTiers: { D_INTERPLAY: 4 } }), never).score).toBe(200);
-    expect(resolveTrick(scenario(0, 12, { familyTiers: { D_INTERPLAY: 3 } }), never).score).toBe(0);
+  it("D_INTERPLAY IV: Niederlage speichert +200, der nächste Sieg zahlt sie als Flat aus (Stufe III speichert nicht)", () => {
+    const afterLoss = resolveTrick(scenario(0, 12, { familyTiers: { D_INTERPLAY: 4 } }), never);
+    expect(afterLoss.score).toBe(0);              // Niederlage zahlt nicht sofort aus
+    expect(afterLoss.interplayStored).toBe(200);  // sondern bankt
+    expect(resolveTrick(scenario(0, 12, { familyTiers: { D_INTERPLAY: 3 } }), never).interplayStored).toBe(0);
+    // Nächster Sieg nach Niederlage: 700 (Wechselspiel-Basis) + 200 (gespeichert) in die multiplizierte Basis; danach verbraucht.
+    const win = resolveTrick(scenario(12, 0, { familyTiers: { D_INTERPLAY: 4 }, interplayStored: 200, lastResult: "loss" }), never);
+    expect(win.score).toBeCloseTo((100 + 700 + 200) * 1.02);
+    expect(win.interplayStored).toBe(0);
   });
 
   it("D_CRIT_FOLLOW IV: Crit-Folgesieg, der selbst Crit ist, gibt zusätzlich +300", () => {

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -11,6 +11,8 @@ import { applyFamilyPick } from "../src/game/families.js";
 // Konstantes Deck: gleicher Wert bildet nur eine Wiederholung, KEINEN Farbblock; Pos 0 hat keinen
 // Formations-Mult (wie in engine.test.js verankert) → isoliert die Score-Flats.
 const constDeck = (v) => Array.from({ length: 40 }, (_, i) => ({ id: `X${i}`, suit: ["R", "B", "G", "Y"][i % 4], baseRank: v, value: v }));
+// Formationsneutral (Werte 12/11, Farbe R/B abwechselnd): gewinnt gegen 0, bildet KEINE Formation → isoliert Score-Flats.
+const flatDeck = () => Array.from({ length: 40 }, (_, i) => ({ id: `F${i}`, suit: i % 2 ? "B" : "R", baseRank: i % 2 ? 11 : 12, value: i % 2 ? 11 : 12 }));
 const identity = () => Array.from({ length: 40 }, (_, i) => i);
 function scenario(pVal, oVal, over = {}) {
   return {
@@ -21,6 +23,8 @@ function scenario(pVal, oVal, over = {}) {
   };
 }
 const rng = makeRng(9);
+// Kritwurf ist rng()<chance: 0,999… crittet nie bei realer Chance, aber immer bei erzwungener Chance 1 (statCritChance:1).
+const never = () => 0.999999;
 
 describe("Familien-Engine-Verdrahtung — Kategorie D über resolveTrick (Schritt 1)", () => {
   it("D_HIGH IV: Stufe zahlt scoreFlat in die multiplizierte Basis (Wert ≥6)", () => {
@@ -82,6 +86,71 @@ describe("Reducer PICK_FAMILY (Schritt 1)", () => {
 
   it("initialState trägt ein leeres familyTiers", () => {
     expect(initialState(makeRng(1)).familyTiers).toEqual({});
+  });
+});
+
+describe("Engine-Parameter je Stufe (Schritt 2) — engine-gekoppelte D-Familien", () => {
+  it("D_MISFIRE: Stufen-Schritt/Cap laden die Ladung (I: +20/200)", () => {
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_MISFIRE: 1 }, misfireScore: 0 }), never).misfireScore).toBe(20);
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_MISFIRE: 1 }, misfireScore: 190 }), never).misfireScore).toBe(200); // Cap
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_MISFIRE: 4 }, misfireScore: 0 }), never).misfireScore).toBe(75); // IV-Schritt
+  });
+  it("D_MISFIRE IV: Crit zahlt die volle Ladung aus und behält 25 %", () => {
+    const paid = resolveTrick(scenario(12, 0, { familyTiers: { D_MISFIRE: 4 }, statCritChance: 1, misfireScore: 400 }), never);
+    expect(paid.lastTrick.isCrit).toBe(true);
+    expect(paid.misfireScore).toBe(100); // round(400 × 0,25)
+    expect(paid.lastTrick.gained).toBeCloseTo((100 + 400) * 1.02 * paid.lastTrick.critMultiplier); // volle 400 in die Basis
+  });
+
+  it("D_WEAKNESS: Stufen-Schwelle rüstet (I: ≥7)", () => {
+    expect(resolveTrick(scenario(0, 12, { familyTiers: { D_WEAKNESS: 1 } }), never).weaknessArmed).toBe(true);  // Abstand 12 ≥7
+    expect(resolveTrick(scenario(6, 12, { familyTiers: { D_WEAKNESS: 1 } }), never).weaknessArmed).toBe(false); // Abstand 6 <7
+  });
+  it("D_WEAKNESS IV: jede Niederlage rüstet, großer Abstand markiert weaknessBig (+900 statt +600)", () => {
+    const small = resolveTrick(scenario(11, 12, { familyTiers: { D_WEAKNESS: 4 } }), never); // Abstand 1
+    expect(small.weaknessArmed).toBe(true);
+    expect(small.weaknessBig).toBe(false);
+    const big = resolveTrick(scenario(5, 12, { familyTiers: { D_WEAKNESS: 4 } }), never); // Abstand 7 ≥5
+    expect(big.weaknessBig).toBe(true);
+    // Auszahlung am nächsten Sieg: big → +900, sonst +600.
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_WEAKNESS: 4 }, weaknessArmed: true, weaknessBig: true }), never).score).toBeCloseTo((100 + 900) * 1.02);
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_WEAKNESS: 4 }, weaknessArmed: true, weaknessBig: false }), never).score).toBeCloseTo((100 + 600) * 1.02);
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_WEAKNESS: 4 }, weaknessArmed: true, weaknessBig: true }), never).weaknessBig).toBe(false); // Sieg verbraucht
+  });
+
+  it("D_SUIT_STREAK IV: Farbwechsel halbiert die Länge (statt Reset auf 1)", () => {
+    // Pos 0 ist Farbe R; state-Farbe B → Wechsel. IV: floor(6/2)=3; I: Reset auf 1.
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_SUIT_STREAK: 4 }, winSuit: "B", winSuitStreak: 6 }), never).winSuitStreak).toBe(3);
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_SUIT_STREAK: 1 }, winSuit: "B", winSuitStreak: 6 }), never).winSuitStreak).toBe(1);
+  });
+
+  it("D_CRIT_MOMENTUM IV: ein Crit erhöht die Siegesserie zusätzlich um 1", () => {
+    const iv = resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_MOMENTUM: 4 }, statCritChance: 1 }), never);
+    expect(iv.lastTrick.isCrit).toBe(true);
+    expect(iv.winStreak).toBe(2); // +1 Sieg, +1 Crit-Bonus
+    // Stufe III ohne streakGainOnCrit → nur der Sieg zählt.
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_MOMENTUM: 3 }, statCritChance: 1 }), never).winStreak).toBe(1);
+  });
+
+  it("D_INTERPLAY IV: eine Niederlage bankt +200 Score (Stufe III nicht)", () => {
+    expect(resolveTrick(scenario(0, 12, { familyTiers: { D_INTERPLAY: 4 } }), never).score).toBe(200);
+    expect(resolveTrick(scenario(0, 12, { familyTiers: { D_INTERPLAY: 3 } }), never).score).toBe(0);
+  });
+
+  it("D_CRIT_FOLLOW IV: Crit-Folgesieg, der selbst Crit ist, gibt zusätzlich +300", () => {
+    const cf = resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_FOLLOW: 4 }, critFollowArmed: true, statCritChance: 1 }), never);
+    expect(cf.lastTrick.isCrit).toBe(true);
+    expect(cf.lastTrick.gained).toBeCloseTo((100 + 700 + 300) * 1.02 * cf.lastTrick.critMultiplier); // 700 (Folge) + 300 (Crit-Bonus)
+    // Folgesieg ohne Crit → nur die 700 (kein +300).
+    const noCrit = resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_FOLLOW: 4 }, critFollowArmed: true } ), never);
+    expect(noCrit.lastTrick.isCrit).toBe(false);
+    expect(noCrit.score).toBeCloseTo((100 + 700) * 1.02);
+  });
+
+  it("D_FULL_HOUSE: löst über den generischen Hook auf (fünfter Segment-Sieg → +500, Stufe I)", () => {
+    let s = scenario(0, 0, { familyTiers: { D_FULL_HOUSE: 1 }, deck: flatDeck(), oppDeck: constDeck(0) });
+    for (let i = 0; i < 5; i++) s = resolveTrick(s, never); // fünf Siege in Folge, fünfter auf Segmentposition 4
+    expect(s.lastTrick.breakdown.flats).toBeCloseTo(500); // isolierter Flat-Anteil der Familie
   });
 });
 

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -157,6 +157,79 @@ describe("Reducer PICK_FAMILY — Kategorie A (kumulativ, Deck-Patch stapelt)", 
   });
 });
 
+describe("Familien-Ziel-Fluss — pickTarget-Stufen (Rarität #167, Kat. A)", () => {
+  const base = (offerEntry) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: [offerEntry] });
+
+  it("PICK_FAMILY auf eine pickTarget-Stufe öffnet die Ziel-Phase, wendet noch nichts an", () => {
+    const s0 = base({ familyId: "A_SUIT_BOOST", tier: 3 });
+    const s1 = reducer(s0, { type: "PICK_FAMILY", familyId: "A_SUIT_BOOST", tier: 3, rng });
+    expect(s1.phase).toBe("family-target");
+    expect(s1.familyTarget).toEqual({ familyId: "A_SUIT_BOOST", tier: 3, suits: [] });
+    expect(s1.offer).toBeNull();
+    expect(s1.deck).toBe(s0.deck);       // noch keine Deckmod
+    expect(s1.familyTiers).toEqual({});  // Rang erst bei CONFIRM
+  });
+
+  it("FAMILY_TARGET_SUIT: Einzelwahl (need 1) schaltet um, ungültige Farbe wird ignoriert", () => {
+    let s = reducer(base({ familyId: "A_SUIT_BOOST", tier: 3 }), { type: "PICK_FAMILY", familyId: "A_SUIT_BOOST", tier: 3, rng });
+    s = reducer(s, { type: "FAMILY_TARGET_SUIT", suit: "R" });
+    expect(s.familyTarget.suits).toEqual(["R"]);
+    s = reducer(s, { type: "FAMILY_TARGET_SUIT", suit: "B" }); // Einzelwahl → ersetzt
+    expect(s.familyTarget.suits).toEqual(["B"]);
+    s = reducer(s, { type: "FAMILY_TARGET_SUIT", suit: "B" }); // erneut → abwählen
+    expect(s.familyTarget.suits).toEqual([]);
+    expect(reducer(s, { type: "FAMILY_TARGET_SUIT", suit: "Z" }).familyTarget.suits).toEqual([]); // ungültig
+  });
+
+  it("FAMILY_TARGET_CONFIRM (A_SUIT_BOOST IV): gewählte Farbe +2, Rang gesetzt, zurück ins Spiel", () => {
+    let s = reducer(base({ familyId: "A_SUIT_BOOST", tier: 4 }), { type: "PICK_FAMILY", familyId: "A_SUIT_BOOST", tier: 4, rng });
+    s = reducer(s, { type: "FAMILY_TARGET_SUIT", suit: "G" });
+    s = reducer(s, { type: "FAMILY_TARGET_CONFIRM", rng });
+    expect(s.phase).toBe("play");
+    expect(s.familyTarget).toBeNull();
+    expect(s.familyTiers).toEqual({ A_SUIT_BOOST: 4 });
+    expect(s.deck.filter((c) => c.suit === "G").every((c) => c.value === c.baseRank + 2)).toBe(true);
+    expect(s.deck.filter((c) => c.suit !== "G").every((c) => c.value === c.baseRank)).toBe(true);
+  });
+
+  it("FAMILY_TARGET_CONFIRM verlangt genau N Farben (unvollständig → No-Op)", () => {
+    let s = reducer(base({ familyId: "A_SUIT_DUEL", tier: 4 }), { type: "PICK_FAMILY", familyId: "A_SUIT_DUEL", tier: 4, rng });
+    s = reducer(s, { type: "FAMILY_TARGET_SUIT", suit: "R" }); // erst 1 von 2
+    const s2 = reducer(s, { type: "FAMILY_TARGET_CONFIRM", rng });
+    expect(s2).toBe(s);                    // unverändert
+    expect(s2.phase).toBe("family-target");
+  });
+
+  it("A_SUIT_DUEL IV: Reihenfolge Gewinner→Verlierer (R +4 / G −1)", () => {
+    let s = reducer(base({ familyId: "A_SUIT_DUEL", tier: 4 }), { type: "PICK_FAMILY", familyId: "A_SUIT_DUEL", tier: 4, rng });
+    s = reducer(s, { type: "FAMILY_TARGET_SUIT", suit: "R" }); // Gewinner
+    s = reducer(s, { type: "FAMILY_TARGET_SUIT", suit: "G" }); // Verlierer
+    expect(s.familyTarget.suits).toEqual(["R", "G"]);
+    s = reducer(s, { type: "FAMILY_TARGET_CONFIRM", rng });
+    expect(s.familyTiers).toEqual({ A_SUIT_DUEL: 4 });
+    expect(s.deck.filter((c) => c.suit === "R").every((c) => c.value === c.baseRank + 4)).toBe(true);
+    expect(s.deck.filter((c) => c.suit === "G").every((c) => c.value === Math.max(0, c.baseRank - 1))).toBe(true);
+    expect(s.deck.filter((c) => c.suit === "B" || c.suit === "Y").every((c) => c.value === c.baseRank)).toBe(true);
+  });
+
+  it("zielfreie A-Stufe und REPLACEMENT-Familie (D) gehen direkt ins Spiel (keine Ziel-Phase)", () => {
+    const a = reducer(base({ familyId: "A_SUIT_BOOST", tier: 1 }), { type: "PICK_FAMILY", familyId: "A_SUIT_BOOST", tier: 1, rng });
+    expect(a.phase).toBe("play"); // I = zufällige Farbe, kein pickTarget
+    const d = reducer({ ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "D_HIGH", tier: 3 }] }, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 3, rng });
+    expect(d.phase).toBe("play");
+  });
+
+  it("Ziel-Actions in falscher Phase sind No-Ops", () => {
+    const play = { ...initialState(makeRng(1)), phase: "play" };
+    expect(reducer(play, { type: "FAMILY_TARGET_SUIT", suit: "R" })).toBe(play);
+    expect(reducer(play, { type: "FAMILY_TARGET_CONFIRM", rng })).toBe(play);
+  });
+
+  it("initialState trägt familyTarget = null", () => {
+    expect(initialState(makeRng(1)).familyTarget).toBeNull();
+  });
+});
+
 describe("Engine-Parameter je Stufe (Schritt 2) — engine-gekoppelte D-Familien", () => {
   it("D_MISFIRE: Stufen-Schritt/Cap laden die Ladung (I: +20/200)", () => {
     expect(resolveTrick(scenario(12, 0, { familyTiers: { D_MISFIRE: 1 }, misfireScore: 0 }), never).misfireScore).toBe(20);

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -150,6 +150,14 @@ describe("Familien-Engine — Kategorie C (Rollen über resolveTrick, Schritt 2b
   });
 });
 
+describe("Familien-Engine — Kategorie E (E_QUICKSHOT IV Anker-Wert über resolveTrick)", () => {
+  it("E_QUICKSHOT IV: jede fünfte Position (Anker) erhält +2 Wert; andere Positionen/Stufen nicht", () => {
+    expect(resolveTrick(scenario(5, 0, { familyTiers: { E_QUICKSHOT: 4 }, pos: 4 }), rng).lastTrick.pValue).toBe(7); // Pos 5 → +2
+    expect(resolveTrick(scenario(5, 0, { familyTiers: { E_QUICKSHOT: 4 }, pos: 3 }), rng).lastTrick.pValue).toBe(5); // Pos 4 → kein Anker
+    expect(resolveTrick(scenario(5, 0, { familyTiers: { E_QUICKSHOT: 3 }, pos: 4 }), rng).lastTrick.pValue).toBe(5); // III: anchor.value 0 → kein Wertbonus
+  });
+});
+
 describe("Reducer PICK_FAMILY (Schritt 1 + Angebotsvalidierung Schritt 3)", () => {
   it("setzt familyTiers[id] auf die Zielstufe und kehrt ins Spiel zurück", () => {
     const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "D_HIGH", tier: 3 }] };

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -230,6 +230,18 @@ describe("buildPerkOffer — gemischtes Angebot Familien + flache Perks (Schritt
       expect(off.filter((e) => !isFam(e) && isLegendary(e))).toHaveLength(1);
     }
   });
+
+  it("bei aktivem Roll (Chance>0) erscheinen NIE zwei Legendäre", () => {
+    for (let seed = 1; seed <= 60; seed++)
+      expect(buildPerkOffer([], {}, rngS(seed), 3, 0.5).filter((e) => !isFam(e) && isLegendary(e)).length).toBeLessThanOrEqual(1);
+  });
+
+  it("ein aktiver Roll kann auch ohne Legendäres ausgehen (Miss)", () => {
+    let anyWithout = false;
+    for (let seed = 1; seed <= 40 && !anyWithout; seed++)
+      if (!buildPerkOffer([], {}, rngS(seed), 3, 0.2).some((e) => !isFam(e) && isLegendary(e))) anyWithout = true;
+    expect(anyWithout).toBe(true);
+  });
 });
 
 describe("applyFamilyPick — reines Patch (Spec §2.4)", () => {

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -3,7 +3,7 @@ import { makeRng } from "../src/game/deck.js";
 import { initialState, reducer } from "../src/game/reducer.js";
 import { resolveTrick } from "../src/game/engine.js";
 import { applyFamilyPick, FAMILY_DEFS } from "../src/game/families.js";
-import { buildPerkOffer, isMigratedPerk, PERK_DEFS, isLegendary } from "../src/game/perks.js";
+import { buildPerkOffer, isMigratedPerk, PERK_DEFS, PERK_LIST, isLegendary } from "../src/game/perks.js";
 
 /* Engine-Verdrahtung des Raritätssystems (Epic #167, Schritt 1): der End-to-End-Nachweis, dass eine
    gehaltene Familien-Stufe (state.familyTiers) über resolveTrick genauso in die multiplizierte Score-Basis
@@ -41,6 +41,24 @@ describe("Familien-Engine-Verdrahtung — Kategorie D über resolveTrick (Schrit
     expect(resolveTrick(scenario(7, 0, { familyTiers: { D_HIGH: 2 } }), rng).score).toBeCloseTo(102);
   });
 
+  it("D_FORMATION_BONUS: Familien-Flat stapelt mit dem Formations-Multiplikator (Wiederholung ×1,25)", () => {
+    // Ohne Formation → nur Basis. Mit Formation (Pos 1 = Wiederholung) fließt der Flat in die multiplizierte Basis.
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_FORMATION_BONUS: 1 } }), rng).lastTrick.gained).toBeCloseTo(102);
+    const deck = [{ id: "a", suit: "R", baseRank: 12, value: 12 }, { id: "b", suit: "R", baseRank: 12, value: 12 }];
+    const opp = [{ id: "o0", suit: "R", baseRank: 0, value: 0 }, { id: "o1", suit: "R", baseRank: 0, value: 0 }];
+    let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: [0, 1], oppOrder: [0, 1], familyTiers: { D_FORMATION_BONUS: 1 } };
+    s = resolveTrick(s, rng); s = resolveTrick(s, rng); // Pos 1 = Wiederholung (×1,25)
+    expect(s.lastTrick.gained).toBeCloseTo((100 + 50) * 1.04 * 1.25); // Stufe I: +50
+  });
+
+  it("D_STREAK: Familien-Flat wächst über mehrere Stiche mit der Serie (Stufe I: +15/Serienpunkt)", () => {
+    let s = scenario(12, 0, { familyTiers: { D_STREAK: 1 }, deck: flatDeck() }); // formationsneutral
+    s = resolveTrick(s, rng); // (100+15)×1,02
+    s = resolveTrick(s, rng); // (100+30)×1,04
+    s = resolveTrick(s, rng); // (100+45)×1,06
+    expect(s.score).toBeCloseTo((100 + 15) * 1.02 + (100 + 30) * 1.04 + (100 + 45) * 1.06);
+  });
+
   it("scoreFlatOnCrit-Familie (D_CRIT_SCORE) zahlt nur bei einem Crit", () => {
     // erzwungener Crit via statCritChance:1 → Rang 2 gibt +175 in die Basis, dann Crit-Faktor.
     const s = resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_SCORE: 2 }, statCritChance: 1 }), rng);
@@ -50,10 +68,10 @@ describe("Familien-Engine-Verdrahtung — Kategorie D über resolveTrick (Schrit
     expect(resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_SCORE: 2 } }), rng).score).toBeCloseTo(102);
   });
 
-  it("Familie UND flacher Perk gleichzeitig — additiv, kein gegenseitiges Überschreiben", () => {
-    // Flacher D3 (Wert ≥8 → +125) + Familie D_HIGH IV (Wert ≥6 → +350) auf einem Sieg mit Wert 8.
-    const s = resolveTrick(scenario(8, 0, { perks: ["D3"], familyTiers: { D_HIGH: 4 } }), rng);
-    expect(s.score).toBeCloseTo((100 + 125 + 350) * 1.02);
+  it("Zwei Familien gleichzeitig — additiv, kein gegenseitiges Überschreiben", () => {
+    // D_HIGH IV (Wert ≥6 → +350) + D_OVERPOWER II (Vorsprung ≥8 → +400) auf einem Sieg mit Wert 8 / Vorsprung 8.
+    const s = resolveTrick(scenario(8, 0, { familyTiers: { D_HIGH: 4, D_OVERPOWER: 2 } }), rng);
+    expect(s.score).toBeCloseTo((100 + 350 + 400) * 1.02);
   });
 
   it("leere familyTiers verändern den Score nicht (reine Additivität)", () => {
@@ -177,11 +195,13 @@ describe("buildPerkOffer — gemischtes Angebot Familien + flache Perks (Schritt
     }
   });
 
-  it("reguläre D-Perks (D1–D19) sind migriert und tauchen NICHT mehr als flache Perks auf", () => {
-    expect(isMigratedPerk(PERK_DEFS.D3)).toBe(true);
+  it("reguläre D-Perks (D1–D19) sind vollständig zu Familien migriert — kein flacher D-Score-Perk mehr", () => {
+    // Nach der Entfernung existiert kein regulärer (nicht-legendärer) cat-D-Perk mehr im flachen Pool;
+    // die D-Legendäre (L4/L5/L6/L10) bleiben flach (isMigratedPerk = false).
+    expect(PERK_LIST.some((p) => p.cat === "D" && !isLegendary(p.id))).toBe(false);
     expect(isMigratedPerk(PERK_DEFS.A1)).toBe(false);
-    expect(isMigratedPerk(PERK_DEFS.L5)).toBe(false); // legendärer D-Perk bleibt flach
-    // Über viele Seeds: kein flacher D-Perk im Angebot; D erscheint nur als Familie.
+    expect(isMigratedPerk(PERK_DEFS.L5)).toBe(false);
+    // Über viele Seeds: das Angebot enthält nie einen flachen regulären D-Perk — D erscheint nur als Familie.
     for (let seed = 0; seed < 40; seed++) {
       for (const e of buildPerkOffer([], {}, rngS(seed), 3)) {
         if (!isFam(e)) expect(PERK_DEFS[e].cat === "D" && !isLegendary(e)).toBe(false);

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -417,18 +417,17 @@ describe("buildPerkOffer — gemischtes Angebot Familien + flache Perks (Schritt
     }
   });
 
-  it("reguläre D- und A-Perks sind vollständig zu Familien migriert — kein flacher regulärer D-/A-Perk mehr", () => {
-    // Nach der Entfernung existiert kein regulärer (nicht-legendärer) cat-D- oder cat-A-Perk mehr im flachen Pool;
+  it("reguläre D-/A-/C-Perks sind vollständig zu Familien migriert — kein flacher regulärer D-/A-/C-Perk mehr", () => {
+    // Nach der Entfernung existiert kein regulärer (nicht-legendärer) cat-D-/A-/C-Perk mehr im flachen Pool;
     // die Legendäre bleiben flach (D: L4/L5/L6/L10; A: L1/L3/L8/L9/L11) → isMigratedPerk = false.
-    expect(PERK_LIST.some((p) => p.cat === "D" && !isLegendary(p.id))).toBe(false);
-    expect(PERK_LIST.some((p) => p.cat === "A" && !isLegendary(p.id))).toBe(false);
-    expect(isMigratedPerk(PERK_DEFS.C1)).toBe(false); // Kat. C noch nicht migriert
+    for (const cat of ["D", "A", "C"]) expect(PERK_LIST.some((p) => p.cat === cat && !isLegendary(p.id))).toBe(false);
+    expect(isMigratedPerk(PERK_DEFS.E1)).toBe(false); // Kat. E noch nicht migriert
     expect(isMigratedPerk(PERK_DEFS.L5)).toBe(false); // Legendär bleibt flach
     expect(isMigratedPerk(PERK_DEFS.L1)).toBe(false); // cat A, aber legendär → bleibt flach
-    // Über viele Seeds: das Angebot enthält nie einen flachen regulären D-/A-Perk — D/A erscheinen nur als Familie.
+    // Über viele Seeds: das Angebot enthält nie einen flachen regulären D-/A-/C-Perk — sie erscheinen nur als Familie.
     for (let seed = 0; seed < 40; seed++) {
       for (const e of buildPerkOffer([], {}, rngS(seed), 3)) {
-        if (!isFam(e)) expect(["D", "A"].includes(PERK_DEFS[e].cat) && !isLegendary(e)).toBe(false);
+        if (!isFam(e)) expect(["D", "A", "C"].includes(PERK_DEFS[e].cat) && !isLegendary(e)).toBe(false);
       }
     }
   });
@@ -456,9 +455,9 @@ describe("buildPerkOffer — gemischtes Angebot Familien + flache Perks (Schritt
 
   it("besessene flache Perks werden nicht erneut angeboten", () => {
     for (let seed = 0; seed < 30; seed++) {
-      const off = buildPerkOffer(["C1", "E1"], {}, rngS(seed), 3);
-      expect(off).not.toContain("C1");
+      const off = buildPerkOffer(["E1", "E2"], {}, rngS(seed), 3);
       expect(off).not.toContain("E1");
+      expect(off).not.toContain("E2");
     }
   });
 

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { makeRng } from "../src/game/deck.js";
+import { makeRng, buildDeck } from "../src/game/deck.js";
 import { initialState, reducer } from "../src/game/reducer.js";
 import { resolveTrick } from "../src/game/engine.js";
 import { applyFamilyPick, FAMILY_DEFS } from "../src/game/families.js";
@@ -136,6 +136,24 @@ describe("Reducer PICK_FAMILY (Schritt 1 + Angebotsvalidierung Schritt 3)", () =
 
   it("initialState trägt ein leeres familyTiers", () => {
     expect(initialState(makeRng(1)).familyTiers).toEqual({});
+  });
+});
+
+describe("Reducer PICK_FAMILY — Kategorie A (kumulativ, Deck-Patch stapelt)", () => {
+  const val = (deck, base) => deck.filter((c) => c.baseRank === base).map((c) => c.value);
+  it("wendet das Stufen-Deckpaket an und stapelt über Stufen (nur höchster Rang angezeigt)", () => {
+    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "A_WEAK_STRONG", tier: 1 }] };
+    s = reducer(s, { type: "PICK_FAMILY", familyId: "A_WEAK_STRONG", tier: 1, rng });
+    expect(s.familyTiers.A_WEAK_STRONG).toBe(1);
+    expect(s.phase).toBe("play");
+    expect(val(s.deck, 5)).toEqual([6, 6, 6, 6]); // ursprüngliche 5er +1
+    // Upgrade auf II: 4er +2 (neues Paket), 5er-Bonus aus I bleibt erhalten (kumulativ).
+    s = { ...s, phase: "levelup", offer: [{ familyId: "A_WEAK_STRONG", tier: 2 }] };
+    s = reducer(s, { type: "PICK_FAMILY", familyId: "A_WEAK_STRONG", tier: 2, rng });
+    expect(s.familyTiers.A_WEAK_STRONG).toBe(2);             // nur der höchste Rang
+    expect(Object.keys(s.familyTiers)).toEqual(["A_WEAK_STRONG"]);
+    expect(val(s.deck, 5)).toEqual([6, 6, 6, 6]);            // I-Bonus bleibt
+    expect(val(s.deck, 4)).toEqual([6, 6, 6, 6]);            // II wendet sein Paket an
   });
 });
 
@@ -299,5 +317,21 @@ describe("applyFamilyPick — reines Patch (Spec §2.4)", () => {
   it("No-Op bei unbekannter Familie / Stufe 0", () => {
     expect(applyFamilyPick("NOPE", 2, { familyTiers: { D_HIGH: 1 } }, rng).familyTiers).toEqual({ D_HIGH: 1 });
     expect(applyFamilyPick("D_HIGH", 0, { familyTiers: { D_HIGH: 1 } }, rng).familyTiers).toEqual({ D_HIGH: 1 });
+  });
+
+  it("CUMULATIVE (Kat. A): onPick liefert ein NEUES Deck, familyTiers steigt, Original unberührt", () => {
+    const deck = buildDeck();
+    const out = applyFamilyPick("A_WEAK_STRONG", 1, { familyTiers: {}, deck, roles: null }, rng);
+    expect(out.familyTiers).toEqual({ A_WEAK_STRONG: 1 });
+    expect(out.deck).not.toBe(deck); // immutabel: neues Deck
+    expect(out.deck.filter((c) => c.baseRank === 5).every((c) => c.value === 6)).toBe(true);
+    expect(deck.filter((c) => c.baseRank === 5).every((c) => c.value === 5)).toBe(true); // Original unverändert
+  });
+
+  it("CUMULATIVE mit pickTarget aber ohne target → Deck unverändert (Ziel-Flow folgt)", () => {
+    const deck = buildDeck();
+    const out = applyFamilyPick("A_SUIT_BOOST", 3, { familyTiers: {}, deck, roles: null }, rng); // A_SUIT_BOOST III braucht Farbwahl
+    expect(out.familyTiers).toEqual({ A_SUIT_BOOST: 3 });
+    expect(out.deck).toBe(deck); // No-Op ohne target
   });
 });

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -80,6 +80,34 @@ describe("Familien-Engine-Verdrahtung — Kategorie D über resolveTrick (Schrit
   });
 });
 
+describe("Familien-Engine — Kategorie B (Wertboni über resolveTrick)", () => {
+  it("B_COUNTER: Familien-cardBonus hebt den Kampfwert der nächsten Karte nach einer Niederlage", () => {
+    const s = resolveTrick(scenario(3, 8, { familyTiers: { B_COUNTER: 4 }, lastResult: "loss" }), rng);
+    expect(s.lastTrick.pValue).toBe(13); // 3 + 10
+    expect(s.wins).toBe(1);              // 13 > 8 → aus der Niederlage wird ein Sieg
+  });
+  it("B_OPENING: die ersten Karten je Durchlauf erhalten den Wertbonus (Stufe I: Pos 1–2 +2)", () => {
+    const s = resolveTrick(scenario(5, 6, { familyTiers: { B_OPENING: 1 } }), rng);
+    expect(s.lastTrick.pValue).toBe(7);  // Pos 0 → +2 → 7 > 6 → Sieg
+    expect(s.wins).toBe(1);
+  });
+  it("B_INITIATIVE: tieArmLosses armiert den Gleichstand-Sieg je Stufe", () => {
+    expect(resolveTrick(scenario(3, 8, { familyTiers: { B_INITIATIVE: 1 } }), rng).tieArmed).toBe(false); // 1 Niederlage < Schwelle 2
+    expect(resolveTrick(scenario(3, 8, { familyTiers: { B_INITIATIVE: 1 }, lossStreak: 1 }), rng).tieArmed).toBe(true); // 2. Niederlage
+    expect(resolveTrick(scenario(3, 8, { familyTiers: { B_INITIATIVE: 2 } }), rng).tieArmed).toBe(true); // Stufe II: schon ab 1
+    const win = resolveTrick(scenario(5, 5, { familyTiers: { B_INITIATIVE: 2 }, tieArmed: true }), rng);
+    expect(win.wins).toBe(1);
+    expect(win.lastTrick.result).toBe("win_tie");
+  });
+  it("B_REVENGE III: bei GENAU 2 Niederlagen +6 auf die nächsten zwei Karten (successorQueue)", () => {
+    const s = resolveTrick(scenario(3, 8, { familyTiers: { B_REVENGE: 3 }, lossStreak: 1 }), rng); // 2. Niederlage armiert
+    expect(s.successorQueue).toEqual([6, 6]);
+    const next = resolveTrick({ ...s, deck: constDeck(4), oppDeck: constDeck(8), playerOrder: identity(), oppOrder: identity(), pos: 0 }, rng);
+    expect(next.lastTrick.pValue).toBe(10);   // 4 + 6 (Kopf der Queue)
+    expect(next.successorQueue).toEqual([6]); // eine verbraucht
+  });
+});
+
 describe("Reducer PICK_FAMILY (Schritt 1 + Angebotsvalidierung Schritt 3)", () => {
   it("setzt familyTiers[id] auf die Zielstufe und kehrt ins Spiel zurück", () => {
     const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "D_HIGH", tier: 3 }] };
@@ -221,19 +249,13 @@ describe("buildPerkOffer — gemischtes Angebot Familien + flache Perks (Schritt
   });
 
   it("bietet nur Stufen ECHT über dem gehaltenen Rang an; IV schließt die Familie ab", () => {
-    // D_HIGH auf Rang 3 → nur noch Stufe IV anbietbar.
-    let sawIV = false;
-    for (let seed = 0; seed < 60; seed++) {
-      for (const e of buildPerkOffer([], { D_HIGH: 3 }, rngS(seed), 3)) {
-        if (isFam(e) && e.familyId === "D_HIGH") { expect(e.tier).toBe(4); sawIV = true; }
-      }
-    }
-    expect(sawIV).toBe(true);
-    // Alle D-Familien auf IV → keine D-Familie mehr im Angebot (nur noch flache Perks).
+    const ownedFlat = PERK_LIST.map((p) => p.id); // alle flachen Perks besessen → Angebotspool = nur Familien
+    // Alle Familien außer D_HIGH auf IV (abgeschlossen), D_HIGH auf Rang III → einzige anbietbare Stufe ist IV.
+    const others = Object.fromEntries(Object.keys(FAMILY_DEFS).filter((id) => id !== "D_HIGH").map((id) => [id, 4]));
+    expect(buildPerkOffer(ownedFlat, { ...others, D_HIGH: 3 }, rngS(1), 3)).toEqual([{ familyId: "D_HIGH", tier: 4 }]);
+    // Alle Familien auf IV + alle flachen Perks besessen → gar kein Angebot mehr.
     const allIV = Object.fromEntries(Object.keys(FAMILY_DEFS).map((id) => [id, 4]));
-    for (let seed = 0; seed < 20; seed++) {
-      for (const e of buildPerkOffer([], allIV, rngS(seed), 3)) expect(isFam(e)).toBe(false);
-    }
+    expect(buildPerkOffer(ownedFlat, allIV, rngS(1), 3)).toEqual([]);
   });
 
   it("besessene flache Perks werden nicht erneut angeboten", () => {

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { makeRng } from "../src/game/deck.js";
+import { initialState, reducer } from "../src/game/reducer.js";
+import { resolveTrick } from "../src/game/engine.js";
+import { applyFamilyPick } from "../src/game/families.js";
+
+/* Engine-Verdrahtung des Raritätssystems (Epic #167, Schritt 1): der End-to-End-Nachweis, dass eine
+   gehaltene Familien-Stufe (state.familyTiers) über resolveTrick genauso in die multiplizierte Score-Basis
+   fließt wie ein flacher D-Perk — additiv, ohne Doppel-Trigger. Teststil analog engine.test.js. */
+
+// Konstantes Deck: gleicher Wert bildet nur eine Wiederholung, KEINEN Farbblock; Pos 0 hat keinen
+// Formations-Mult (wie in engine.test.js verankert) → isoliert die Score-Flats.
+const constDeck = (v) => Array.from({ length: 40 }, (_, i) => ({ id: `X${i}`, suit: ["R", "B", "G", "Y"][i % 4], baseRank: v, value: v }));
+const identity = () => Array.from({ length: 40 }, (_, i) => i);
+function scenario(pVal, oVal, over = {}) {
+  return {
+    ...initialState(makeRng(1)),
+    deck: constDeck(pVal), oppDeck: constDeck(oVal),
+    playerOrder: identity(), oppOrder: identity(),
+    ...over,
+  };
+}
+const rng = makeRng(9);
+
+describe("Familien-Engine-Verdrahtung — Kategorie D über resolveTrick (Schritt 1)", () => {
+  it("D_HIGH IV: Stufe zahlt scoreFlat in die multiplizierte Basis (Wert ≥6)", () => {
+    // Wert 6 ≥ Schwelle 6 → +350; (100+350)×streakBaseMult(1)=1,02
+    expect(resolveTrick(scenario(6, 0, { familyTiers: { D_HIGH: 4 } }), rng).score).toBeCloseTo(459);
+    // Wert 5 < 6 → nur Basis
+    expect(resolveTrick(scenario(5, 0, { familyTiers: { D_HIGH: 4 } }), rng).score).toBeCloseTo(102);
+  });
+
+  it("nur die gehaltene Stufe zählt — kein Doppel-Trigger über Stufen (Spec §2.3/§9)", () => {
+    // D_HIGH auf Rang 2: Schwelle ≥8/+150. Rang 1 (≥9/+100) darf NICHT zusätzlich zählen.
+    expect(resolveTrick(scenario(8, 0, { familyTiers: { D_HIGH: 2 } }), rng).score).toBeCloseTo(255); // (100+150)×1,02
+    expect(resolveTrick(scenario(7, 0, { familyTiers: { D_HIGH: 2 } }), rng).score).toBeCloseTo(102);
+  });
+
+  it("scoreFlatOnCrit-Familie (D_CRIT_SCORE) zahlt nur bei einem Crit", () => {
+    // erzwungener Crit via statCritChance:1 → Rang 2 gibt +175 in die Basis, dann Crit-Faktor.
+    const s = resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_SCORE: 2 }, statCritChance: 1 }), rng);
+    expect(s.lastTrick.isCrit).toBe(true);
+    expect(s.lastTrick.gained).toBeCloseTo((100 + 175) * 1.02 * s.lastTrick.critMultiplier);
+    // Ohne Crit (keine Crit-Chance) trägt die Familie nichts bei → nur Basis.
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_SCORE: 2 } }), rng).score).toBeCloseTo(102);
+  });
+
+  it("Familie UND flacher Perk gleichzeitig — additiv, kein gegenseitiges Überschreiben", () => {
+    // Flacher D3 (Wert ≥8 → +125) + Familie D_HIGH IV (Wert ≥6 → +350) auf einem Sieg mit Wert 8.
+    const s = resolveTrick(scenario(8, 0, { perks: ["D3"], familyTiers: { D_HIGH: 4 } }), rng);
+    expect(s.score).toBeCloseTo((100 + 125 + 350) * 1.02);
+  });
+
+  it("leere familyTiers verändern den Score nicht (reine Additivität)", () => {
+    expect(resolveTrick(scenario(12, 0, { familyTiers: {} }), rng).score).toBeCloseTo(102);
+    expect(resolveTrick(scenario(12, 0), rng).score).toBeCloseTo(102); // Feld ganz weggelassen
+  });
+});
+
+describe("Reducer PICK_FAMILY (Schritt 1)", () => {
+  it("setzt familyTiers[id] auf die Zielstufe und kehrt ins Spiel zurück", () => {
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup" };
+    const s1 = reducer(s0, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 3, rng });
+    expect(s1.familyTiers.D_HIGH).toBe(3);
+    expect(s1.phase).toBe("play");
+  });
+
+  it("Upgrade ersetzt die gehaltene Stufe (nur höchste aktiv)", () => {
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", familyTiers: { D_HIGH: 1 } };
+    const s1 = reducer(s0, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 3, rng });
+    expect(s1.familyTiers.D_HIGH).toBe(3);
+    expect(Object.keys(s1.familyTiers)).toEqual(["D_HIGH"]); // kein zweiter Rang derselben Familie
+  });
+
+  it("ignoriert unbekannte Familie, Stufe 0 und die falsche Phase", () => {
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup" };
+    expect(reducer(s0, { type: "PICK_FAMILY", familyId: "NOPE", tier: 2, rng })).toBe(s0);
+    expect(reducer(s0, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 0, rng })).toBe(s0);
+    const play = { ...initialState(makeRng(1)), phase: "play" };
+    expect(reducer(play, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 2, rng })).toBe(play);
+  });
+
+  it("initialState trägt ein leeres familyTiers", () => {
+    expect(initialState(makeRng(1)).familyTiers).toEqual({});
+  });
+});
+
+describe("applyFamilyPick — reines Patch (Spec §2.4)", () => {
+  it("REPLACEMENT: nur familyTiers ändert sich, Deck/Rollen unangetastet", () => {
+    const deck = [{ id: "a", value: 3 }];
+    const roles = { X: ["a"] };
+    const out = applyFamilyPick("D_HIGH", 2, { familyTiers: { D_STREAK: 1 }, deck, roles }, rng);
+    expect(out.familyTiers).toEqual({ D_STREAK: 1, D_HIGH: 2 });
+    expect(out.deck).toBe(deck);   // identische Referenz → keine Deckmod bei REPLACEMENT
+    expect(out.roles).toBe(roles);
+  });
+
+  it("No-Op bei unbekannter Familie / Stufe 0", () => {
+    expect(applyFamilyPick("NOPE", 2, { familyTiers: { D_HIGH: 1 } }, rng).familyTiers).toEqual({ D_HIGH: 1 });
+    expect(applyFamilyPick("D_HIGH", 0, { familyTiers: { D_HIGH: 1 } }, rng).familyTiers).toEqual({ D_HIGH: 1 });
+  });
+});

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -108,6 +108,48 @@ describe("Familien-Engine — Kategorie B (Wertboni über resolveTrick)", () => 
   });
 });
 
+describe("Familien-Engine — Kategorie C (Rollen über resolveTrick, Schritt 2b)", () => {
+  it("C_VANGUARD: Rollenkarte auf Position 1–5 erhält den Wertbonus (nur mit Rolle)", () => {
+    const s = resolveTrick(scenario(5, 6, { familyTiers: { C_VANGUARD: 1 }, roles: { C_VANGUARD: ["X0"] } }), rng);
+    expect(s.lastTrick.pValue).toBe(7); // 5 + 2
+    expect(s.wins).toBe(1);
+    expect(resolveTrick(scenario(5, 6, { familyTiers: { C_VANGUARD: 1 }, roles: {} }), rng).wins).toBe(0); // keine Rolle → 0
+  });
+  it("C_FINISHER: Rollenkarte auf der letzten Segmentposition erhält den Bonus", () => {
+    const s = resolveTrick(scenario(5, 6, { familyTiers: { C_FINISHER: 1 }, roles: { C_FINISHER: ["X4"] }, pos: 4 }), rng);
+    expect(s.lastTrick.pValue).toBe(8); // Pos 5 (%5===4) → 5 + 3
+  });
+  it("C_TRIUMPH: Rollen-Sieg armiert die Karte; beim nächsten Auftauchen +Bonus (Stufe III: +3)", () => {
+    let s = resolveTrick(scenario(8, 0, { familyTiers: { C_TRIUMPH: 3 }, roles: { C_TRIUMPH: ["X0"] } }), rng);
+    expect(s.triumphArmed).toContain("X0");
+    const s2 = resolveTrick({ ...s, deck: constDeck(8), oppDeck: constDeck(0), playerOrder: identity(), oppOrder: identity(), pos: 0 }, rng);
+    expect(s2.lastTrick.pValue).toBe(11); // 8 + 3
+  });
+  it("C_RELAY III: Rollen-Sieg gibt der nächsten Karte +3 (successorQueue)", () => {
+    const s = resolveTrick(scenario(8, 0, { familyTiers: { C_RELAY: 3 }, roles: { C_RELAY: ["X0"] } }), rng); // X0 gewinnt
+    expect(s.successorQueue[0]).toBe(3);
+    expect(resolveTrick(s, rng).lastTrick.pValue).toBe(11); // nächste Karte 8 + 3
+  });
+  it("C_LEADER IV: Rollen-Sieg armiert die nächsten DREI Karten je +4", () => {
+    const s = resolveTrick(scenario(8, 0, { familyTiers: { C_LEADER: 4 }, roles: { C_LEADER: ["X0"] } }), rng);
+    expect(s.successorQueue.slice(0, 3)).toEqual([4, 4, 4]);
+  });
+  it("C_GUARD IV: einer der zwei Vorgänger verlor → +6 (secondLastResult)", () => {
+    const armed = scenario(3, 8, { familyTiers: { C_GUARD: 4 }, roles: { C_GUARD: ["X0"] }, lastResult: "win", recentResults: ["loss", "win"] });
+    expect(resolveTrick(armed, rng).lastTrick.pValue).toBe(9); // 3 + 6 (zweiter Vorgänger verlor)
+    const both = scenario(3, 8, { familyTiers: { C_GUARD: 4 }, roles: { C_GUARD: ["X0"] }, lastResult: "win", recentResults: ["win", "win"] });
+    expect(resolveTrick(both, rng).lastTrick.pValue).toBe(3); // beide gewonnen → kein Bonus
+  });
+  it("C_SURVIVOR: Segment-Rang (I nur erste 4 Segmente, II nur Tiefste, III zwei Tiefste)", () => {
+    // Segment 0 (Pos 0–4) Werte [1,5,2,9,7] → Pos 0 tiefste (Rang 0), Pos 2 zweittiefste (Rang 1).
+    const deck = [1, 5, 2, 9, 7, ...Array(35).fill(9)].map((v, i) => ({ id: `Y${i}`, suit: ["R", "B", "G", "Y"][i % 4], baseRank: v, value: v }));
+    const base = (fam, over) => ({ ...initialState(makeRng(1)), deck, oppDeck: constDeck(0), playerOrder: identity(), oppOrder: identity(), familyTiers: fam, ...over });
+    expect(resolveTrick(base({ C_SURVIVOR: 1 }), rng).lastTrick.pValue).toBe(3);              // Pos 0 tiefste, Segment 0 <4 → +2
+    expect(resolveTrick(base({ C_SURVIVOR: 3 }, { pos: 2 }), rng).lastTrick.pValue).toBe(5);  // Pos 2 Rang 1 → +3
+    expect(resolveTrick(base({ C_SURVIVOR: 2 }, { pos: 2 }), rng).lastTrick.pValue).toBe(2);  // II nur Tiefste → Rang 1 kein Bonus
+  });
+});
+
 describe("Reducer PICK_FAMILY (Schritt 1 + Angebotsvalidierung Schritt 3)", () => {
   it("setzt familyTiers[id] auf die Zielstufe und kehrt ins Spiel zurück", () => {
     const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "D_HIGH", tier: 3 }] };

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -2,7 +2,8 @@ import { describe, it, expect } from "vitest";
 import { makeRng } from "../src/game/deck.js";
 import { initialState, reducer } from "../src/game/reducer.js";
 import { resolveTrick } from "../src/game/engine.js";
-import { applyFamilyPick } from "../src/game/families.js";
+import { applyFamilyPick, FAMILY_DEFS } from "../src/game/families.js";
+import { buildPerkOffer, isMigratedPerk, PERK_DEFS, isLegendary } from "../src/game/perks.js";
 
 /* Engine-Verdrahtung des Raritätssystems (Epic #167, Schritt 1): der End-to-End-Nachweis, dass eine
    gehaltene Familien-Stufe (state.familyTiers) über resolveTrick genauso in die multiplizierte Score-Basis
@@ -61,27 +62,30 @@ describe("Familien-Engine-Verdrahtung — Kategorie D über resolveTrick (Schrit
   });
 });
 
-describe("Reducer PICK_FAMILY (Schritt 1)", () => {
+describe("Reducer PICK_FAMILY (Schritt 1 + Angebotsvalidierung Schritt 3)", () => {
   it("setzt familyTiers[id] auf die Zielstufe und kehrt ins Spiel zurück", () => {
-    const s0 = { ...initialState(makeRng(1)), phase: "levelup" };
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "D_HIGH", tier: 3 }] };
     const s1 = reducer(s0, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 3, rng });
     expect(s1.familyTiers.D_HIGH).toBe(3);
     expect(s1.phase).toBe("play");
+    expect(s1.offer).toBeNull();
   });
 
   it("Upgrade ersetzt die gehaltene Stufe (nur höchste aktiv)", () => {
-    const s0 = { ...initialState(makeRng(1)), phase: "levelup", familyTiers: { D_HIGH: 1 } };
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", familyTiers: { D_HIGH: 1 }, offer: [{ familyId: "D_HIGH", tier: 3 }] };
     const s1 = reducer(s0, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 3, rng });
     expect(s1.familyTiers.D_HIGH).toBe(3);
     expect(Object.keys(s1.familyTiers)).toEqual(["D_HIGH"]); // kein zweiter Rang derselben Familie
   });
 
-  it("ignoriert unbekannte Familie, Stufe 0 und die falsche Phase", () => {
-    const s0 = { ...initialState(makeRng(1)), phase: "levelup" };
-    expect(reducer(s0, { type: "PICK_FAMILY", familyId: "NOPE", tier: 2, rng })).toBe(s0);
-    expect(reducer(s0, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 0, rng })).toBe(s0);
-    const play = { ...initialState(makeRng(1)), phase: "play" };
-    expect(reducer(play, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 2, rng })).toBe(play);
+  it("ignoriert Familie/Stufe außerhalb des Angebots, Stufe 0 und die falsche Phase", () => {
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "D_HIGH", tier: 3 }] };
+    expect(reducer(s0, { type: "PICK_FAMILY", familyId: "NOPE", tier: 2, rng })).toBe(s0);       // unbekannte Familie
+    expect(reducer(s0, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 2, rng })).toBe(s0);     // Stufe nicht im Angebot
+    expect(reducer(s0, { type: "PICK_FAMILY", familyId: "D_STREAK", tier: 3, rng })).toBe(s0);   // Familie nicht im Angebot
+    expect(reducer(s0, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 0, rng })).toBe(s0);     // Stufe 0
+    const play = { ...initialState(makeRng(1)), phase: "play", offer: [{ familyId: "D_HIGH", tier: 3 }] };
+    expect(reducer(play, { type: "PICK_FAMILY", familyId: "D_HIGH", tier: 3, rng })).toBe(play); // falsche Phase
   });
 
   it("initialState trägt ein leeres familyTiers", () => {
@@ -157,6 +161,74 @@ describe("Engine-Parameter je Stufe (Schritt 2) — engine-gekoppelte D-Familien
     let s = scenario(0, 0, { familyTiers: { D_FULL_HOUSE: 1 }, deck: flatDeck(), oppDeck: constDeck(0) });
     for (let i = 0; i < 5; i++) s = resolveTrick(s, never); // fünf Siege in Folge, fünfter auf Segmentposition 4
     expect(s.lastTrick.breakdown.flats).toBeCloseTo(500); // isolierter Flat-Anteil der Familie
+  });
+});
+
+describe("buildPerkOffer — gemischtes Angebot Familien + flache Perks (Schritt 3)", () => {
+  const isFam = (e) => e && typeof e === "object" && e.familyId != null;
+  const rngS = (seed) => makeRng(seed);
+
+  it("liefert count Einträge; jeder ist ein flacher Perk-String ODER {familyId,tier}", () => {
+    const off = buildPerkOffer([], {}, rngS(3), 3);
+    expect(off).toHaveLength(3);
+    for (const e of off) {
+      if (isFam(e)) { expect(FAMILY_DEFS[e.familyId]).toBeTruthy(); expect([1, 2, 3, 4]).toContain(e.tier); }
+      else { expect(typeof e).toBe("string"); expect(PERK_DEFS[e]).toBeTruthy(); }
+    }
+  });
+
+  it("reguläre D-Perks (D1–D19) sind migriert und tauchen NICHT mehr als flache Perks auf", () => {
+    expect(isMigratedPerk(PERK_DEFS.D3)).toBe(true);
+    expect(isMigratedPerk(PERK_DEFS.A1)).toBe(false);
+    expect(isMigratedPerk(PERK_DEFS.L5)).toBe(false); // legendärer D-Perk bleibt flach
+    // Über viele Seeds: kein flacher D-Perk im Angebot; D erscheint nur als Familie.
+    for (let seed = 0; seed < 40; seed++) {
+      for (const e of buildPerkOffer([], {}, rngS(seed), 3)) {
+        if (!isFam(e)) expect(PERK_DEFS[e].cat === "D" && !isLegendary(e)).toBe(false);
+      }
+    }
+  });
+
+  it("deterministisch über den rng (gleicher Seed → gleiches Angebot)", () => {
+    expect(buildPerkOffer([], {}, rngS(7), 3)).toEqual(buildPerkOffer([], {}, rngS(7), 3));
+  });
+
+  it("eine Familie erscheint höchstens einmal je Angebot (keine zwei Stufen derselben Familie)", () => {
+    for (let seed = 0; seed < 40; seed++) {
+      const fams = buildPerkOffer([], {}, rngS(seed), 3).filter(isFam).map((e) => e.familyId);
+      expect(new Set(fams).size).toBe(fams.length);
+    }
+  });
+
+  it("bietet nur Stufen ECHT über dem gehaltenen Rang an; IV schließt die Familie ab", () => {
+    // D_HIGH auf Rang 3 → nur noch Stufe IV anbietbar.
+    let sawIV = false;
+    for (let seed = 0; seed < 60; seed++) {
+      for (const e of buildPerkOffer([], { D_HIGH: 3 }, rngS(seed), 3)) {
+        if (isFam(e) && e.familyId === "D_HIGH") { expect(e.tier).toBe(4); sawIV = true; }
+      }
+    }
+    expect(sawIV).toBe(true);
+    // Alle D-Familien auf IV → keine D-Familie mehr im Angebot (nur noch flache Perks).
+    const allIV = Object.fromEntries(Object.keys(FAMILY_DEFS).map((id) => [id, 4]));
+    for (let seed = 0; seed < 20; seed++) {
+      for (const e of buildPerkOffer([], allIV, rngS(seed), 3)) expect(isFam(e)).toBe(false);
+    }
+  });
+
+  it("besessene flache Perks werden nicht erneut angeboten", () => {
+    for (let seed = 0; seed < 30; seed++) {
+      const off = buildPerkOffer(["A1", "A2"], {}, rngS(seed), 3);
+      expect(off).not.toContain("A1");
+      expect(off).not.toContain("A2");
+    }
+  });
+
+  it("Legendär-Wurf: mit Chance 1 enthält das Angebot genau ein Legendäres (flach)", () => {
+    for (let seed = 0; seed < 10; seed++) {
+      const off = buildPerkOffer([], {}, rngS(seed), 3, 1);
+      expect(off.filter((e) => !isFam(e) && isLegendary(e))).toHaveLength(1);
+    }
   });
 });
 

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -164,7 +164,7 @@ describe("Familien-Ziel-Fluss — pickTarget-Stufen (Rarität #167, Kat. A)", ()
     const s0 = base({ familyId: "A_SUIT_BOOST", tier: 3 });
     const s1 = reducer(s0, { type: "PICK_FAMILY", familyId: "A_SUIT_BOOST", tier: 3, rng });
     expect(s1.phase).toBe("family-target");
-    expect(s1.familyTarget).toEqual({ familyId: "A_SUIT_BOOST", tier: 3, suits: [] });
+    expect(s1.familyTarget).toEqual({ familyId: "A_SUIT_BOOST", tier: 3, kind: "suits", need: 1, suits: [], cards: [] });
     expect(s1.offer).toBeNull();
     expect(s1.deck).toBe(s0.deck);       // noch keine Deckmod
     expect(s1.familyTiers).toEqual({});  // Rang erst bei CONFIRM
@@ -227,6 +227,67 @@ describe("Familien-Ziel-Fluss — pickTarget-Stufen (Rarität #167, Kat. A)", ()
 
   it("initialState trägt familyTarget = null", () => {
     expect(initialState(makeRng(1)).familyTarget).toBeNull();
+  });
+});
+
+describe("Familien-Ziel-Fluss — Karten-Modus (Kat. C Rollen + C_SACRIFICE)", () => {
+  const lvl = (offerEntry, over = {}) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: [offerEntry], ...over });
+
+  it("ROLE (C_VANGUARD I): PICK_FAMILY öffnet Karten-Ziel (need 1), CONFIRM setzt roles[familyId]", () => {
+    let s = reducer(lvl({ familyId: "C_VANGUARD", tier: 1 }), { type: "PICK_FAMILY", familyId: "C_VANGUARD", tier: 1, rng });
+    expect(s.phase).toBe("family-target");
+    expect(s.familyTarget).toMatchObject({ familyId: "C_VANGUARD", tier: 1, kind: "cards", need: 1, cards: [] });
+    s = reducer(s, { type: "FAMILY_TARGET_CARD", cardId: "R5" });
+    expect(s.familyTarget.cards).toEqual(["R5"]);
+    s = reducer(s, { type: "FAMILY_TARGET_CONFIRM", rng });
+    expect(s.phase).toBe("play");
+    expect(s.familyTiers).toEqual({ C_VANGUARD: 1 });
+    expect(s.roles.C_VANGUARD).toEqual(["R5"]);
+    expect(s.familyTarget).toBeNull();
+  });
+
+  it("ROLE-Upgrade wählt nur ZUSÄTZLICHE Ziele; bestehende bleiben (Spec §2.3)", () => {
+    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "C_VANGUARD", tier: 3 }],
+              familyTiers: { C_VANGUARD: 1 }, roles: { C_VANGUARD: ["R5"] } };
+    s = reducer(s, { type: "PICK_FAMILY", familyId: "C_VANGUARD", tier: 3, rng });
+    expect(s.familyTarget.need).toBe(2); // 3 Ziele − 1 bereits gehalten
+    s = reducer(s, { type: "FAMILY_TARGET_CARD", cardId: "R6" });
+    s = reducer(s, { type: "FAMILY_TARGET_CARD", cardId: "R7" });
+    s = reducer(s, { type: "FAMILY_TARGET_CONFIRM", rng });
+    expect(s.familyTiers.C_VANGUARD).toBe(3);
+    expect(s.roles.C_VANGUARD).toEqual(["R5", "R6", "R7"]); // Bestand + zwei neue
+  });
+
+  it("ROLE-Upgrade ohne neue Ziele (need 0) wendet direkt an (C_LEADER I→II, je 1 Ziel)", () => {
+    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "C_LEADER", tier: 2 }],
+              familyTiers: { C_LEADER: 1 }, roles: { C_LEADER: ["R5"] } };
+    s = reducer(s, { type: "PICK_FAMILY", familyId: "C_LEADER", tier: 2, rng });
+    expect(s.phase).toBe("play");             // keine Ziel-Phase
+    expect(s.familyTiers.C_LEADER).toBe(2);
+    expect(s.roles.C_LEADER).toEqual(["R5"]); // Rolle unverändert
+  });
+
+  it("FAMILY_TARGET_CARD: gehaltene Rollenkarte, unbekannte Karte und Limit werden ignoriert", () => {
+    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "C_VANGUARD", tier: 3 }],
+              familyTiers: { C_VANGUARD: 1 }, roles: { C_VANGUARD: ["R5"] } };
+    s = reducer(s, { type: "PICK_FAMILY", familyId: "C_VANGUARD", tier: 3, rng }); // need 2
+    expect(reducer(s, { type: "FAMILY_TARGET_CARD", cardId: "R5" }).familyTarget.cards).toEqual([]);   // bereits Rolle
+    expect(reducer(s, { type: "FAMILY_TARGET_CARD", cardId: "ZZ9" }).familyTarget.cards).toEqual([]);  // existiert nicht
+    s = reducer(s, { type: "FAMILY_TARGET_CARD", cardId: "R6" });
+    s = reducer(s, { type: "FAMILY_TARGET_CARD", cardId: "R7" });
+    expect(reducer(s, { type: "FAMILY_TARGET_CARD", cardId: "R8" }).familyTarget.cards).toEqual(["R6", "R7"]); // Limit 2
+  });
+
+  it("CUMULATIVE (C_SACRIFICE I): Karten-Ziel opfert die Karte (−2) & bufft Nachfolger (+3), keine Rolle", () => {
+    const deck = ["a", "b", "c"].map((id) => ({ id, suit: "R", baseRank: 5, value: 5 }));
+    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: [{ familyId: "C_SACRIFICE", tier: 1 }], deck, playerOrder: [0, 1, 2] };
+    s = reducer(s, { type: "PICK_FAMILY", familyId: "C_SACRIFICE", tier: 1, rng });
+    expect(s.familyTarget).toMatchObject({ kind: "cards", need: 1 });
+    s = reducer(s, { type: "FAMILY_TARGET_CARD", cardId: "a" });
+    s = reducer(s, { type: "FAMILY_TARGET_CONFIRM", rng });
+    expect(s.familyTiers).toEqual({ C_SACRIFICE: 1 });
+    expect(s.deck.map((c) => c.value)).toEqual([3, 8, 5]); // a −2, direkter Nachfolger b +3
+    expect(s.roles.C_SACRIFICE).toBeUndefined();           // Deck-Mod, keine Rolle
   });
 });
 

--- a/test/families.test.js
+++ b/test/families.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  FAMILY_DEFS, FAMILY_LIST, familyDef, familyCategory,
+  activeTierDef, activeTierDefs, familySumHook, familyProdHook,
+} from "../src/game/families.js";
+import { UPGRADE_TYPES } from "../src/game/rarity.js";
+
+describe("Familien-Registry — Struktur", () => {
+  it("jede Familie hat id/cat/name/upgradeType und vier Stufen mit Beschreibung", () => {
+    for (const fam of FAMILY_LIST) {
+      expect(fam.id).toBeTruthy();
+      expect(["A", "B", "C", "D", "E"]).toContain(fam.cat);
+      expect(fam.name).toBeTruthy();
+      expect(Object.values(UPGRADE_TYPES)).toContain(fam.upgradeType);
+      for (const t of [1, 2, 3, 4]) {
+        expect(fam.tiers[t]).toBeTruthy();
+        expect(typeof fam.tiers[t].desc).toBe("string");
+        expect(fam.tiers[t].desc.length).toBeGreaterThan(0);
+      }
+    }
+  });
+  it("Kategorie D vollständig (19 Familien, alle Regelersetzung)", () => {
+    const d = FAMILY_LIST.filter((f) => f.cat === "D");
+    expect(d).toHaveLength(19);
+    for (const f of d) expect(f.upgradeType).toBe(UPGRADE_TYPES.REPLACEMENT);
+  });
+});
+
+describe("Kategorie D — Stufeneffekte (Spec §3.2 D)", () => {
+  it("Punktebonus: Formation-Sieg 50/100/175/300", () => {
+    const f = FAMILY_DEFS.D_FORMATION_BONUS.tiers;
+    expect([1, 2, 3, 4].map((t) => f[t].scoreFlat({ hasFormation: true }))).toEqual([50, 100, 175, 300]);
+    expect(f[4].scoreFlat({ hasFormation: false })).toBe(0);
+  });
+  it("Hohe Karten: Schwelle sinkt 9→6, Auszahlung steigt", () => {
+    const f = FAMILY_DEFS.D_HIGH.tiers;
+    expect(f[1].scoreFlat({ winValue: 9 })).toBe(100);
+    expect(f[1].scoreFlat({ winValue: 8 })).toBe(0);
+    expect(f[4].scoreFlat({ winValue: 6 })).toBe(350);
+    expect(f[4].scoreFlat({ winValue: 5 })).toBe(0);
+  });
+  it("Siegesserie: Schritt × Serienpunkt, gedeckelt", () => {
+    const f = FAMILY_DEFS.D_STREAK.tiers;
+    expect(f[1].scoreFlat({ winStreak: 3 })).toBe(45);   // 15×3
+    expect(f[1].scoreFlat({ winStreak: 20 })).toBe(150); // Cap
+    expect(f[4].scoreFlat({ winStreak: 4 })).toBe(200);  // 50×4
+  });
+  it("Übermacht: Vorsprung-Schwelle sinkt 10→4", () => {
+    const f = FAMILY_DEFS.D_OVERPOWER.tiers;
+    expect(f[1].scoreFlat({ margin: 10 })).toBe(300);
+    expect(f[1].scoreFlat({ margin: 9 })).toBe(0);
+    expect(f[4].scoreFlat({ margin: 4 })).toBe(750);
+  });
+  it("Präzision: I/II exakt gleich, III/IV auch ±1", () => {
+    const f = FAMILY_DEFS.D_PRECISION.tiers;
+    expect(f[1].scoreFlat({ winValue: 5, lastWinValue: 5 })).toBe(250);
+    expect(f[1].scoreFlat({ winValue: 5, lastWinValue: 6 })).toBe(0);   // ±1 zählt noch nicht
+    expect(f[3].scoreFlat({ winValue: 5, lastWinValue: 6 })).toBe(550); // ±1 zählt
+    expect(f[4].scoreFlat({ winValue: 5, lastWinValue: 7 })).toBe(0);   // ±2 nicht
+  });
+  it("Zehnter Sieg: Zähler-Intervall sinkt 12→5", () => {
+    const f = FAMILY_DEFS.D_TENTH_WIN.tiers;
+    expect(f[1].scoreFlat({ wins: 12 })).toBe(600);
+    expect(f[1].scoreFlat({ wins: 11 })).toBe(0);
+    expect(f[4].scoreFlat({ wins: 5 })).toBe(1000);
+  });
+  it("Crit-Familien nutzen scoreFlatOnCrit (nicht scoreFlat)", () => {
+    expect(FAMILY_DEFS.D_CRIT_SCORE.tiers[2].scoreFlatOnCrit()).toBe(175);
+    expect(FAMILY_DEFS.D_CRIT_SCORE.tiers[2].scoreFlat).toBeUndefined();
+    expect(FAMILY_DEFS.D_OVERCRIT.tiers[2].scoreFlatOnCrit({ rawCrit: 1.2 })).toBe(300);
+  });
+});
+
+describe("Resolver — Regelersetzung (nur höchste Stufe aktiv)", () => {
+  it("activeTierDef liefert die Def der gehaltenen Stufe", () => {
+    expect(activeTierDef("D_HIGH", 3)).toBe(FAMILY_DEFS.D_HIGH.tiers[3]);
+    expect(activeTierDef("D_HIGH", 0)).toBeNull();
+    expect(activeTierDef("UNBEKANNT", 2)).toBeNull();
+  });
+  it("familySumHook summiert genau die aktive Stufe je Familie (kein Doppel-Trigger)", () => {
+    // D_HIGH auf Rang 2 (Schwelle ≥8/+150) — Rang 1 darf NICHT zusätzlich zählen.
+    expect(familySumHook({ D_HIGH: 2 }, "scoreFlat", { winValue: 8 })).toBe(150);
+    expect(familySumHook({ D_HIGH: 2 }, "scoreFlat", { winValue: 7 })).toBe(0);
+    // Zwei Familien gleichzeitig: additive Summe ihrer aktiven Stufen.
+    expect(familySumHook({ D_HIGH: 4, D_OVERPOWER: 2 }, "scoreFlat", { winValue: 6, margin: 8 })).toBe(350 + 400);
+  });
+  it("activeTierDefs liefert eine Def je gehaltener Familie", () => {
+    expect(activeTierDefs({ D_HIGH: 1, D_STREAK: 4 })).toHaveLength(2);
+    expect(activeTierDefs({})).toHaveLength(0);
+  });
+  it("familyProdHook default 1 ohne scoreMult-Familien", () => {
+    expect(familyProdHook({ D_HIGH: 2 }, "scoreMult", {})).toBe(1);
+  });
+});

--- a/test/families.test.js
+++ b/test/families.test.js
@@ -51,6 +51,14 @@ describe("Familien-Registry — Struktur", () => {
       else expect(f.tiers[t].pickTarget.cards).toBeGreaterThanOrEqual(1);
     }
   });
+  it("Kategorie E vollständig (9 Familien, alle Regelersetzung, ohne Ziel)", () => {
+    const e = FAMILY_LIST.filter((f) => f.cat === "E");
+    expect(e).toHaveLength(9);
+    for (const f of e) {
+      expect(f.upgradeType).toBe(UPGRADE_TYPES.REPLACEMENT);
+      for (const t of [1, 2, 3, 4]) expect(f.tiers[t].pickTarget).toBeUndefined();
+    }
+  });
 });
 
 describe("Kategorie A — Kumulative Deck-Stufen (Spec §3.2 A)", () => {
@@ -245,6 +253,40 @@ describe("Kategorie C — Rollen/Stufeneffekte (Spec §3.2 C)", () => {
     // IV: zwei Karten je −3, ihr Nachfolger je +7. a→b (+7); c letzte → kein Nachfolger.
     expect(f[4].onPick(deck, null, { cards: ["a", "c"], order: [0, 1, 2] }).map((c) => c.value)).toEqual([2, 12, 2]);
     expect(f[1].onPick(deck, null, { cards: ["a"] })).toBe(deck); // ohne order → No-Op
+  });
+});
+
+describe("Kategorie E — Formations-Parameter je Stufe (Spec §3.2 E)", () => {
+  it("E_PACE / E_COLORBRIDGE: Gap-Budget je Lauf/Segment (1/1 → 1/∞ → 2/∞ → ∞/∞)", () => {
+    const p = FAMILY_DEFS.E_PACE.tiers, c = FAMILY_DEFS.E_COLORBRIDGE.tiers;
+    expect([1, 2, 3, 4].map((t) => [p[t].gapRun, p[t].gapSeg])).toEqual([[1, 1], [1, Infinity], [2, Infinity], [Infinity, Infinity]]);
+    expect([1, 2, 3, 4].map((t) => [c[t].suitGapRun, c[t].suitGapSeg])).toEqual([[1, 1], [1, Infinity], [2, Infinity], [Infinity, Infinity]]);
+  });
+  it("E_GENTLE / E_BIGSTEP: Gleichstand-/Rückschritt-Budget (I/II 1, III 2, IV ∞)", () => {
+    expect([1, 2, 3, 4].map((t) => FAMILY_DEFS.E_GENTLE.tiers[t].eqRun)).toEqual([1, 1, 2, Infinity]);
+    expect([1, 2, 3, 4].map((t) => FAMILY_DEFS.E_BIGSTEP.tiers[t].revRun)).toEqual([1, 1, 2, Infinity]);
+  });
+  it("E_PENDULUM: Wechsel-Schwellen je Stufe; IV Faktorstart 1,35", () => {
+    const p = FAMILY_DEFS.E_PENDULUM.tiers;
+    expect([1, 2, 3, 4].map((t) => [p[t].wMinLen, p[t].wMinDiff])).toEqual([[3, 3], [2, 4], [2, 3], [2, 2]]);
+    expect(p[4].wFactorStart).toBe(1.35);
+  });
+  it("E_RPM: Doppel-Treppe-Budget je Segment (I/II 1, III 2, IV ∞)", () => {
+    expect([1, 2, 3, 4].map((t) => FAMILY_DEFS.E_RPM.tiers[t].drehSeg)).toEqual([1, 1, 2, Infinity]);
+  });
+  it("E_LOSS / E_QUICKSHOT: Anker-Prädikate + Faktor/Wert je Stufe (0-basierte Positionen)", () => {
+    const l = FAMILY_DEFS.E_LOSS.tiers, q = FAMILY_DEFS.E_QUICKSHOT.tiers;
+    expect([19, 39].every((p) => l[1].anchor.at(p))).toBe(true); // Pos 20/40
+    expect(l[1].anchor.at(9)).toBe(false);                       // Pos 10 nicht bei I
+    expect(l[2].anchor.at(9)).toBe(true);                        // Pos 10 bei II
+    expect(l[3].anchor.at(4)).toBe(true);                        // Pos 5 (Segmentende) bei III
+    expect(l[4].anchor.factor).toBe(1.35);
+    expect([4, 24].every((p) => q[1].anchor.at(p))).toBe(true);  // Pos 5/25
+    expect(q[1].anchor.at(14)).toBe(false);                      // Pos 15 nicht bei I
+    expect(q[4].anchor.value).toBe(2);                           // IV +2 Wert
+  });
+  it("E_SEGMENT: offene Grenzen je Stufe (1/2/∞/∞)", () => {
+    expect([1, 2, 3, 4].map((t) => FAMILY_DEFS.E_SEGMENT.tiers[t].openBoundaries)).toEqual([1, 2, Infinity, Infinity]);
   });
 });
 

--- a/test/families.test.js
+++ b/test/families.test.js
@@ -38,6 +38,19 @@ describe("Familien-Registry — Struktur", () => {
       for (const t of [1, 2, 3, 4]) expect(typeof f.tiers[t].onPick).toBe("function");
     }
   });
+  it("Kategorie C vollständig (10 Familien: 8 ROLE, 1 REPLACEMENT, 1 CUMULATIVE)", () => {
+    const c = FAMILY_LIST.filter((f) => f.cat === "C");
+    expect(c).toHaveLength(10);
+    const byType = (t) => c.filter((f) => f.upgradeType === t).map((f) => f.id);
+    expect(byType(UPGRADE_TYPES.ROLE)).toHaveLength(8);
+    expect(byType(UPGRADE_TYPES.REPLACEMENT)).toEqual(["C_SURVIVOR"]);
+    expect(byType(UPGRADE_TYPES.CUMULATIVE)).toEqual(["C_SACRIFICE"]);
+    // ROLE/CUMULATIVE-Stufen tragen pickTarget.cards; REPLACEMENT (C_SURVIVOR) trägt kein Ziel.
+    for (const f of c) for (const t of [1, 2, 3, 4]) {
+      if (f.upgradeType === UPGRADE_TYPES.REPLACEMENT) expect(f.tiers[t].pickTarget).toBeUndefined();
+      else expect(f.tiers[t].pickTarget.cards).toBeGreaterThanOrEqual(1);
+    }
+  });
 });
 
 describe("Kategorie A — Kumulative Deck-Stufen (Spec §3.2 A)", () => {
@@ -155,6 +168,83 @@ describe("Kategorie A — Kumulative Deck-Stufen (Spec §3.2 A)", () => {
     const i = t[1].onPick(d, makeRng(7));
     expect(nChanged(d, i)).toBe(2);
     expect(deltas(d, i)[5]).toBe(0); // Wert3 (einzeln) nie betroffen
+  });
+});
+
+describe("Kategorie C — Rollen/Stufeneffekte (Spec §3.2 C)", () => {
+  it("C_VANGUARD: isRole & Position 1–5 (IV 1–10), Bonus 2/3/4/4, Ziele 1/2/3/4", () => {
+    const f = FAMILY_DEFS.C_VANGUARD.tiers;
+    const ctx = (pos) => ({ isRole: (id) => id === "C_VANGUARD", posInCycle: pos });
+    expect([1, 2, 3, 4].map((t) => f[t].cardBonus(ctx(4)))).toEqual([2, 3, 4, 4]);
+    expect(f[1].cardBonus(ctx(5))).toBe(0);   // Position 6 → außerhalb 1–5
+    expect(f[4].cardBonus(ctx(9))).toBe(4);   // IV bis Position 10
+    expect(f[4].cardBonus(ctx(10))).toBe(0);
+    expect(f[1].cardBonus({ isRole: () => false, posInCycle: 0 })).toBe(0); // keine Rolle
+    expect([1, 2, 3, 4].map((t) => f[t].pickTarget.cards)).toEqual([1, 2, 3, 4]);
+  });
+  it("C_TRIUMPH: triumphActive → 2/2/3/4; triumph-Marker je Stufe", () => {
+    const f = FAMILY_DEFS.C_TRIUMPH.tiers;
+    expect([1, 2, 3, 4].map((t) => f[t].cardBonus({ triumphActive: true }))).toEqual([2, 2, 3, 4]);
+    expect(f[4].cardBonus({ triumphActive: false })).toBe(0);
+    expect([1, 2, 3, 4].every((t) => f[t].triumph === true)).toBe(true);
+    expect([1, 2, 3, 4].map((t) => f[t].pickTarget.cards)).toEqual([1, 2, 3, 4]);
+  });
+  it("C_GUARD: Vorgänger-Niederlage → 3/4/5; IV auch zweiter Vorgänger → 6", () => {
+    const f = FAMILY_DEFS.C_GUARD.tiers;
+    const r = (over) => ({ isRole: (id) => id === "C_GUARD", ...over });
+    expect([1, 2, 3].map((t) => f[t].cardBonus(r({ lastResult: "loss" })))).toEqual([3, 4, 5]);
+    expect(f[1].cardBonus(r({ lastResult: "win" }))).toBe(0);
+    expect(f[4].cardBonus(r({ lastResult: "win", secondLastResult: "loss" }))).toBe(6); // einer der zwei
+    expect(f[4].cardBonus(r({ lastResult: "win", secondLastResult: "win" }))).toBe(0);
+  });
+  it("C_RELAY / C_LEADER: relay/relayBonus + Ziele je Stufe", () => {
+    const r = FAMILY_DEFS.C_RELAY.tiers, l = FAMILY_DEFS.C_LEADER.tiers;
+    expect([1, 2, 3, 4].map((t) => [r[t].relay, r[t].relayBonus])).toEqual([[1, 2], [1, 2], [1, 3], [2, 3]]);
+    expect([1, 2, 3, 4].map((t) => r[t].pickTarget.cards)).toEqual([1, 2, 3, 4]);
+    expect(r[1].cardBonus).toBeUndefined(); // reiner relay, kein cardBonus
+    expect([1, 2, 3, 4].map((t) => [l[t].relay, l[t].relayBonus])).toEqual([[1, 2], [2, 2], [2, 3], [3, 4]]);
+    expect([1, 2, 3, 4].map((t) => l[t].pickTarget.cards)).toEqual([1, 1, 2, 2]);
+  });
+  it("C_FINISHER: letzte Segmentposition (IV letzte zwei), Bonus 3/4/5/5", () => {
+    const f = FAMILY_DEFS.C_FINISHER.tiers;
+    const r = (pos) => ({ isRole: (id) => id === "C_FINISHER", posInCycle: pos });
+    expect(f[1].cardBonus(r(4))).toBe(3);   // pos 5 → %5===4
+    expect(f[1].cardBonus(r(3))).toBe(0);
+    expect(f[3].cardBonus(r(9))).toBe(5);   // pos 10 → %5===4
+    expect(f[4].cardBonus(r(3))).toBe(5);   // letzte zwei: %5===3
+    expect(f[4].cardBonus(r(4))).toBe(5);
+    expect(f[4].cardBonus(r(2))).toBe(0);
+  });
+  it("C_SURVIVOR: REPLACEMENT, segmentLowRank/segmentIndex (I erste 4 Segmente, III/IV zwei Tiefste)", () => {
+    expect(FAMILY_DEFS.C_SURVIVOR.upgradeType).toBe(UPGRADE_TYPES.REPLACEMENT);
+    const f = FAMILY_DEFS.C_SURVIVOR.tiers;
+    expect(f[1].pickTarget).toBeUndefined();
+    expect(f[1].cardBonus({ segmentIndex: 3, segmentLowRank: 0 })).toBe(2); // Segment <4, tiefste
+    expect(f[1].cardBonus({ segmentIndex: 4, segmentLowRank: 0 })).toBe(0); // Segment >=4
+    expect(f[2].cardBonus({ segmentIndex: 7, segmentLowRank: 0 })).toBe(2); // jedes Segment
+    expect(f[2].cardBonus({ segmentLowRank: 1 })).toBe(0);                  // nur tiefste
+    expect(f[3].cardBonus({ segmentLowRank: 1 })).toBe(3);                  // zwei tiefste
+    expect(f[4].cardBonus({ segmentLowRank: 1 })).toBe(5);
+    expect(f[4].cardBonus({ segmentLowRank: 2 })).toBe(0);
+    expect([1, 2, 3, 4].every((t) => f[t].segmentLow === true)).toBe(true);
+  });
+  it("C_JOKER / C_BRIDGE: Formations-Marker + Modus/Span je Stufe", () => {
+    const j = FAMILY_DEFS.C_JOKER.tiers, b = FAMILY_DEFS.C_BRIDGE.tiers;
+    expect([1, 2, 3, 4].map((t) => j[t].jokerMode)).toEqual(["pred", "pred", "predOrSucc", "free"]);
+    expect([1, 2, 3, 4].every((t) => j[t].jokerRole === true)).toBe(true);
+    expect([1, 2, 3, 4].map((t) => b[t].bridgeSpan)).toEqual([1, 1, 2, 99]);
+    expect([1, 2, 3, 4].every((t) => b[t].bridgeRole === true)).toBe(true);
+    expect([1, 2, 3, 4].map((t) => j[t].pickTarget.cards)).toEqual([1, 2, 3, 4]);
+  });
+  it("C_SACRIFICE: CUMULATIVE, onPick opfert Karte(n) & bufft Nachfolger (order = playerOrder)", () => {
+    expect(FAMILY_DEFS.C_SACRIFICE.upgradeType).toBe(UPGRADE_TYPES.CUMULATIVE);
+    const f = FAMILY_DEFS.C_SACRIFICE.tiers;
+    const deck = ["a", "b", "c"].map((id) => ({ id, suit: "R", baseRank: 5, value: 5 }));
+    // I: Opfer a (−2), direkter Nachfolger b (+3); c unberührt.
+    expect(f[1].onPick(deck, null, { cards: ["a"], order: [0, 1, 2] }).map((c) => c.value)).toEqual([3, 8, 5]);
+    // IV: zwei Karten je −3, ihr Nachfolger je +7. a→b (+7); c letzte → kein Nachfolger.
+    expect(f[4].onPick(deck, null, { cards: ["a", "c"], order: [0, 1, 2] }).map((c) => c.value)).toEqual([2, 12, 2]);
+    expect(f[1].onPick(deck, null, { cards: ["a"] })).toBe(deck); // ohne order → No-Op
   });
 });
 

--- a/test/families.test.js
+++ b/test/families.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   FAMILY_DEFS, FAMILY_LIST, familyDef, familyCategory,
-  activeTierDef, activeTierDefs, familySumHook, familyProdHook,
+  activeTierDef, activeTierDefs, familySumHook, familyProdHook, hasCritFamily,
 } from "../src/game/families.js";
 import { UPGRADE_TYPES } from "../src/game/rarity.js";
 import { buildDeck, makeRng } from "../src/game/deck.js";
@@ -433,5 +433,12 @@ describe("Resolver — Regelersetzung (nur höchste Stufe aktiv)", () => {
   });
   it("familyProdHook default 1 ohne scoreMult-Familien", () => {
     expect(familyProdHook({ D_HIGH: 2 }, "scoreMult", {})).toBe(1);
+  });
+  it("hasCritFamily: nur mit crit-belohnender Familie (scoreFlatOnCrit) true — #166 UI-Sichtbarkeit", () => {
+    expect(hasCritFamily({ D_CRIT_SCORE: 2 })).toBe(true);          // scoreFlatOnCrit
+    expect(hasCritFamily({ D_OVERCRIT: 1 })).toBe(true);
+    expect(hasCritFamily({ D_HIGH: 4 })).toBe(false);              // nur scoreFlat
+    expect(hasCritFamily({ D_HIGH: 4, D_SHARP_EYE: 3 })).toBe(true); // eine reicht
+    expect(hasCritFamily({})).toBe(false);
   });
 });

--- a/test/families.test.js
+++ b/test/families.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   FAMILY_DEFS, FAMILY_LIST, familyDef, familyCategory,
   activeTierDef, activeTierDefs, familySumHook, familyProdHook, hasCritFamily,
+  isLayoutFamily, layoutFamilies,
 } from "../src/game/families.js";
 import { UPGRADE_TYPES } from "../src/game/rarity.js";
 import { buildDeck, makeRng } from "../src/game/deck.js";
@@ -440,5 +441,14 @@ describe("Resolver — Regelersetzung (nur höchste Stufe aktiv)", () => {
     expect(hasCritFamily({ D_HIGH: 4 })).toBe(false);              // nur scoreFlat
     expect(hasCritFamily({ D_HIGH: 4, D_SHARP_EYE: 3 })).toBe(true); // eine reicht
     expect(hasCritFamily({})).toBe(false);
+  });
+  it("isLayoutFamily / layoutFamilies: Aufstellungshilfe (#166) — alle E + kuratierte C/B/D", () => {
+    for (const id of ["E_PACE", "E_SEGMENT", "C_JOKER", "C_FINISHER", "D_FULL_HOUSE", "B_TIGHT"]) expect(isLayoutFamily(id)).toBe(true);
+    for (const id of ["C_TRIUMPH", "C_SACRIFICE", "B_COUNTER", "D_HIGH", "D_STREAK"]) expect(isLayoutFamily(id)).toBe(false);
+    const held = { C_VANGUARD: 2, C_TRIUMPH: 3, E_LOSS: 1, B_OPENING: 4, B_COUNTER: 2, D_FORMATION_BONUS: 1, D_HIGH: 4 };
+    expect(layoutFamilies(held).map((f) => f.id).sort()).toEqual(["B_OPENING", "C_VANGUARD", "D_FORMATION_BONUS", "E_LOSS"]);
+    const v = layoutFamilies({ C_VANGUARD: 2 })[0];
+    expect(v).toMatchObject({ id: "C_VANGUARD", name: "Vorhut", tier: 2 });
+    expect(v.desc.length).toBeGreaterThan(0);
   });
 });

--- a/test/families.test.js
+++ b/test/families.test.js
@@ -4,6 +4,7 @@ import {
   activeTierDef, activeTierDefs, familySumHook, familyProdHook,
 } from "../src/game/families.js";
 import { UPGRADE_TYPES } from "../src/game/rarity.js";
+import { buildDeck, makeRng } from "../src/game/deck.js";
 
 describe("Familien-Registry — Struktur", () => {
   it("jede Familie hat id/cat/name/upgradeType und vier Stufen mit Beschreibung", () => {
@@ -28,6 +29,132 @@ describe("Familien-Registry — Struktur", () => {
     const b = FAMILY_LIST.filter((f) => f.cat === "B");
     expect(b).toHaveLength(10);
     for (const f of b) expect(f.upgradeType).toBe(UPGRADE_TYPES.REPLACEMENT);
+  });
+  it("Kategorie A vollständig (10 Familien, alle Kumulativ, jede Stufe mit onPick)", () => {
+    const a = FAMILY_LIST.filter((f) => f.cat === "A");
+    expect(a).toHaveLength(10);
+    for (const f of a) {
+      expect(f.upgradeType).toBe(UPGRADE_TYPES.CUMULATIVE);
+      for (const t of [1, 2, 3, 4]) expect(typeof f.tiers[t].onPick).toBe("function");
+    }
+  });
+});
+
+describe("Kategorie A — Kumulative Deck-Stufen (Spec §3.2 A)", () => {
+  // Frisches Deck: 40 Karten, value === baseRank (1..10 × R/B/G/Y). deltas = Wertänderung je Position.
+  const deltas = (before, after) => after.map((c, i) => c.value - before[i].value);
+  const nChanged = (before, after) => deltas(before, after).filter((d) => d !== 0).length;
+
+  it("A_WEAK_STRONG: ursprüngliche Wertgruppen abwärts (5→+1, 4→+2, 3→+3, 1&2→+4)", () => {
+    const t = FAMILY_DEFS.A_WEAK_STRONG.tiers;
+    const grp = (tier, base) => t[tier].onPick(buildDeck()).filter((c) => c.baseRank === base).map((c) => c.value);
+    expect(grp(1, 5)).toEqual([6, 6, 6, 6]); // 5 → +1
+    expect(grp(2, 4)).toEqual([6, 6, 6, 6]); // 4 → +2
+    expect(grp(3, 3)).toEqual([6, 6, 6, 6]); // 3 → +3
+    expect(grp(4, 1)).toEqual([5, 5, 5, 5]); // 1 → +4
+    expect(grp(4, 2)).toEqual([6, 6, 6, 6]); // 2 → +4
+    // Nachbargruppen bleiben unberührt (Stufe I fasst nur die 5er an).
+    expect(t[1].onPick(buildDeck()).filter((c) => c.baseRank !== 5).every((c) => c.value === c.baseRank)).toBe(true);
+  });
+
+  it("A_EVEN: I vier zufällige Gerade; II 2er&8er; III 4er&6er; IV alle Geraden je +1", () => {
+    const t = FAMILY_DEFS.A_EVEN.tiers; const d = buildDeck();
+    const i = t[1].onPick(d, makeRng(3));
+    expect(nChanged(d, i)).toBe(4);
+    expect(deltas(d, i).every((x) => x === 0 || x === 1)).toBe(true);
+    expect(i.every((c, k) => deltas(d, i)[k] === 0 || c.baseRank % 2 === 0)).toBe(true); // nur gerade betroffen
+    expect(t[2].onPick(d).filter((c) => c.baseRank === 2 || c.baseRank === 8).every((c) => c.value === c.baseRank + 1)).toBe(true);
+    expect(t[2].onPick(d).filter((c) => c.baseRank !== 2 && c.baseRank !== 8).every((c) => c.value === c.baseRank)).toBe(true);
+    expect(t[3].onPick(d).filter((c) => c.baseRank === 4 || c.baseRank === 6).every((c) => c.value === c.baseRank + 1)).toBe(true);
+    expect(t[4].onPick(d).filter((c) => c.baseRank % 2 === 0).every((c) => c.value === c.baseRank + 1)).toBe(true);
+    expect(t[4].onPick(d).filter((c) => c.baseRank % 2 === 1).every((c) => c.value === c.baseRank)).toBe(true);
+  });
+
+  it("A_ODD: I vier zufällige Ungerade; II 3er&7er; III 1er&9er; IV alle Ungeraden je +1", () => {
+    const t = FAMILY_DEFS.A_ODD.tiers; const d = buildDeck();
+    const i = t[1].onPick(d, makeRng(3));
+    expect(nChanged(d, i)).toBe(4);
+    expect(i.every((c, k) => deltas(d, i)[k] === 0 || c.baseRank % 2 === 1)).toBe(true);
+    expect(t[2].onPick(d).filter((c) => c.baseRank === 3 || c.baseRank === 7).every((c) => c.value === c.baseRank + 1)).toBe(true);
+    expect(t[3].onPick(d).filter((c) => c.baseRank === 1 || c.baseRank === 9).every((c) => c.value === c.baseRank + 1)).toBe(true);
+    expect(t[4].onPick(d).filter((c) => c.baseRank % 2 === 1).every((c) => c.value === c.baseRank + 1)).toBe(true);
+  });
+
+  it("A_SUIT_BOOST: I zufällige Farbe 4 Karten; II zufällige Farbe alle; III/IV gewählte Farbe", () => {
+    const t = FAMILY_DEFS.A_SUIT_BOOST.tiers; const d = buildDeck();
+    const i = t[1].onPick(d, makeRng(2));
+    expect(nChanged(d, i)).toBe(4);
+    expect(new Set(i.filter((c, k) => deltas(d, i)[k] !== 0).map((c) => c.suit)).size).toBe(1); // dieselbe Farbe
+    expect(nChanged(d, t[2].onPick(d, makeRng(2)))).toBe(10); // alle 10 einer Farbe
+    const iii = t[3].onPick(d, makeRng(0), { suits: ["R"] });
+    expect(iii.filter((c) => c.suit === "R").every((c) => c.value === c.baseRank + 1)).toBe(true);
+    expect(iii.filter((c) => c.suit !== "R").every((c) => c.value === c.baseRank)).toBe(true);
+    expect(t[4].onPick(d, makeRng(0), { suits: ["B"] }).filter((c) => c.suit === "B").every((c) => c.value === c.baseRank + 2)).toBe(true);
+    expect(t[3].onPick(d, makeRng(0), null)).toBe(d); // ohne Ziel-Flow → No-Op (identische Referenz)
+  });
+
+  it("A_SMALL_BIG: zufällige ursprüngliche 1–3er (2/3/4 Karten), IV alle zwölf", () => {
+    const t = FAMILY_DEFS.A_SMALL_BIG.tiers; const d = buildDeck();
+    expect(nChanged(d, t[1].onPick(d, makeRng(4)))).toBe(2);
+    expect(nChanged(d, t[2].onPick(d, makeRng(4)))).toBe(3);
+    expect(nChanged(d, t[3].onPick(d, makeRng(4)))).toBe(4);
+    const i = t[1].onPick(d, makeRng(4));
+    expect(i.every((c, k) => deltas(d, i)[k] === 0 || (c.baseRank >= 1 && c.baseRank <= 3))).toBe(true); // nur 1–3er
+    expect(deltas(d, i).every((x) => x === 0 || x === 3)).toBe(true);                                    // +3
+    const iv = t[4].onPick(d);
+    expect(iv.filter((c) => c.baseRank <= 3)).toHaveLength(12);
+    expect(iv.filter((c) => c.baseRank <= 3).every((c) => c.value === c.baseRank + 3)).toBe(true);
+  });
+
+  it("A_MIDRANGE: zufällige aktuelle 4–7er (3/5), III alle 4–7, IV alle 3–8", () => {
+    const t = FAMILY_DEFS.A_MIDRANGE.tiers; const d = buildDeck();
+    expect(nChanged(d, t[1].onPick(d, makeRng(1)))).toBe(3);
+    expect(nChanged(d, t[2].onPick(d, makeRng(1)))).toBe(5);
+    expect(nChanged(d, t[3].onPick(d))).toBe(16); // baseRank 4..7 → 4 Werte × 4 Farben
+    expect(t[3].onPick(d).filter((c) => c.value !== c.baseRank).every((c) => c.baseRank >= 4 && c.baseRank <= 7)).toBe(true);
+    expect(nChanged(d, t[4].onPick(d))).toBe(24); // baseRank 3..8 → 6 Werte × 4 Farben
+  });
+
+  it("A_TOP / A_BOTTOM: N höchste bzw. niedrigste je +delta (Rangliste über aktuellen Wert)", () => {
+    const d = buildDeck();
+    const top = FAMILY_DEFS.A_TOP.tiers, bot = FAMILY_DEFS.A_BOTTOM.tiers;
+    const t1 = top[1].onPick(d);
+    expect(nChanged(d, t1)).toBe(2);
+    expect(deltas(d, t1).filter((x) => x !== 0).every((x) => x === 2)).toBe(true);
+    expect(t1.filter((c, k) => deltas(d, t1)[k] !== 0).every((c) => c.baseRank === 10)).toBe(true); // Höchste
+    expect(nChanged(d, top[4].onPick(d))).toBe(5);
+    const b1 = bot[1].onPick(d);
+    expect(nChanged(d, b1)).toBe(2);
+    expect(deltas(d, b1).filter((x) => x !== 0).every((x) => x === 3)).toBe(true);
+    expect(b1.filter((c, k) => deltas(d, b1)[k] !== 0).every((c) => c.baseRank === 1)).toBe(true); // Niedrigste
+    expect(nChanged(d, bot[4].onPick(d))).toBe(5);
+  });
+
+  it("A_SUIT_DUEL: Gewinnerfarbe hoch / Verliererfarbe −1; III/IV gewählt", () => {
+    const t = FAMILY_DEFS.A_SUIT_DUEL.tiers; const d = buildDeck();
+    const i = t[1].onPick(d, makeRng(2));
+    const up = new Set(i.filter((c, k) => deltas(d, i)[k] === 1).map((c) => c.suit));
+    const down = new Set(i.filter((c, k) => deltas(d, i)[k] === -1).map((c) => c.suit));
+    expect(up.size).toBe(1); expect(down.size).toBe(1);
+    expect([...up][0]).not.toBe([...down][0]); // zwei verschiedene Farben
+    const iii = t[3].onPick(d, makeRng(1), { suits: ["R"] });
+    expect(iii.filter((c) => c.suit === "R").every((c) => c.value === c.baseRank + 3)).toBe(true);
+    const dl = new Set(iii.filter((c) => c.value - c.baseRank === -1).map((c) => c.suit));
+    expect(dl.size).toBe(1); expect(dl.has("R")).toBe(false); // Verlierer ≠ Gewinner
+    const iv = t[4].onPick(d, makeRng(0), { suits: ["R", "G"] });
+    expect(iv.filter((c) => c.suit === "R").every((c) => c.value === c.baseRank + 4)).toBe(true);
+    expect(iv.filter((c) => c.suit === "G").every((c) => c.value === Math.max(0, c.baseRank - 1))).toBe(true);
+    expect(t[4].onPick(d, makeRng(0), null)).toBe(d); // ohne Ziel-Flow → No-Op
+  });
+
+  it("A_CONDENSE: Schwellen über Häufigkeit je aktuellem Wert (III ≥3, IV ≥2)", () => {
+    const t = FAMILY_DEFS.A_CONDENSE.tiers;
+    const d = [1, 1, 2, 2, 2, 3].map((v, i) => ({ id: `c${i}`, suit: "R", baseRank: v, value: v })); // Wert1×2, Wert2×3, Wert3×1
+    expect(deltas(d, t[3].onPick(d))).toEqual([0, 0, 1, 1, 1, 0]); // nur Wert2 (≥3)
+    expect(deltas(d, t[4].onPick(d))).toEqual([1, 1, 1, 1, 1, 0]); // Wert1 & Wert2 (≥2)
+    const i = t[1].onPick(d, makeRng(7));
+    expect(nChanged(d, i)).toBe(2);
+    expect(deltas(d, i)[5]).toBe(0); // Wert3 (einzeln) nie betroffen
   });
 });
 

--- a/test/families.test.js
+++ b/test/families.test.js
@@ -24,6 +24,90 @@ describe("Familien-Registry — Struktur", () => {
     expect(d).toHaveLength(19);
     for (const f of d) expect(f.upgradeType).toBe(UPGRADE_TYPES.REPLACEMENT);
   });
+  it("Kategorie B vollständig (10 Familien, alle Regelersetzung)", () => {
+    const b = FAMILY_LIST.filter((f) => f.cat === "B");
+    expect(b).toHaveLength(10);
+    for (const f of b) expect(f.upgradeType).toBe(UPGRADE_TYPES.REPLACEMENT);
+  });
+});
+
+describe("Kategorie B — Stufeneffekte (Spec §3.2 B)", () => {
+  it("Gegenangriff: nach Niederlage +3/+5/+7/+10", () => {
+    const f = FAMILY_DEFS.B_COUNTER.tiers;
+    expect([1, 2, 3, 4].map((t) => f[t].cardBonus({ lostLastTrick: true }))).toEqual([3, 5, 7, 10]);
+    expect(f[4].cardBonus({ lostLastTrick: false })).toBe(0);
+  });
+  it("Momentum: nur direkt nächste Karte; I braucht Serie 4, II–IV genau 3 (Spec §3.3)", () => {
+    const f = FAMILY_DEFS.B_MOMENTUM.tiers;
+    expect(f[1].cardBonus({ winStreak: 4 })).toBe(4);
+    expect(f[1].cardBonus({ winStreak: 3 })).toBe(0);
+    expect(f[2].cardBonus({ winStreak: 3 })).toBe(5);
+    expect(f[2].cardBonus({ winStreak: 2 })).toBe(0); // kein Trigger nach nur 2 Siegen
+    expect(f[4].cardBonus({ winStreak: 4 })).toBe(0); // genau 3, nicht mehr
+  });
+  it("Starker Auftakt: erste n Karten je +n", () => {
+    const f = FAMILY_DEFS.B_OPENING.tiers;
+    expect(f[1].cardBonus({ posInCycle: 1 })).toBe(2);
+    expect(f[1].cardBonus({ posInCycle: 2 })).toBe(0);
+    expect(f[4].cardBonus({ posInCycle: 4 })).toBe(5);
+    expect(f[4].cardBonus({ posInCycle: 5 })).toBe(0);
+  });
+  it("Zehnter Schlag: Positionsraster verdichtet sich (20/40 → jede 5.)", () => {
+    const f = FAMILY_DEFS.B_TENTH_STRIKE.tiers;
+    expect(f[1].cardBonus({ posInCycle: 19 })).toBe(6); // Pos 20
+    expect(f[1].cardBonus({ posInCycle: 9 })).toBe(0);  // Pos 10 (noch nicht)
+    expect(f[2].cardBonus({ posInCycle: 9 })).toBe(6);  // Pos 10
+    expect(f[3].cardBonus({ posInCycle: 4 })).toBe(6);  // Pos 5
+    expect(f[4].cardBonus({ posInCycle: 4 })).toBe(8);  // Pos 5, +8
+  });
+  it("Knappe Kiste: I/II nur Wiederholung, III/IV jede Formation", () => {
+    const f = FAMILY_DEFS.B_TIGHT.tiers;
+    const rep = { posForm: { mult: 1.3, formations: [{ type: "wiederholung" }] } };
+    const treppe = { posForm: { mult: 1.35, formations: [{ type: "treppe" }] } };
+    expect(f[2].cardBonus(rep)).toBe(2);
+    expect(f[2].cardBonus(treppe)).toBe(0);           // nur Wiederholung
+    expect(f[3].cardBonus(treppe)).toBe(2);           // jede Formation (mult > 1)
+    expect(f[4].cardBonus({ posForm: { mult: 1, formations: [] } })).toBe(0);
+  });
+  it("Durchbruch: sinceWin-Schwelle sinkt 6→3, Bonus steigt", () => {
+    const f = FAMILY_DEFS.B_BREAKTHROUGH.tiers;
+    expect(f[1].cardBonus({ sinceWin: 6 })).toBe(7);
+    expect(f[1].cardBonus({ sinceWin: 5 })).toBe(0);
+    expect(f[4].cardBonus({ sinceWin: 3 })).toBe(15);
+  });
+  it("Revanche: I/II/IV cardBonus, III markiert revengeTwoCard (kein cardBonus)", () => {
+    const f = FAMILY_DEFS.B_REVENGE.tiers;
+    expect(f[2].cardBonus({ lossStreak: 2 })).toBe(7);
+    expect(f[4].cardBonus({ lossStreak: 1 })).toBe(8);
+    expect(f[3].cardBonus).toBeUndefined();
+    expect(f[3].revengeTwoCard).toEqual({ losses: 2, bonus: 6, count: 2 });
+  });
+  it("Perfekte Folge: Treppen-Ordinal → Bonus je Stufe", () => {
+    const f = FAMILY_DEFS.B_PERFECT.tiers;
+    const stair = (ord) => ({ posForm: { formations: [{ type: "treppe", ordinal: ord }] } });
+    expect([1, 2, 3].map((o) => f[2].cardBonus(stair(o)))).toEqual([1, 2, 3]);
+    expect(f[2].cardBonus(stair(5))).toBe(4);   // ab der 4. Karte konstant der Cap
+    expect(f[1].cardBonus(stair(2))).toBe(0);   // I: erst ab der 3. Karte
+    expect(f[1].cardBonus(stair(3))).toBe(1);
+    expect(f[4].cardBonus(stair(1))).toBe(3);
+    expect(f[4].cardBonus({ posForm: { formations: [{ type: "wiederholung", ordinal: 2 }] } })).toBe(0); // keine Treppe
+  });
+  it("Überzahl: Vergleich Dauerwert (pValueBase) vs. Vorgänger je Stufe", () => {
+    const f = FAMILY_DEFS.B_SUPERIOR.tiers;
+    expect(f[1].cardBonus({ predValue: 5, pValueBase: 7 })).toBe(2); // ≥2 höher
+    expect(f[1].cardBonus({ predValue: 5, pValueBase: 6 })).toBe(0); // nur 1 höher
+    expect(f[2].cardBonus({ predValue: 5, pValueBase: 6 })).toBe(3); // höher
+    expect(f[3].cardBonus({ predValue: 5, pValueBase: 5 })).toBe(3); // nicht niedriger
+    expect(f[4].cardBonus({ predValue: 5, pValueBase: 8 })).toBe(5); // höher → +5
+    expect(f[4].cardBonus({ predValue: 5, pValueBase: 5 })).toBe(2); // gleich → +2
+    expect(f[2].cardBonus({ predValue: null, pValueBase: 9 })).toBe(0); // kein Vorgänger
+  });
+  it("Initiative: tieArmLosses je Stufe; IV zusätzlich +2 nach Niederlage", () => {
+    const f = FAMILY_DEFS.B_INITIATIVE.tiers;
+    expect([1, 2, 3, 4].map((t) => f[t].tieArmLosses)).toEqual([2, 1, 1, 1]);
+    expect(f[4].cardBonus({ lostLastTrick: true })).toBe(2);
+    expect(f[1].cardBonus).toBeUndefined();
+  });
 });
 
 describe("Kategorie D — Stufeneffekte (Spec §3.2 D)", () => {

--- a/test/formations.test.js
+++ b/test/formations.test.js
@@ -106,23 +106,7 @@ describe("formationPotential (Startdeck-Band, #Pass6)", () => {
   });
 });
 
-describe("Rollen-Eingriffe: Joker (C8) & Bindeglied (C10)", () => {
-  it("Joker zählt als Farbe des direkten Vorgängers → bildet einen Farbblock", () => {
-    const deck = [["R", 5], ["R", 2], ["B", 8]].map(card); // B ist Joker → alle „rot"
-    const roles = { C8: [deck[2].id] };
-    const f = computeFormations(idOrder(3), deck, roles);
-    expect(f[2].formations.some((x) => x.type === "farbblock")).toBe(true);
-    expect(+f[2].mult.toFixed(2)).toBe(1.35);
-    // ohne Rolle: kein Farbblock (Farben R,R,B)
-    expect(computeFormations(idOrder(3), deck)[2].formations.some((x) => x.type === "farbblock")).toBe(false);
-  });
-  it("Bindeglied darf für die Treppe als ±1 gelten", () => {
-    const deck = [["R", 3], ["B", 3], ["G", 5]].map(card); // 3,3,5: normal keine Treppe (3→3 nicht steigend)
-    expect(computeFormations(idOrder(3), deck)[2].formations.some((x) => x.type === "treppe")).toBe(false);
-    const roles = { C10: [deck[1].id] }; // mittlere Karte darf als 4 gelten → 3<4<5
-    expect(computeFormations(idOrder(3), deck, roles)[2].formations.some((x) => x.type === "treppe")).toBe(true);
-  });
-});
+// Joker (C8) & Bindeglied (C10) sind zu den Familien C_JOKER/C_BRIDGE migriert (#167) — Tests direkt darunter.
 
 describe("Rollen-Familien (Rarität #167): C_JOKER & C_BRIDGE über familyTiers", () => {
   const withFam = (deck, roles, familyTiers) => computeFormations(idOrder(deck.length), deck, roles, [], [], [], {}, familyTiers);

--- a/test/formations.test.js
+++ b/test/formations.test.js
@@ -127,52 +127,57 @@ describe("Rollen-Familien (Rarität #167): C_JOKER & C_BRIDGE über familyTiers"
   });
 });
 
-describe("Formationswerkzeuge (V2 §22.6 E)", () => {
-  const f = (arr, perks) => computeFormations(idOrder(arr.length), arr.map(card), {}, perks);
+describe("Formationsfamilien (Rarität #167 Kat. E über familyTiers)", () => {
+  // E1–E9 sind zu Familien migriert (#167); computeFormations liest sie über familyTiers (8. Param). Stufe II ≈ das
+  // frühere flache Verhalten.
+  const withE = (arr, familyTiers) => computeFormations(idOrder(arr.length), arr.map(card), {}, [], [], [], {}, familyTiers);
   const hasType = (g, pos, t) => g[pos].formations.some((x) => x.type === t);
 
-  it("E7 Kontrollverlust: Position 10/20/30/40 werden Anker (×1,25)", () => {
+  it("E_LOSS: Segment-Anker (II: Position 10/20/30/40 ×1,25; IV ×1,35)", () => {
     const deck = Array.from({ length: 10 }, (_, i) => [i % 2 ? "B" : "R", i % 2 ? 1 : 3]); // formationsneutral
-    const g = f(deck, ["E7"]);
-    expect(hasType(g, 9, "anker")).toBe(true); // Position 10
-    expect(g[9].mult).toBeCloseTo(1.25);
-    expect(hasType(f(deck, []), 9, "anker")).toBe(false);
+    expect(hasType(withE(deck, { E_LOSS: 2 }), 9, "anker")).toBe(true); // Position 10
+    expect(withE(deck, { E_LOSS: 2 })[9].mult).toBeCloseTo(1.25);
+    expect(hasType(withE(deck, {}), 9, "anker")).toBe(false);
+    expect(withE(deck, { E_LOSS: 4 })[9].mult).toBeCloseTo(1.35); // IV ×1,35
   });
-  it("E8 Schnellschuss: Position 5/15/25/35 werden Anker", () => {
+  it("E_QUICKSHOT: Anker (II: Position 5/15/25/35)", () => {
     const deck = Array.from({ length: 6 }, (_, i) => [i % 2 ? "B" : "R", i % 2 ? 1 : 3]);
-    expect(hasType(f(deck, ["E8"]), 4, "anker")).toBe(true); // Position 5
+    expect(hasType(withE(deck, { E_QUICKSHOT: 2 }), 4, "anker")).toBe(true); // Position 5
+    expect(hasType(withE(deck, { E_QUICKSHOT: 1 }), 4, "anker")).toBe(true); // Position 5 auch bei I
   });
-  it("E9 Segmentarbeit: Farbblock läuft über die Segmentgrenze", () => {
+  it("E_SEGMENT: Farbblock läuft über die geöffnete Segmentgrenze (III: alle offen)", () => {
     const deck = [["B", 4], ["G", 1], ["Y", 3], ["R", 5], ["R", 2], ["R", 8], ["R", 3]]; // R-Block Pos 4–7 über Grenze
-    expect(hasType(f(deck, []), 5, "farbblock")).toBe(false);
-    expect(hasType(f(deck, ["E9"]), 5, "farbblock")).toBe(true);
+    expect(hasType(withE(deck, {}), 5, "farbblock")).toBe(false);
+    expect(hasType(withE(deck, { E_SEGMENT: 3 }), 5, "farbblock")).toBe(true);
   });
-  it("E5 Pendelwerk: Wechsel schon ab 2 Karten erkannt (Marker; ordinal ≤2 → Faktor 1)", () => {
+  it("E_PENDULUM: Wechsel ab 2 Karten (II Marker/Faktor 1); IV Faktor bereits ab Länge 2 (×1,35)", () => {
     const deck = [["R", 2], ["B", 9]];
-    expect(hasType(f(deck, []), 1, "wechsel")).toBe(false);
-    const g = f(deck, ["E5"]);
-    expect(hasType(g, 1, "wechsel")).toBe(true);
-    // #99: ein reiner 2-Karten-Wechsel ist nur ein Marker — Faktor 1, kein Score-Mult, keine „aktive
-    // Formation". Erst ab der 3. Karte zahlt der Wechsel; E5 wirkt sonst nur über Overlap/Verlängerung.
-    expect(g[1].formations.find((x) => x.type === "wechsel").factor).toBe(1);
-    expect(g[1].mult).toBe(1);
-    expect(positionHasFormation(g[1])).toBe(false);
+    expect(hasType(withE(deck, {}), 1, "wechsel")).toBe(false);
+    const g2 = withE(deck, { E_PENDULUM: 2 });
+    expect(hasType(g2, 1, "wechsel")).toBe(true);
+    expect(g2[1].formations.find((x) => x.type === "wechsel").factor).toBe(1); // #99: 2-Karten-Wechsel nur Marker
+    expect(positionHasFormation(g2[1])).toBe(false);
+    expect(withE(deck, { E_PENDULUM: 4 })[1].mult).toBeCloseTo(1.35);           // IV: aktive Formation ab Länge 2
   });
-  it("E1 Schrittmacher: Wiederholung mit einer fremden Karte dazwischen (fremde zählt nicht)", () => {
+  it("E_PACE: Wiederholung mit fremder Karte; Gap-Budget je Stufe (I 1, III 2)", () => {
     const deck = [["R", 5], ["B", 8], ["G", 5]]; // 5,8,5
-    expect(hasType(f(deck, []), 2, "wiederholung")).toBe(false);
-    const g = f(deck, ["E1"]);
+    expect(hasType(withE(deck, {}), 2, "wiederholung")).toBe(false);
+    const g = withE(deck, { E_PACE: 2 });
     expect(hasType(g, 2, "wiederholung")).toBe(true);
     expect(hasType(g, 1, "wiederholung")).toBe(false); // die 8 ist kein Mitglied
+    // 5,8,5,9,5: I erlaubt nur EINEN Gap (Lauf endet nach dem 2. Fünfer), III erlaubt zwei (alle drei Fünfer).
+    const d2 = [["R", 5], ["B", 8], ["G", 5], ["Y", 9], ["R", 5]];
+    expect(hasType(withE(d2, { E_PACE: 1 }), 4, "wiederholung")).toBe(false);
+    expect(hasType(withE(d2, { E_PACE: 3 }), 4, "wiederholung")).toBe(true);
   });
-  it("E3 Sanfter Anstieg: Treppe darf einmal gleich sein", () => {
-    const deck = [["R", 3], ["B", 5], ["G", 5], ["Y", 7]]; // 3,5,5,7 (einmal gleich)
-    expect(hasType(f(deck, []), 3, "treppe")).toBe(false);
-    expect(hasType(f(deck, ["E3"]), 3, "treppe")).toBe(true);
+  it("E_GENTLE: Treppe darf einen Gleichstand enthalten", () => {
+    const deck = [["R", 3], ["B", 5], ["G", 5], ["Y", 7]]; // 3,5,5,7
+    expect(hasType(withE(deck, {}), 3, "treppe")).toBe(false);
+    expect(hasType(withE(deck, { E_GENTLE: 2 }), 3, "treppe")).toBe(true);
   });
-  it("E4 Großer Schritt: Treppe darf einmal einen Rückschritt enthalten", () => {
-    const deck = [["R", 3], ["B", 5], ["G", 4], ["Y", 6]]; // 3,5,4,6: Schritte ≤3, ein Rückschritt (5→4)
-    expect(hasType(f(deck, []), 3, "treppe")).toBe(false);
-    expect(hasType(f(deck, ["E4"]), 3, "treppe")).toBe(true);
+  it("E_BIGSTEP: Treppe darf einen Rückschritt enthalten", () => {
+    const deck = [["R", 3], ["B", 5], ["G", 4], ["Y", 6]]; // 3,5,4,6: ein Rückschritt (5→4)
+    expect(hasType(withE(deck, {}), 3, "treppe")).toBe(false);
+    expect(hasType(withE(deck, { E_BIGSTEP: 2 }), 3, "treppe")).toBe(true);
   });
 });

--- a/test/formations.test.js
+++ b/test/formations.test.js
@@ -124,6 +124,25 @@ describe("Rollen-Eingriffe: Joker (C8) & Bindeglied (C10)", () => {
   });
 });
 
+describe("Rollen-Familien (Rarität #167): C_JOKER & C_BRIDGE über familyTiers", () => {
+  const withFam = (deck, roles, familyTiers) => computeFormations(idOrder(deck.length), deck, roles, [], [], [], {}, familyTiers);
+  it("C_JOKER I (pred): zählt als Vorgängerfarbe (wie flach C8)", () => {
+    const deck = [["R", 5], ["R", 2], ["B", 8]].map(card); // B als R → Farbblock R,R,R
+    expect(withFam(deck, { C_JOKER: [deck[2].id] }, { C_JOKER: 1 })[2].formations.some((x) => x.type === "farbblock")).toBe(true);
+  });
+  it("C_JOKER IV (free): zählt als beliebige Farbe — auch mitten im Block", () => {
+    const deck = [["R", 5], ["B", 2], ["R", 8]].map(card); // R,B,R: normal kein Farbblock
+    expect(computeFormations(idOrder(3), deck)[2].formations.some((x) => x.type === "farbblock")).toBe(false);
+    // B (Mitte) als freier Joker → R,(R),R = Farbblock
+    expect(withFam(deck, { C_JOKER: [deck[1].id] }, { C_JOKER: 4 })[2].formations.some((x) => x.type === "farbblock")).toBe(true);
+  });
+  it("C_BRIDGE: Span je Stufe (I ±1 reicht nicht, III ±2 erlaubt die steilere Treppe)", () => {
+    const deck = [["R", 3], ["B", 8], ["G", 9]].map(card); // 3→8 zu steil (Schritt 5 > 3); Bindeglied auf der 8
+    expect(withFam(deck, { C_BRIDGE: [deck[1].id] }, { C_BRIDGE: 1 })[2].formations.some((x) => x.type === "treppe")).toBe(false); // ±1
+    expect(withFam(deck, { C_BRIDGE: [deck[1].id] }, { C_BRIDGE: 3 })[2].formations.some((x) => x.type === "treppe")).toBe(true);  // ±2 → 8 zählt als 6 → 3,6,9
+  });
+});
+
 describe("Formationswerkzeuge (V2 §22.6 E)", () => {
   const f = (arr, perks) => computeFormations(idOrder(arr.length), arr.map(card), {}, perks);
   const hasType = (g, pos, t) => g[pos].formations.some((x) => x.type === t);

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -38,27 +38,12 @@ describe("Perks — Deck-Modifikationen (Kat. A)", () => {
   });
 });
 
-describe("Perks — cardBonus (Kat. B) via effectivePlayerValue", () => {
-  it("B1 Gegenangriff: +4 nur nach einer Niederlage", () => {
-    expect(effectivePlayerValue(5, ["B1"], { lostLastTrick: true })).toBe(9);
-    expect(effectivePlayerValue(5, ["B1"], { lostLastTrick: false })).toBe(5);
-  });
-
-  it("B3 Starker Auftakt: +4 in den ersten drei Stichen des Durchlaufs", () => {
-    expect(effectivePlayerValue(4, ["B3"], { posInCycle: 0 })).toBe(8);
-    expect(effectivePlayerValue(4, ["B3"], { posInCycle: 2 })).toBe(8);
-    expect(effectivePlayerValue(4, ["B3"], { posInCycle: 3 })).toBe(4);
-  });
-
-  it("B5 Initiative: kein Kartenbonus mehr — nur winTieAfterLoss-Flag (§22.6)", () => {
-    expect(effectivePlayerValue(3, ["B5"], { lostLastTrick: true })).toBe(3);
-    expect(PERK_DEFS.B5.cardBonus).toBeUndefined();
-    expect(PERK_DEFS.B5.winTieAfterLoss).toBe(true);
-  });
-
-  it("Boni mehrerer Perks summieren sich", () => {
-    const v = effectivePlayerValue(2, ["B1", "B4"], { lostLastTrick: true, posInCycle: 9 });
-    expect(v).toBe(2 + 4 + 8); // B1 +4, B4 +8 (Position 10)
+describe("effectivePlayerValue — cardBonus-Summation", () => {
+  // Kat.-B-Wertboni sind zu Familien migriert (#167) — Engine-Integration in families-engine.test.js.
+  // Hier bleibt die generische Summation der flachen cardBonus-Hooks (C-Rollen) geprüft.
+  it("summiert die cardBonus-Hooks der gehaltenen Perks auf den Basiswert", () => {
+    expect(effectivePlayerValue(5, ["C7"], { isSegmentLow: true })).toBe(8);  // C7 +3
+    expect(effectivePlayerValue(5, ["C7"], { isSegmentLow: false })).toBe(5); // Bedingung nicht erfüllt
   });
 });
 
@@ -137,7 +122,7 @@ describe("streakBaseMult (Basis-Siegesserie #39)", () => {
 describe("baseScoreMultFor (Header-Chip #37 — V2: nur noch Basis-Serie #39)", () => {
   it("Serie 0 → ×1,00; D-Perks multiplizieren nicht mehr (Flat-Score)", () => {
     expect(baseScoreMultFor([], {})).toBeCloseTo(1);
-    expect(baseScoreMultFor(["A1", "B1"], {})).toBeCloseTo(1); // flache Perks tragen keinen Score-Multiplikator
+    expect(baseScoreMultFor(["A1", "A2"], {})).toBeCloseTo(1); // flache Perks tragen keinen Score-Multiplikator
   });
   it("Siegesserie hebt den Mult (#39): +2 %/Stufe bis Cap +150 % (#100)", () => {
     expect(baseScoreMultFor([], { winStreak: 0 })).toBeCloseTo(1);
@@ -151,10 +136,10 @@ describe("Layout-Perks (#95): Positions-/Formations-relevante Perks", () => {
   it("alle E-Werkzeuge zählen als Layout-Perk", () => {
     PERK_LIST.filter((p) => p.cat === "E").forEach((p) => expect(isLayoutPerk(p.id)).toBe(true));
   });
-  it("kuratierte B/C/L sind enthalten, layout-fremde Perks nicht", () => {
-    // D-Score ist zu Familien migriert (#167); die formationsbezogenen D-Familien folgen in der Layout-Hilfe mit #166.
-    ["B4", "B6", "B9", "C1", "C8", "L3", "L11"].forEach((id) => expect(isLayoutPerk(id)).toBe(true));
-    ["A1", "B1", "B2", "C2", "L5"].forEach((id) => expect(isLayoutPerk(id)).toBe(false));
+  it("kuratierte C/L sind enthalten, layout-fremde Perks nicht", () => {
+    // B-Stich und D-Score sind zu Familien migriert (#167); ihre layout-relevanten Familien folgen mit #166.
+    ["C1", "C8", "L3", "L11"].forEach((id) => expect(isLayoutPerk(id)).toBe(true));
+    ["A1", "C2", "L5"].forEach((id) => expect(isLayoutPerk(id)).toBe(false));
   });
   it("layoutPerks filtert die gehaltenen Perks in Reihenfolge", () => {
     expect(layoutPerks(["A1", "E1", "C8"])).toEqual(["E1", "C8"]);
@@ -175,17 +160,6 @@ describe("Neue Normal-Perks (#71)", () => {
     expect(sumV(PERK_DEFS.A8.onPick(buildDeck())) - sumV(buildDeck())).toBe(20);
     expect(PERK_DEFS.A8.onPick(buildDeck()).filter((c) => c.value === 6 && c.baseRank === 1)).toHaveLength(4);
   });
-  it("B6 Knappe Kiste: +2 temp Wert, wenn die Karte in einer Wiederholung liegt", () => {
-    const inWied = { posForm: { formations: [{ type: "wiederholung", ordinal: 2, factor: 1.3 }] } };
-    expect(PERK_DEFS.B6.cardBonus(inWied)).toBe(2);
-    expect(PERK_DEFS.B6.cardBonus({ posForm: { formations: [{ type: "treppe", ordinal: 3 }] } })).toBe(0);
-    expect(PERK_DEFS.B6.cardBonus({})).toBe(0);
-  });
-  it("B7 Durchbruch: +10 ab 5 Stichen ohne Sieg", () => {
-    expect(PERK_DEFS.B7.cardBonus({ sinceWin: 4 })).toBe(0);
-    expect(PERK_DEFS.B7.cardBonus({ sinceWin: 5 })).toBe(10);
-    expect(PERK_DEFS.B7.cardBonus({ sinceWin: 8 })).toBe(10);
-  });
   it("C3 Leibwache: +5, wenn Rolle und der Vorgänger verlor", () => {
     expect(PERK_DEFS.C3.cardBonus({ isRole: (id) => id === "C3", lastResult: "loss" })).toBe(5);
     expect(PERK_DEFS.C3.cardBonus({ isRole: (id) => id === "C3", lastResult: "win" })).toBe(0);
@@ -196,14 +170,6 @@ describe("Neue Normal-Perks (#71)", () => {
     expect(PERK_DEFS.C6.cardBonus({ isRole: (id) => id === "C6", posInCycle: 9 })).toBe(5);
     expect(PERK_DEFS.C6.cardBonus({ isRole: (id) => id === "C6", posInCycle: 3 })).toBe(0);
     expect(PERK_DEFS.C6.cardBonus({ isRole: () => false, posInCycle: 4 })).toBe(0);
-  });
-});
-
-describe("Durchbruch (B7) — sinceWin-Zähler in der Engine (#71)", () => {
-  it("+10 auf die Karte nach 5 Stichen ohne Sieg", () => {
-    // sinceWin=5 im State → Durchbruch-cardBonus greift für DIESEN Stich (Karte 3 → 13).
-    expect(effectivePlayerValue(3, ["B7"], { sinceWin: 5 })).toBe(13);
-    expect(effectivePlayerValue(3, ["B7"], { sinceWin: 4 })).toBe(3);
   });
 });
 
@@ -233,13 +199,6 @@ describe("Seltene Perks (#71, Phase 2a)", () => {
   });
 });
 
-describe("Seltene Perks (#71, Phase 2b — Historie-Hooks)", () => {
-  it("B8 Revanche: +7 ab 2 Niederlagen in Folge", () => {
-    expect(PERK_DEFS.B8.cardBonus({ lossStreak: 2 })).toBe(7);
-    expect(PERK_DEFS.B8.cardBonus({ lossStreak: 1 })).toBe(0);
-  });
-});
-
 describe("Kartenrollen — Hooks (V2 §22.6 C)", () => {
   it("C1 Vorhut: +3 auf Position 1–5, wenn Rolle", () => {
     expect(PERK_DEFS.C1.cardBonus({ isRole: (id) => id === "C1", posInCycle: 0 })).toBe(3);
@@ -265,14 +224,4 @@ describe("Kartenrollen — Hooks (V2 §22.6 C)", () => {
   });
 });
 
-describe("Seltene Perks (#71, Phase 2f — Historie-Hooks)", () => {
-  it("B9 Perfekte Folge: temp Wert nach Treppen-Position (1→+1 … 4+→+4)", () => {
-    const treppe = (ord) => ({ posForm: { formations: [{ type: "treppe", ordinal: ord, factor: 1.25 }] } });
-    expect(PERK_DEFS.B9.cardBonus(treppe(1))).toBe(1);
-    expect(PERK_DEFS.B9.cardBonus(treppe(2))).toBe(2);
-    expect(PERK_DEFS.B9.cardBonus(treppe(3))).toBe(3);
-    expect(PERK_DEFS.B9.cardBonus(treppe(4))).toBe(4);
-    expect(PERK_DEFS.B9.cardBonus(treppe(5))).toBe(4); // Deckel
-    expect(PERK_DEFS.B9.cardBonus({ posForm: { formations: [{ type: "farbblock", ordinal: 3 }] } })).toBe(0);
-  });
-});
+// B9 Perfekte Folge ist zu Familie B_PERFECT migriert (#167) — Treppen-Ordinal-Tests in families.test.js.

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildDeck, makeRng } from "../src/game/deck.js";
-import { PERK_DEFS, PERK_LIST, buildOffer, critChanceFor, critChanceRawFor, isLegendary, baseScoreMultFor, streakBaseMult, isLayoutPerk, layoutPerks } from "../src/game/perks.js";
+import { PERK_DEFS, PERK_LIST, critChanceFor, critChanceRawFor, isLegendary, baseScoreMultFor, streakBaseMult, isLayoutPerk, layoutPerks } from "../src/game/perks.js";
 import { effectivePlayerValue } from "../src/game/engine.js";
 
 describe("Perks — Deck-Modifikationen (Kat. A)", () => {
@@ -62,53 +62,8 @@ describe("Perks — cardBonus (Kat. B) via effectivePlayerValue", () => {
   });
 });
 
-describe("buildOffer", () => {
-  it("liefert count Perks, ohne bereits besessene, ohne Duplikate", () => {
-    const offer = buildOffer(["A1", "A2"], makeRng(1), 3);
-    expect(offer).toHaveLength(3);
-    expect(offer).not.toContain("A1");
-    expect(new Set(offer).size).toBe(3);
-  });
-
-  it("gibt bei fast leerem Pool nur die Restmenge", () => {
-    const owned = PERK_LIST.filter((p) => p.id !== "A1" && p.id !== "A2").map((p) => p.id);
-    expect(buildOffer(owned, makeRng(1), 3, 9)).toHaveLength(2); // nur A1/A2 übrig (Commons)
-  });
-
-  // ---- Rarität: kein Level-Gate mehr (Perk nach jeder Runde) — nur gewichtet + Legendary-Cap ----
-  it("höchstens EIN Legendary je Angebot", () => {
-    // Nur Legendaries übrig → das Angebot enthält genau 1 (max 1 pro Angebot), und der ist legendär.
-    const owned = PERK_LIST.filter((p) => !isLegendary(p.id)).map((p) => p.id);
-    const off = buildOffer(owned, makeRng(3), 3);
-    expect(off).toHaveLength(1);
-    expect(isLegendary(off[0])).toBe(true);
-  });
-  it("gewichtete Auswahl ist bei festem Seed deterministisch", () => {
-    expect(buildOffer([], makeRng(7), 3)).toEqual(buildOffer([], makeRng(7), 3));
-  });
-  it("bereits gewählte Legendaries werden nicht erneut angeboten", () => {
-    expect(buildOffer(["L1"], makeRng(1), 3)).not.toContain("L1");
-  });
-
-  // ---- Expliziter Legendär-Roll (Shop #107 S5c): Chance>0 → Legendäre nur über den Wurf, genau 0 oder 1 ----
-  it("legendaryChance=1 erzwingt genau EIN Legendary im Angebot", () => {
-    for (let seed = 1; seed <= 20; seed++) {
-      const off = buildOffer([], makeRng(seed), 3, 1);
-      expect(off).toHaveLength(3);
-      expect(off.filter((id) => isLegendary(id))).toHaveLength(1);
-    }
-  });
-  it("bei aktivem Roll (Chance>0) erscheinen NIE zwei Legendäre", () => {
-    for (let seed = 1; seed <= 60; seed++)
-      expect(buildOffer([], makeRng(seed), 3, 0.5).filter((id) => isLegendary(id)).length).toBeLessThanOrEqual(1);
-  });
-  it("ein aktiver Roll kann auch ohne Legendary ausgehen (Miss)", () => {
-    let anyWithout = false;
-    for (let seed = 1; seed <= 40 && !anyWithout; seed++)
-      if (!buildOffer([], makeRng(seed), 3, 0.2).some((id) => isLegendary(id))) anyWithout = true;
-    expect(anyWithout).toBe(true);
-  });
-});
+// Das Angebot läuft jetzt über buildPerkOffer (gemischt Familien + flache Perks) — Tests dort in
+// test/families-engine.test.js (inkl. Legendär-Wurf). Das alte flache buildOffer wurde entfernt (#167 Schritt 4).
 
 describe("critChanceFor / critChanceRawFor (V2: kein Perk trägt Crit-Chance — Stat/Blitz in der Engine)", () => {
   it("kein Perk-Beitrag → Roh-Chance 0 (Stat/Blitz addiert die Engine obendrauf)", () => {

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -8,11 +8,11 @@ import { effectivePlayerValue } from "../src/game/engine.js";
 // Ziel-Fluss in test/families-engine.test.js.
 
 describe("effectivePlayerValue — cardBonus-Summation", () => {
-  // Kat.-B-Wertboni sind zu Familien migriert (#167) — Engine-Integration in families-engine.test.js.
-  // Hier bleibt die generische Summation der flachen cardBonus-Hooks (C-Rollen) geprüft.
+  // Kat. B und C sind zu Familien migriert (#167) — Engine-Integration in families-engine.test.js.
+  // Hier bleibt die generische Summation der flachen cardBonus-Hooks geprüft (jetzt über ein Legendär-Beispiel).
   it("summiert die cardBonus-Hooks der gehaltenen Perks auf den Basiswert", () => {
-    expect(effectivePlayerValue(5, ["C7"], { isSegmentLow: true })).toBe(8);  // C7 +3
-    expect(effectivePlayerValue(5, ["C7"], { isSegmentLow: false })).toBe(5); // Bedingung nicht erfüllt
+    expect(effectivePlayerValue(5, ["L3"], { posInCycle: 35 })).toBe(10); // L3 +5 auf Position 36–40
+    expect(effectivePlayerValue(5, ["L3"], { posInCycle: 10 })).toBe(5);  // Bedingung nicht erfüllt
   });
 });
 
@@ -33,7 +33,7 @@ describe("Legendäre Perks — Hooks (V2 §22.6 L)", () => {
   it("die zehn verbliebenen L-Perks sind als legendary markiert (L7 entfernt, #162)", () => {
     for (const id of ["L1", "L2", "L3", "L4", "L5", "L6", "L8", "L9", "L10", "L11"]) expect(isLegendary(id)).toBe(true);
     expect(PERK_DEFS.L7).toBeUndefined(); // Königsmacher ersatzlos entfernt (Spec §9)
-    expect(isLegendary("C1")).toBe(false);
+    expect(isLegendary("E1")).toBe(false);
   });
   it("L1 Überladung: permMod +6 auf die gewählten Karten", () => {
     const deck = buildDeck().slice(0, 3);
@@ -91,7 +91,7 @@ describe("streakBaseMult (Basis-Siegesserie #39)", () => {
 describe("baseScoreMultFor (Header-Chip #37 — V2: nur noch Basis-Serie #39)", () => {
   it("Serie 0 → ×1,00; D-Perks multiplizieren nicht mehr (Flat-Score)", () => {
     expect(baseScoreMultFor([], {})).toBeCloseTo(1);
-    expect(baseScoreMultFor(["C1", "E1"], {})).toBeCloseTo(1); // flache Perks tragen keinen Score-Multiplikator
+    expect(baseScoreMultFor(["E1", "E2"], {})).toBeCloseTo(1); // flache Perks tragen keinen Score-Multiplikator
   });
   it("Siegesserie hebt den Mult (#39): +2 %/Stufe bis Cap +150 % (#100)", () => {
     expect(baseScoreMultFor([], { winStreak: 0 })).toBeCloseTo(1);
@@ -105,31 +105,19 @@ describe("Layout-Perks (#95): Positions-/Formations-relevante Perks", () => {
   it("alle E-Werkzeuge zählen als Layout-Perk", () => {
     PERK_LIST.filter((p) => p.cat === "E").forEach((p) => expect(isLayoutPerk(p.id)).toBe(true));
   });
-  it("kuratierte C/L sind enthalten, layout-fremde Perks nicht", () => {
-    // B-Stich und D-Score sind zu Familien migriert (#167); ihre layout-relevanten Familien folgen mit #166.
-    ["C1", "C8", "L3", "L11"].forEach((id) => expect(isLayoutPerk(id)).toBe(true));
-    ["C9", "C2", "L5"].forEach((id) => expect(isLayoutPerk(id)).toBe(false));
+  it("kuratierte L sind enthalten, layout-fremde Perks nicht", () => {
+    // B-Stich, D-Score UND C-Rollen sind zu Familien migriert (#167); ihre layout-relevanten Familien folgen mit #166
+    // (layoutPerks kennt nur flache `perks`). Übrig als flache Layout-Perks: E-Werkzeuge + L3/L11.
+    ["L3", "L11"].forEach((id) => expect(isLayoutPerk(id)).toBe(true));
+    ["L1", "L5"].forEach((id) => expect(isLayoutPerk(id)).toBe(false));
   });
   it("layoutPerks filtert die gehaltenen Perks in Reihenfolge", () => {
-    expect(layoutPerks(["C9", "E1", "C8"])).toEqual(["E1", "C8"]);
+    expect(layoutPerks(["L1", "E1", "L3"])).toEqual(["E1", "L3"]);
     expect(layoutPerks([])).toEqual([]);
   });
 });
 
-describe("Neue Normal-Perks (#71)", () => {
-  // A6/A7/A8 (Deck-Mods) sind zu Familien A_MIDRANGE/A_TOP/A_BOTTOM migriert (#167) — Tests in families.test.js.
-  it("C3 Leibwache: +5, wenn Rolle und der Vorgänger verlor", () => {
-    expect(PERK_DEFS.C3.cardBonus({ isRole: (id) => id === "C3", lastResult: "loss" })).toBe(5);
-    expect(PERK_DEFS.C3.cardBonus({ isRole: (id) => id === "C3", lastResult: "win" })).toBe(0);
-    expect(PERK_DEFS.C3.cardBonus({ isRole: () => false, lastResult: "loss" })).toBe(0); // keine Rolle
-  });
-  it("C6 Finisher: +5 auf der letzten Segment-Position, wenn Rolle", () => {
-    expect(PERK_DEFS.C6.cardBonus({ isRole: (id) => id === "C6", posInCycle: 4 })).toBe(5);
-    expect(PERK_DEFS.C6.cardBonus({ isRole: (id) => id === "C6", posInCycle: 9 })).toBe(5);
-    expect(PERK_DEFS.C6.cardBonus({ isRole: (id) => id === "C6", posInCycle: 3 })).toBe(0);
-    expect(PERK_DEFS.C6.cardBonus({ isRole: () => false, posInCycle: 4 })).toBe(0);
-  });
-});
+// Frühere Normal-Perks A6/A7/A8 (Deck) und C3/C6 (Rollen) sind zu Familien migriert (#167) — Tests in families.test.js.
 
 describe("Seltene Perks (#71, Phase 2a)", () => {
   // A9 Farbduell / A10 Verdichtung sind zu Familien A_SUIT_DUEL/A_CONDENSE migriert (#167) — Tests in families.test.js.
@@ -151,29 +139,6 @@ describe("Seltene Perks (#71, Phase 2a)", () => {
   });
 });
 
-describe("Kartenrollen — Hooks (V2 §22.6 C)", () => {
-  it("C1 Vorhut: +3 auf Position 1–5, wenn Rolle", () => {
-    expect(PERK_DEFS.C1.cardBonus({ isRole: (id) => id === "C1", posInCycle: 0 })).toBe(3);
-    expect(PERK_DEFS.C1.cardBonus({ isRole: (id) => id === "C1", posInCycle: 4 })).toBe(3);
-    expect(PERK_DEFS.C1.cardBonus({ isRole: (id) => id === "C1", posInCycle: 5 })).toBe(0);
-    expect(PERK_DEFS.C1.cardBonus({ isRole: () => false, posInCycle: 0 })).toBe(0);
-  });
-  it("C2 Triumph: +2 nur wenn armiert (triumphActive)", () => {
-    expect(PERK_DEFS.C2.cardBonus({ triumphActive: true })).toBe(2);
-    expect(PERK_DEFS.C2.cardBonus({ triumphActive: false })).toBe(0);
-  });
-  it("C7 Überlebensvorteil: +3, wenn die Karte Segment-Tiefste ist", () => {
-    expect(PERK_DEFS.C7.cardBonus({ isSegmentLow: true })).toBe(3);
-    expect(PERK_DEFS.C7.cardBonus({ isSegmentLow: false })).toBe(0);
-  });
-  it("Ziel-Perks tragen needsTarget; C4/C5 relay; C9 sacrificeMod", () => {
-    expect(PERK_DEFS.C1.needsTarget).toBe(3);
-    expect(PERK_DEFS.C5.needsTarget).toBe(1);
-    expect(PERK_DEFS.C4.relay).toBe(1);
-    expect(PERK_DEFS.C5.relay).toBe(2);
-    expect(PERK_DEFS.C9.needsTarget).toBe(1);
-    expect(PERK_DEFS.C9.sacrificeMod).toBe(true);
-  });
-});
-
-// B9 Perfekte Folge ist zu Familie B_PERFECT migriert (#167) — Treppen-Ordinal-Tests in families.test.js.
+// Kartenrollen (Kat. C: Vorhut/Triumph/Leibwache/Staffelläufer/Anführer/Finisher/Überlebensvorteil/Joker/Opfergabe/
+// Bindeglied) sind zu Familien migriert (#167) — Stufeneffekte in families.test.js, Engine/Flow in families-engine.test.js.
+// B9 Perfekte Folge → Familie B_PERFECT (#167), Treppen-Ordinal-Tests ebenfalls in families.test.js.

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -91,7 +91,7 @@ describe("streakBaseMult (Basis-Siegesserie #39)", () => {
 describe("baseScoreMultFor (Header-Chip #37 — V2: nur noch Basis-Serie #39)", () => {
   it("Serie 0 → ×1,00; D-Perks multiplizieren nicht mehr (Flat-Score)", () => {
     expect(baseScoreMultFor([], {})).toBeCloseTo(1);
-    expect(baseScoreMultFor(["E1", "E2"], {})).toBeCloseTo(1); // flache Perks tragen keinen Score-Multiplikator
+    expect(baseScoreMultFor(["L2", "L3"], {})).toBeCloseTo(1); // flache Perks tragen keinen Score-Multiplikator
   });
   it("Siegesserie hebt den Mult (#39): +2 %/Stufe bis Cap +150 % (#100)", () => {
     expect(baseScoreMultFor([], { winStreak: 0 })).toBeCloseTo(1);
@@ -102,17 +102,17 @@ describe("baseScoreMultFor (Header-Chip #37 — V2: nur noch Basis-Serie #39)", 
 });
 
 describe("Layout-Perks (#95): Positions-/Formations-relevante Perks", () => {
-  it("alle E-Werkzeuge zählen als Layout-Perk", () => {
+  it("verbliebene cat-E-Perks (nur E10) zählen als Layout-Perk", () => {
     PERK_LIST.filter((p) => p.cat === "E").forEach((p) => expect(isLayoutPerk(p.id)).toBe(true));
   });
   it("kuratierte L sind enthalten, layout-fremde Perks nicht", () => {
-    // B-Stich, D-Score UND C-Rollen sind zu Familien migriert (#167); ihre layout-relevanten Familien folgen mit #166
-    // (layoutPerks kennt nur flache `perks`). Übrig als flache Layout-Perks: E-Werkzeuge + L3/L11.
+    // B/C/D/E sind zu Familien migriert (#167); ihre layout-relevanten Familien folgen mit #166 (layoutPerks kennt
+    // nur flache `perks`). Übrig als flache Layout-Perks: L3/L11 (+ das nie angebotene E10 cat E).
     ["L3", "L11"].forEach((id) => expect(isLayoutPerk(id)).toBe(true));
     ["L1", "L5"].forEach((id) => expect(isLayoutPerk(id)).toBe(false));
   });
   it("layoutPerks filtert die gehaltenen Perks in Reihenfolge", () => {
-    expect(layoutPerks(["L1", "E1", "L3"])).toEqual(["E1", "L3"]);
+    expect(layoutPerks(["L1", "L11", "L3"])).toEqual(["L11", "L3"]);
     expect(layoutPerks([])).toEqual([]);
   });
 });
@@ -121,15 +121,10 @@ describe("Layout-Perks (#95): Positions-/Formations-relevante Perks", () => {
 
 describe("Seltene Perks (#71, Phase 2a)", () => {
   // A9 Farbduell / A10 Verdichtung sind zu Familien A_SUIT_DUEL/A_CONDENSE migriert (#167) — Tests in families.test.js.
-  it("E-Werkzeuge sind reine Marker; E10 hat extraSwap, ist aber als Perk deaktiviert (#162)", () => {
-    for (const id of ["E1", "E2", "E3", "E4", "E5", "E6", "E7", "E8", "E9"]) {
-      expect(PERK_DEFS[id].cat).toBe("E");
-      expect(PERK_DEFS[id].cardBonus).toBeUndefined();
-      expect(PERK_DEFS[id].scoreFlat).toBeUndefined();
-      expect(PERK_DEFS[id].critChance).toBeUndefined();
-    }
+  it("E1–E9 sind zu Familien migriert (#167); E10 bleibt als deaktivierter extraSwap-Perk", () => {
+    for (const id of ["E1", "E2", "E3", "E4", "E5", "E6", "E7", "E8", "E9"]) expect(PERK_DEFS[id]).toBeUndefined();
     expect(PERK_DEFS.E10.extraSwap).toBe(1);
-    expect(PERK_DEFS.E10.offerable).toBe(false); // #162: aus dem Perk-Pool genommen → wird Shop-Familie
+    expect(PERK_DEFS.E10.offerable).toBe(false); // #162: aus dem Perk-Pool genommen → wird Shop-Familie (#164)
   });
   it("V2 §22.4: alle A–E sind normal (keine Rares mehr); nur L ist legendär", () => {
     for (const p of PERK_LIST) {

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -67,8 +67,8 @@ describe("Perks — cardBonus (Kat. B) via effectivePlayerValue", () => {
 
 describe("critChanceFor / critChanceRawFor (V2: kein Perk trägt Crit-Chance — Stat/Blitz in der Engine)", () => {
   it("kein Perk-Beitrag → Roh-Chance 0 (Stat/Blitz addiert die Engine obendrauf)", () => {
-    expect(critChanceRawFor(["L4", "L5", "D14"], {})).toBe(0);
-    expect(critChanceFor(["L4", "L5", "D14"], {})).toBe(0);
+    expect(critChanceRawFor(["L4", "L5"], {})).toBe(0);
+    expect(critChanceFor(["L4", "L5"], {})).toBe(0);
   });
   it("critChanceFor klemmt auf [0,1]", () => {
     expect(critChanceFor([], {})).toBe(0);
@@ -79,7 +79,7 @@ describe("Legendäre Perks — Hooks (V2 §22.6 L)", () => {
   it("die zehn verbliebenen L-Perks sind als legendary markiert (L7 entfernt, #162)", () => {
     for (const id of ["L1", "L2", "L3", "L4", "L5", "L6", "L8", "L9", "L10", "L11"]) expect(isLegendary(id)).toBe(true);
     expect(PERK_DEFS.L7).toBeUndefined(); // Königsmacher ersatzlos entfernt (Spec §9)
-    expect(isLegendary("D1")).toBe(false);
+    expect(isLegendary("A1")).toBe(false);
   });
   it("L1 Überladung: permMod +6 auf die gewählten Karten", () => {
     const deck = buildDeck().slice(0, 3);
@@ -121,14 +121,7 @@ describe("Legendäre Perks — Hooks (V2 §22.6 L)", () => {
   });
 });
 
-describe("Hohe-Karte-Schwelle konsolidiert auf 8 — D3/D7 (#34)", () => {
-  it("D3/D7 lösen ab Kartenwert 8 aus (und nicht bei 7)", () => {
-    expect(PERK_DEFS.D3.scoreFlat({ winValue: 8 })).toBe(125);
-    expect(PERK_DEFS.D3.scoreFlat({ winValue: 7 })).toBe(0);
-    expect(PERK_DEFS.D7.scoreFlatOnCrit({ winValue: 8 })).toBe(300);
-    expect(PERK_DEFS.D7.scoreFlatOnCrit({ winValue: 7 })).toBe(0);
-  });
-});
+// D-Score-Schwellen (früher D3/D7) sind zu den Familien D_HIGH/D_SHARP_EYE migriert — Tests in families.test.js.
 
 describe("streakBaseMult (Basis-Siegesserie #39)", () => {
   it("+2 %/Stufe, gedeckelt bei +150 % (Cap ab Serie 75, #100)", () => {
@@ -144,7 +137,7 @@ describe("streakBaseMult (Basis-Siegesserie #39)", () => {
 describe("baseScoreMultFor (Header-Chip #37 — V2: nur noch Basis-Serie #39)", () => {
   it("Serie 0 → ×1,00; D-Perks multiplizieren nicht mehr (Flat-Score)", () => {
     expect(baseScoreMultFor([], {})).toBeCloseTo(1);
-    expect(baseScoreMultFor(["D1", "D2"], {})).toBeCloseTo(1); // D flach → kein Multiplikator
+    expect(baseScoreMultFor(["A1", "B1"], {})).toBeCloseTo(1); // flache Perks tragen keinen Score-Multiplikator
   });
   it("Siegesserie hebt den Mult (#39): +2 %/Stufe bis Cap +150 % (#100)", () => {
     expect(baseScoreMultFor([], { winStreak: 0 })).toBeCloseTo(1);
@@ -158,12 +151,13 @@ describe("Layout-Perks (#95): Positions-/Formations-relevante Perks", () => {
   it("alle E-Werkzeuge zählen als Layout-Perk", () => {
     PERK_LIST.filter((p) => p.cat === "E").forEach((p) => expect(isLayoutPerk(p.id)).toBe(true));
   });
-  it("kuratierte B/C/D/L sind enthalten, layout-fremde Perks nicht", () => {
-    ["B4", "B6", "B9", "C1", "C8", "D1", "L3", "L11"].forEach((id) => expect(isLayoutPerk(id)).toBe(true));
-    ["A1", "B1", "B2", "C2", "D2", "D6", "L5"].forEach((id) => expect(isLayoutPerk(id)).toBe(false));
+  it("kuratierte B/C/L sind enthalten, layout-fremde Perks nicht", () => {
+    // D-Score ist zu Familien migriert (#167); die formationsbezogenen D-Familien folgen in der Layout-Hilfe mit #166.
+    ["B4", "B6", "B9", "C1", "C8", "L3", "L11"].forEach((id) => expect(isLayoutPerk(id)).toBe(true));
+    ["A1", "B1", "B2", "C2", "L5"].forEach((id) => expect(isLayoutPerk(id)).toBe(false));
   });
   it("layoutPerks filtert die gehaltenen Perks in Reihenfolge", () => {
-    expect(layoutPerks(["A1", "E1", "D2", "C8"])).toEqual(["E1", "C8"]);
+    expect(layoutPerks(["A1", "E1", "C8"])).toEqual(["E1", "C8"]);
     expect(layoutPerks([])).toEqual([]);
   });
 });
@@ -221,14 +215,6 @@ describe("Seltene Perks (#71, Phase 2a)", () => {
   it("A10 Verdichtung: im frischen Deck kommt jeder Wert 4× vor → alle +1 (+40)", () => {
     expect(sumV(PERK_DEFS.A10.onPick(buildDeck())) - sumV(buildDeck())).toBe(40);
   });
-  it("D10 Übermacht: +350 Score ab 8 Wertpunkten Vorsprung, sonst 0", () => {
-    expect(PERK_DEFS.D10.scoreFlat({ margin: 8 })).toBe(350);
-    expect(PERK_DEFS.D10.scoreFlat({ margin: 7 })).toBe(0);
-  });
-  it("D11 Kritische Ernte: +250 Crit-Flat mit aktiver Formation", () => {
-    expect(PERK_DEFS.D11.scoreFlatOnCrit({ hasFormation: true })).toBe(250);
-    expect(PERK_DEFS.D11.scoreFlatOnCrit({ hasFormation: false })).toBe(0);
-  });
   it("E-Werkzeuge sind reine Marker; E10 hat extraSwap, ist aber als Perk deaktiviert (#162)", () => {
     for (const id of ["E1", "E2", "E3", "E4", "E5", "E6", "E7", "E8", "E9"]) {
       expect(PERK_DEFS[id].cat).toBe("E");
@@ -251,30 +237,6 @@ describe("Seltene Perks (#71, Phase 2b — Historie-Hooks)", () => {
   it("B8 Revanche: +7 ab 2 Niederlagen in Folge", () => {
     expect(PERK_DEFS.B8.cardBonus({ lossStreak: 2 })).toBe(7);
     expect(PERK_DEFS.B8.cardBonus({ lossStreak: 1 })).toBe(0);
-  });
-  it("D12 Präzision: +400 bei gleichem Wert wie letzter Sieg (erster Sieg 0)", () => {
-    expect(PERK_DEFS.D12.scoreFlat({ winValue: 8, lastWinValue: 8 })).toBe(400);
-    expect(PERK_DEFS.D12.scoreFlat({ winValue: 8, lastWinValue: 7 })).toBe(0);
-    expect(PERK_DEFS.D12.scoreFlat({ winValue: 8, lastWinValue: null })).toBe(0);
-  });
-  it("D13 Wechselspiel: +200 bei Sieg direkt nach einer Niederlage", () => {
-    expect(PERK_DEFS.D13.scoreFlat({ lastResult: "loss" })).toBe(200);
-    expect(PERK_DEFS.D13.scoreFlat({ lastResult: "win" })).toBe(0);
-  });
-});
-
-describe("Seltene Perks (#71, Phase 2c — Crit-Historie-Hooks)", () => {
-  it("D14 Crit-Folge: +200 bei Sieg direkt nach einem Crit", () => {
-    expect(PERK_DEFS.D14.scoreFlat({ critFollowArmed: true })).toBe(200);
-    expect(PERK_DEFS.D14.scoreFlat({ critFollowArmed: false })).toBe(0);
-  });
-  it("D15 Fehlzündung: zahlt die akkumulierte Score-Ladung bei Crit aus", () => {
-    expect(PERK_DEFS.D15.scoreFlatOnCrit({ misfireScore: 120 })).toBe(120);
-    expect(PERK_DEFS.D15.scoreFlatOnCrit({})).toBe(0);
-  });
-  it("D16 Schwachstellenanalyse: +300 nach klarer Niederlage (gerüstet)", () => {
-    expect(PERK_DEFS.D16.scoreFlat({ weaknessArmed: true })).toBe(300);
-    expect(PERK_DEFS.D16.scoreFlat({ weaknessArmed: false })).toBe(0);
   });
 });
 
@@ -312,18 +274,5 @@ describe("Seltene Perks (#71, Phase 2f — Historie-Hooks)", () => {
     expect(PERK_DEFS.B9.cardBonus(treppe(4))).toBe(4);
     expect(PERK_DEFS.B9.cardBonus(treppe(5))).toBe(4); // Deckel
     expect(PERK_DEFS.B9.cardBonus({ posForm: { formations: [{ type: "farbblock", ordinal: 3 }] } })).toBe(0);
-  });
-  it("D17 Farbserie: +100 je weiterem Sieg gleicher Farbe, gedeckelt bei 400", () => {
-    expect(PERK_DEFS.D17.scoreFlat({ suitStreak: 1 })).toBe(0);
-    expect(PERK_DEFS.D17.scoreFlat({ suitStreak: 2 })).toBe(100);
-    expect(PERK_DEFS.D17.scoreFlat({ suitStreak: 3 })).toBe(200);
-    expect(PERK_DEFS.D17.scoreFlat({ suitStreak: 5 })).toBe(400);
-    expect(PERK_DEFS.D17.scoreFlat({ suitStreak: 9 })).toBe(400); // Deckel
-  });
-  it("D18 Volles Haus: +750 auf der letzten Segment-Position mit 4 Vorsiegen", () => {
-    expect(PERK_DEFS.D18.scoreFlat({ posInCycle: 4, recentWinCount: 4 })).toBe(750);
-    expect(PERK_DEFS.D18.scoreFlat({ posInCycle: 9, recentWinCount: 4 })).toBe(750);
-    expect(PERK_DEFS.D18.scoreFlat({ posInCycle: 3, recentWinCount: 4 })).toBe(0); // nicht Segment-Ende
-    expect(PERK_DEFS.D18.scoreFlat({ posInCycle: 4, recentWinCount: 3 })).toBe(0); // nur 3 Vorsiege
   });
 });

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -1,42 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { buildDeck, makeRng } from "../src/game/deck.js";
+import { buildDeck } from "../src/game/deck.js";
 import { PERK_DEFS, PERK_LIST, critChanceFor, critChanceRawFor, isLegendary, baseScoreMultFor, streakBaseMult, isLayoutPerk, layoutPerks } from "../src/game/perks.js";
 import { effectivePlayerValue } from "../src/game/engine.js";
 
-describe("Perks — Deck-Modifikationen (Kat. A)", () => {
-  it("A1 Starke Fünfen: alle Wert-5 → +4 (Wert 9)", () => {
-    const d = PERK_DEFS.A1.onPick(buildDeck());
-    expect(d.filter((c) => c.value === 5)).toHaveLength(0);
-    expect(d.filter((c) => c.value === 9 && c.baseRank === 5)).toHaveLength(4); // die 4 beförderten 5er
-  });
-
-  it("A2 Gerade Stärke: gerade Werte +1, ungerade unverändert", () => {
-    const d = PERK_DEFS.A2.onPick(buildDeck());
-    const r2 = d.find((c) => c.id === "R2");
-    const r3 = d.find((c) => c.id === "R3");
-    expect(r2.value).toBe(3); // gerade → +1
-    expect(r3.value).toBe(3); // ungerade → unverändert
-  });
-
-  it("A5 Kleine ganz groß: vier unterschiedliche Karten (ursprünglich 1–3) je +5", () => {
-    const base = buildDeck();
-    const d = PERK_DEFS.A5.onPick(base, makeRng(3));
-    const changedIdx = base.map((_, i) => i).filter((i) => d[i].value !== base[i].value);
-    expect(changedIdx).toHaveLength(4);            // vier Karten
-    expect(new Set(changedIdx).size).toBe(4);      // unterschiedlich
-    for (const i of changedIdx) {
-      expect(base[i].baseRank).toBeGreaterThanOrEqual(1); // Auswahl über den ursprünglichen Wert
-      expect(base[i].baseRank).toBeLessThanOrEqual(3);
-      expect(d[i].value).toBe(base[i].value + 5);
-    }
-  });
-
-  it("Deck-Mods sind immutabel (Original-Deck unverändert)", () => {
-    const base = buildDeck();
-    PERK_DEFS.A1.onPick(base);
-    expect(base.filter((c) => c.value === 5)).toHaveLength(4);
-  });
-});
+// Kat.-A-Deck-Mods (früher A1–A10 onPick) sind zu KUMULATIVEN Familien migriert (#167) — die
+// Deck-Effekte je Stufe sind in test/families.test.js geprüft (onPick direkt), der Reducer-Pick +
+// Ziel-Fluss in test/families-engine.test.js.
 
 describe("effectivePlayerValue — cardBonus-Summation", () => {
   // Kat.-B-Wertboni sind zu Familien migriert (#167) — Engine-Integration in families-engine.test.js.
@@ -64,7 +33,7 @@ describe("Legendäre Perks — Hooks (V2 §22.6 L)", () => {
   it("die zehn verbliebenen L-Perks sind als legendary markiert (L7 entfernt, #162)", () => {
     for (const id of ["L1", "L2", "L3", "L4", "L5", "L6", "L8", "L9", "L10", "L11"]) expect(isLegendary(id)).toBe(true);
     expect(PERK_DEFS.L7).toBeUndefined(); // Königsmacher ersatzlos entfernt (Spec §9)
-    expect(isLegendary("A1")).toBe(false);
+    expect(isLegendary("C1")).toBe(false);
   });
   it("L1 Überladung: permMod +6 auf die gewählten Karten", () => {
     const deck = buildDeck().slice(0, 3);
@@ -122,7 +91,7 @@ describe("streakBaseMult (Basis-Siegesserie #39)", () => {
 describe("baseScoreMultFor (Header-Chip #37 — V2: nur noch Basis-Serie #39)", () => {
   it("Serie 0 → ×1,00; D-Perks multiplizieren nicht mehr (Flat-Score)", () => {
     expect(baseScoreMultFor([], {})).toBeCloseTo(1);
-    expect(baseScoreMultFor(["A1", "A2"], {})).toBeCloseTo(1); // flache Perks tragen keinen Score-Multiplikator
+    expect(baseScoreMultFor(["C1", "E1"], {})).toBeCloseTo(1); // flache Perks tragen keinen Score-Multiplikator
   });
   it("Siegesserie hebt den Mult (#39): +2 %/Stufe bis Cap +150 % (#100)", () => {
     expect(baseScoreMultFor([], { winStreak: 0 })).toBeCloseTo(1);
@@ -139,27 +108,16 @@ describe("Layout-Perks (#95): Positions-/Formations-relevante Perks", () => {
   it("kuratierte C/L sind enthalten, layout-fremde Perks nicht", () => {
     // B-Stich und D-Score sind zu Familien migriert (#167); ihre layout-relevanten Familien folgen mit #166.
     ["C1", "C8", "L3", "L11"].forEach((id) => expect(isLayoutPerk(id)).toBe(true));
-    ["A1", "C2", "L5"].forEach((id) => expect(isLayoutPerk(id)).toBe(false));
+    ["C9", "C2", "L5"].forEach((id) => expect(isLayoutPerk(id)).toBe(false));
   });
   it("layoutPerks filtert die gehaltenen Perks in Reihenfolge", () => {
-    expect(layoutPerks(["A1", "E1", "C8"])).toEqual(["E1", "C8"]);
+    expect(layoutPerks(["C9", "E1", "C8"])).toEqual(["E1", "C8"]);
     expect(layoutPerks([])).toEqual([]);
   });
 });
 
 describe("Neue Normal-Perks (#71)", () => {
-  const sumV = (d) => d.reduce((s, c) => s + c.value, 0);
-  it("A6 Mittelklasse: Werte 4–7 je +1 (Startdeck 16 Karten → +16)", () => {
-    expect(sumV(PERK_DEFS.A6.onPick(buildDeck())) - sumV(buildDeck())).toBe(16);
-  });
-  it("A7 Spitzenförderung: die vier höchsten Karten je +4 (+16; vier 10er → 14)", () => {
-    expect(sumV(PERK_DEFS.A7.onPick(buildDeck())) - sumV(buildDeck())).toBe(16);
-    expect(PERK_DEFS.A7.onPick(buildDeck()).filter((c) => c.value === 14)).toHaveLength(4);
-  });
-  it("A8 Nachzügler: die vier niedrigsten Karten je +5 (+20; vier 1er → 6)", () => {
-    expect(sumV(PERK_DEFS.A8.onPick(buildDeck())) - sumV(buildDeck())).toBe(20);
-    expect(PERK_DEFS.A8.onPick(buildDeck()).filter((c) => c.value === 6 && c.baseRank === 1)).toHaveLength(4);
-  });
+  // A6/A7/A8 (Deck-Mods) sind zu Familien A_MIDRANGE/A_TOP/A_BOTTOM migriert (#167) — Tests in families.test.js.
   it("C3 Leibwache: +5, wenn Rolle und der Vorgänger verlor", () => {
     expect(PERK_DEFS.C3.cardBonus({ isRole: (id) => id === "C3", lastResult: "loss" })).toBe(5);
     expect(PERK_DEFS.C3.cardBonus({ isRole: (id) => id === "C3", lastResult: "win" })).toBe(0);
@@ -174,13 +132,7 @@ describe("Neue Normal-Perks (#71)", () => {
 });
 
 describe("Seltene Perks (#71, Phase 2a)", () => {
-  const sumV = (d) => d.reduce((s, c) => s + c.value, 0);
-  it("A9 Farbduell: eine Farbe +3, eine −1 → netto +20", () => {
-    expect(sumV(PERK_DEFS.A9.onPick(buildDeck(), makeRng(2))) - sumV(buildDeck())).toBe(20);
-  });
-  it("A10 Verdichtung: im frischen Deck kommt jeder Wert 4× vor → alle +1 (+40)", () => {
-    expect(sumV(PERK_DEFS.A10.onPick(buildDeck())) - sumV(buildDeck())).toBe(40);
-  });
+  // A9 Farbduell / A10 Verdichtung sind zu Familien A_SUIT_DUEL/A_CONDENSE migriert (#167) — Tests in families.test.js.
   it("E-Werkzeuge sind reine Marker; E10 hat extraSwap, ist aber als Perk deaktiviert (#162)", () => {
     for (const id of ["E1", "E2", "E3", "E4", "E5", "E6", "E7", "E8", "E9"]) {
       expect(PERK_DEFS[id].cat).toBe("E");

--- a/test/perks.test.js
+++ b/test/perks.test.js
@@ -121,8 +121,9 @@ describe("critChanceFor / critChanceRawFor (V2: kein Perk trägt Crit-Chance —
 });
 
 describe("Legendäre Perks — Hooks (V2 §22.6 L)", () => {
-  it("alle elf L-Perks sind als legendary markiert", () => {
-    for (const id of ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8", "L9", "L10", "L11"]) expect(isLegendary(id)).toBe(true);
+  it("die zehn verbliebenen L-Perks sind als legendary markiert (L7 entfernt, #162)", () => {
+    for (const id of ["L1", "L2", "L3", "L4", "L5", "L6", "L8", "L9", "L10", "L11"]) expect(isLegendary(id)).toBe(true);
+    expect(PERK_DEFS.L7).toBeUndefined(); // Königsmacher ersatzlos entfernt (Spec §9)
     expect(isLegendary("D1")).toBe(false);
   });
   it("L1 Überladung: permMod +6 auf die gewählten Karten", () => {
@@ -148,10 +149,6 @@ describe("Legendäre Perks — Hooks (V2 §22.6 L)", () => {
     expect(PERK_DEFS.L6.critMultBonus({ rawCrit: 1.5 })).toBeCloseTo(0.5); // Überschuss über 100 %
     expect(PERK_DEFS.L6.critMultBonus({ rawCrit: 3 })).toBeCloseTo(1);     // Cap +100 %
     expect(PERK_DEFS.L6.critMultBonus({ rawCrit: 0.8 })).toBe(0);          // unter 100 % → 0
-  });
-  it("L7 Königsmacher: +5, wenn Segment-Höchste", () => {
-    expect(PERK_DEFS.L7.cardBonus({ isSegmentHigh: true })).toBe(5);
-    expect(PERK_DEFS.L7.cardBonus({ isSegmentHigh: false })).toBe(0);
   });
   it("L9 Blutvertrag: permMod −2/gewählt, +6/Nachfolger", () => {
     const deck = buildDeck().slice(0, 3);
@@ -207,11 +204,11 @@ describe("Layout-Perks (#95): Positions-/Formations-relevante Perks", () => {
     PERK_LIST.filter((p) => p.cat === "E").forEach((p) => expect(isLayoutPerk(p.id)).toBe(true));
   });
   it("kuratierte B/C/D/L sind enthalten, layout-fremde Perks nicht", () => {
-    ["B4", "B6", "B9", "C1", "C8", "D1", "L3", "L7", "L11"].forEach((id) => expect(isLayoutPerk(id)).toBe(true));
+    ["B4", "B6", "B9", "C1", "C8", "D1", "L3", "L11"].forEach((id) => expect(isLayoutPerk(id)).toBe(true));
     ["A1", "B1", "B2", "C2", "D2", "D6", "L5"].forEach((id) => expect(isLayoutPerk(id)).toBe(false));
   });
   it("layoutPerks filtert die gehaltenen Perks in Reihenfolge", () => {
-    expect(layoutPerks(["A1", "E1", "D2", "C8", "L7"])).toEqual(["E1", "C8", "L7"]);
+    expect(layoutPerks(["A1", "E1", "D2", "C8"])).toEqual(["E1", "C8"]);
     expect(layoutPerks([])).toEqual([]);
   });
 });
@@ -277,7 +274,7 @@ describe("Seltene Perks (#71, Phase 2a)", () => {
     expect(PERK_DEFS.D11.scoreFlatOnCrit({ hasFormation: true })).toBe(250);
     expect(PERK_DEFS.D11.scoreFlatOnCrit({ hasFormation: false })).toBe(0);
   });
-  it("E-Werkzeuge sind reine Marker (Wirkung in computeFormations); E10 hat extraSwap", () => {
+  it("E-Werkzeuge sind reine Marker; E10 hat extraSwap, ist aber als Perk deaktiviert (#162)", () => {
     for (const id of ["E1", "E2", "E3", "E4", "E5", "E6", "E7", "E8", "E9"]) {
       expect(PERK_DEFS[id].cat).toBe("E");
       expect(PERK_DEFS[id].cardBonus).toBeUndefined();
@@ -285,6 +282,7 @@ describe("Seltene Perks (#71, Phase 2a)", () => {
       expect(PERK_DEFS[id].critChance).toBeUndefined();
     }
     expect(PERK_DEFS.E10.extraSwap).toBe(1);
+    expect(PERK_DEFS.E10.offerable).toBe(false); // #162: aus dem Perk-Pool genommen → wird Shop-Familie
   });
   it("V2 §22.4: alle A–E sind normal (keine Rares mehr); nur L ist legendär", () => {
     for (const p of PERK_LIST) {

--- a/test/rarity.test.js
+++ b/test/rarity.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  TIERS, TIER_META, TIER_WEIGHTS, ROMAN,
+  priceOfTier, romanOf, rarityKeyOf, tierColor, tierLabel,
+  canOfferFamilyTier, offerableTiers,
+  familyTierOf, withFamilyTier, familyComplete,
+  buildFamilyOffer, UPGRADE_TYPES,
+} from "../src/game/rarity.js";
+
+// Deterministischer PRNG (mulberry32) — wie in den übrigen Suites: gleicher Seed → gleiche Züge.
+function makeRng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe("Stufen-Metadaten (Spec §1)", () => {
+  it("vier Stufen mit festen Preisen 8/12/18/30", () => {
+    expect(TIERS).toEqual([1, 2, 3, 4]);
+    expect([1, 2, 3, 4].map(priceOfTier)).toEqual([8, 12, 18, 30]);
+  });
+  it("interne Rarität normal/uncommon/rare/epic; sichtbares Etikett Stufe IV = Rar", () => {
+    expect([1, 2, 3, 4].map(rarityKeyOf)).toEqual(["normal", "uncommon", "rare", "epic"]);
+    expect(TIER_META[4].label).toBe("Rar");
+  });
+  it("Farbskala Grau/Grün/Blau/Lila", () => {
+    expect([1, 2, 3, 4].map(tierColor)).toEqual(["#8a8a95", "#4ade80", "#5a8ade", "#a855f7"]);
+  });
+  it("römische Stufe im Etikett: Momentum III; Rang 0 → nur Name", () => {
+    expect(romanOf(3)).toBe("III");
+    expect(tierLabel("Momentum", 3)).toBe("Momentum III");
+    expect(tierLabel("Momentum", 0)).toBe("Momentum");
+    expect(ROMAN[4]).toBe("IV");
+  });
+});
+
+describe("Angebotsfilter (Spec §2.4)", () => {
+  it("nur Stufen ECHT über dem aktuellen Rang", () => {
+    expect(canOfferFamilyTier(0, 1)).toBe(true);
+    expect(canOfferFamilyTier(2, 2)).toBe(false); // gleich zählt nicht
+    expect(canOfferFamilyTier(2, 1)).toBe(false); // niedriger nicht
+    expect(canOfferFamilyTier(2, 3)).toBe(true);
+    expect(canOfferFamilyTier(4, 4)).toBe(false); // IV schließt ab
+  });
+  it("offerableTiers: Rang 2 → [3,4]; Rang 4 → [] (abgeschlossen)", () => {
+    const fam = { id: "F", tiers: [1, 2, 3, 4] };
+    expect(offerableTiers(fam, 0)).toEqual([1, 2, 3, 4]);
+    expect(offerableTiers(fam, 2)).toEqual([3, 4]);
+    expect(offerableTiers(fam, 4)).toEqual([]);
+  });
+});
+
+describe("Familienzustand (immutabel)", () => {
+  it("lesen/schreiben ohne Mutation", () => {
+    const ft = { A: 2 };
+    expect(familyTierOf(ft, "A")).toBe(2);
+    expect(familyTierOf(ft, "B")).toBe(0);
+    const ft2 = withFamilyTier(ft, "B", 3);
+    expect(ft2).toEqual({ A: 2, B: 3 });
+    expect(ft).toEqual({ A: 2 }); // Original unverändert
+    expect(familyComplete({ A: 4 }, "A")).toBe(true);
+    expect(familyComplete({ A: 3 }, "A")).toBe(false);
+  });
+});
+
+describe("buildFamilyOffer (Spec §2)", () => {
+  const fams = [
+    { id: "A", tiers: [1, 2, 3, 4] },
+    { id: "B", tiers: [1, 2, 3, 4] },
+    { id: "C", tiers: [1, 2, 3, 4] },
+    { id: "D", tiers: [1, 2, 3, 4] },
+  ];
+
+  it("deterministisch bei gleichem Seed", () => {
+    const a = buildFamilyOffer(fams, {}, makeRng(7), 3);
+    const b = buildFamilyOffer(fams, {}, makeRng(7), 3);
+    expect(a).toEqual(b);
+    expect(a).toHaveLength(3);
+  });
+
+  it("liefert VERSCHIEDENE Familien (keine Dublette je Angebot)", () => {
+    const off = buildFamilyOffer(fams, {}, makeRng(3), 4);
+    const ids = off.map((o) => o.familyId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("bietet nur Stufen über dem aktuellen Rang; jede gewählte Stufe ist anbietbar", () => {
+    const ft = { A: 2, B: 4, C: 0, D: 3 };
+    const off = buildFamilyOffer(fams, ft, makeRng(11), 4);
+    expect(off.some((o) => o.familyId === "B")).toBe(false); // Rang IV → nie angeboten
+    for (const o of off) {
+      const cur = ft[o.familyId] || 0;
+      expect(o.tier).toBeGreaterThan(cur);
+    }
+  });
+
+  it("überspringt deaktivierte Familien und respektiert count", () => {
+    const withDisabled = [...fams, { id: "E", tiers: [1, 2, 3, 4], enabled: false }];
+    const off = buildFamilyOffer(withDisabled, {}, makeRng(5), 10);
+    expect(off.some((o) => o.familyId === "E")).toBe(false);
+    expect(off).toHaveLength(4); // nur A–D verfügbar
+  });
+
+  it("leeres Angebot, wenn alle Familien abgeschlossen sind", () => {
+    expect(buildFamilyOffer(fams, { A: 4, B: 4, C: 4, D: 4 }, makeRng(1), 3)).toEqual([]);
+  });
+});
+
+describe("Upgrade-Typen (Spec §2.3)", () => {
+  it("drei Marker", () => {
+    expect(UPGRADE_TYPES).toEqual({ REPLACEMENT: "replacement", CUMULATIVE: "cumulative", ROLE: "role" });
+    expect(TIER_WEIGHTS[1]).toBeGreaterThan(TIER_WEIGHTS[4]); // höhere Stufe seltener
+  });
+});

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -30,8 +30,8 @@ describe("Reducer", () => {
   // Deck-Mods beim Pick (früher flache Kat.-A-Perks) sind zu KUMULATIVEN Familien migriert (#167) — der
   // Familien-Pick + Ziel-Fluss ist in test/families-engine.test.js geprüft; PICK_PERK verändert das Deck nicht mehr.
   it("PICK_PERK ignoriert Perks außerhalb des Angebots", () => {
-    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "C1", "E2"] };
-    expect(reducer(s0, { type: "PICK_PERK", perkId: "C3", rng })).toBe(s0);
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "L3", "E2"] };
+    expect(reducer(s0, { type: "PICK_PERK", perkId: "L5", rng })).toBe(s0); // nicht im Angebot → No-Op
   });
 
   it("L1 Überladung (Ziel-Perk): CONFIRM_TARGET gibt 5 gewählten Karten +6", () => {
@@ -52,7 +52,7 @@ describe("Reducer", () => {
   });
 
   it("RESET beginnt einen frischen Lauf mit Start-Pick = Stat (V2 §22.2)", () => {
-    const dirty = { ...initialState(makeRng(1)), score: 999, perks: ["E1", "C1"] };
+    const dirty = { ...initialState(makeRng(1)), score: 999, perks: ["E1", "L3"] };
     const fresh = reducer(dirty, { type: "RESET", rng });
     expect(fresh.score).toBe(0);
     expect(fresh.perks).toEqual([]);
@@ -77,7 +77,7 @@ describe("Reducer", () => {
 
 describe("PICK_PERK — nach jeder Runde zurück in play (Neuer Loop)", () => {
   it("Wahl aus dem levelup-Angebot → play, offer null, Perk übernommen", () => {
-    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "C1", "E2"] };
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "L3", "E2"] };
     const s1 = reducer(s0, { type: "PICK_PERK", perkId: "E2", rng });
     expect(s1.phase).toBe("play");
     expect(s1.offer).toBeNull();
@@ -235,7 +235,7 @@ describe("Skill-Auswahl — PICK_SKILL / DECLINE_SKILL (Stufe A)", () => {
 });
 
 describe("DECLINE_PERK — Perk-Angebot ablehnen → +Münze (#138)", () => {
-  const perkLevelup = (over = {}) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "C1", "E2"], ...over });
+  const perkLevelup = (over = {}) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "L3", "E2"], ...over });
 
   it("schreibt PERK_DECLINE_COINS gut, verwirft das Angebot und kehrt in play zurück", () => {
     const s0 = perkLevelup({ shop: { ...initialState(makeRng(1)).shop, coins: 3 } });
@@ -317,38 +317,10 @@ describe("Formationsphase — SWAP/UNDO/RESET/CONFIRM (V2 §22.8)", () => {
   });
 });
 
-describe("Kartenrollen — Zielauswahl PICK_PERK/CONFIRM_TARGET (V2 §22.6 C)", () => {
-  const lvl = (over = {}) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: ["C1", "E1", "E2"], ...over });
-
-  it("PICK_PERK eines Ziel-Perks öffnet die Zielauswahl (phase target)", () => {
-    const s = reducer(lvl(), { type: "PICK_PERK", perkId: "C1", rng });
-    expect(s.phase).toBe("target");
-    expect(s.targetPerk).toBe("C1");
-    expect(s.perks).toEqual(["C1"]); // Perk bereits gehalten
-  });
-  it("CONFIRM_TARGET setzt die Rolle und geht in play", () => {
-    let s = reducer(lvl(), { type: "PICK_PERK", perkId: "C1", rng });
-    const ids = s.playerOrder.slice(0, 3).map((di) => s.deck[di].id);
-    s = reducer(s, { type: "CONFIRM_TARGET", cardIds: ids });
-    expect(s.phase).toBe("play");
-    expect(s.targetPerk).toBeNull();
-    expect(s.roles.C1).toEqual(ids);
-  });
-  it("CONFIRM_TARGET verlangt genau needsTarget unterschiedliche Karten", () => {
-    const s = reducer(lvl(), { type: "PICK_PERK", perkId: "C1", rng });
-    const two = s.playerOrder.slice(0, 2).map((di) => s.deck[di].id);
-    expect(reducer(s, { type: "CONFIRM_TARGET", cardIds: two })).toBe(s); // zu wenige → wirkungslos
-  });
-  it("C9 Opfergabe: gewählte Karte −3, direkter Nachfolger +5 (dauerhaft)", () => {
-    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: ["C9", "E1", "E2"] };
-    s = reducer(s, { type: "PICK_PERK", perkId: "C9", rng });
-    const targetDi = s.playerOrder[0], succDi = s.playerOrder[1];
-    const tv = s.deck[targetDi].value, sv = s.deck[succDi].value;
-    s = reducer(s, { type: "CONFIRM_TARGET", cardIds: [s.deck[targetDi].id] });
-    expect(s.deck[targetDi].value).toBe(Math.max(0, tv - 3));
-    expect(s.deck[succDi].value).toBe(sv + 5);
-  });
-
+// Kat.-C-Rollen (inkl. C9 Opfergabe) sind zu Familien migriert (#167) → laufen über den Familien-Ziel-Fluss
+// (FAMILY_TARGET_*, geprüft in families-engine.test.js). Das flache CONFIRM_TARGET dient nur noch den Ziel-Legendären
+// (L1/L9 permMod); die Ziel-Phasen-Öffnung/Validierung deckt der L1-Test oben ab.
+describe("Ziel-Legendäre — CONFIRM_TARGET permMod (V2 §22.6)", () => {
   it("L9 Blutvertrag: 4 gewählte Karten −2, ihre direkten Nachfolger +6 (dauerhaft)", () => {
     let s = { ...initialState(makeRng(1)), phase: "levelup", offer: ["L9", "E1", "E2"] };
     s = reducer(s, { type: "PICK_PERK", perkId: "L9", rng: makeRng(1) });

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -30,7 +30,7 @@ describe("Reducer", () => {
   // Deck-Mods beim Pick (früher flache Kat.-A-Perks) sind zu KUMULATIVEN Familien migriert (#167) — der
   // Familien-Pick + Ziel-Fluss ist in test/families-engine.test.js geprüft; PICK_PERK verändert das Deck nicht mehr.
   it("PICK_PERK ignoriert Perks außerhalb des Angebots", () => {
-    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "L3", "E2"] };
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["L1", "L2", "L3"] };
     expect(reducer(s0, { type: "PICK_PERK", perkId: "L5", rng })).toBe(s0); // nicht im Angebot → No-Op
   });
 
@@ -52,7 +52,7 @@ describe("Reducer", () => {
   });
 
   it("RESET beginnt einen frischen Lauf mit Start-Pick = Stat (V2 §22.2)", () => {
-    const dirty = { ...initialState(makeRng(1)), score: 999, perks: ["E1", "L3"] };
+    const dirty = { ...initialState(makeRng(1)), score: 999, perks: ["L1", "L3"] };
     const fresh = reducer(dirty, { type: "RESET", rng });
     expect(fresh.score).toBe(0);
     expect(fresh.perks).toEqual([]);
@@ -77,11 +77,11 @@ describe("Reducer", () => {
 
 describe("PICK_PERK — nach jeder Runde zurück in play (Neuer Loop)", () => {
   it("Wahl aus dem levelup-Angebot → play, offer null, Perk übernommen", () => {
-    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "L3", "E2"] };
-    const s1 = reducer(s0, { type: "PICK_PERK", perkId: "E2", rng });
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["L1", "L2", "L3"] };
+    const s1 = reducer(s0, { type: "PICK_PERK", perkId: "L2", rng }); // L2: cardBonus, kein needsTarget → direkt play
     expect(s1.phase).toBe("play");
     expect(s1.offer).toBeNull();
-    expect(s1.perks).toEqual(["E2"]);
+    expect(s1.perks).toEqual(["L2"]);
   });
 });
 
@@ -235,7 +235,7 @@ describe("Skill-Auswahl — PICK_SKILL / DECLINE_SKILL (Stufe A)", () => {
 });
 
 describe("DECLINE_PERK — Perk-Angebot ablehnen → +Münze (#138)", () => {
-  const perkLevelup = (over = {}) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "L3", "E2"], ...over });
+  const perkLevelup = (over = {}) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: ["L1", "L2", "L3"], ...over });
 
   it("schreibt PERK_DECLINE_COINS gut, verwirft das Angebot und kehrt in play zurück", () => {
     const s0 = perkLevelup({ shop: { ...initialState(makeRng(1)).shop, coins: 3 } });
@@ -322,7 +322,7 @@ describe("Formationsphase — SWAP/UNDO/RESET/CONFIRM (V2 §22.8)", () => {
 // (L1/L9 permMod); die Ziel-Phasen-Öffnung/Validierung deckt der L1-Test oben ab.
 describe("Ziel-Legendäre — CONFIRM_TARGET permMod (V2 §22.6)", () => {
   it("L9 Blutvertrag: 4 gewählte Karten −2, ihre direkten Nachfolger +6 (dauerhaft)", () => {
-    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: ["L9", "E1", "E2"] };
+    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: ["L9", "L1", "L2"] };
     s = reducer(s, { type: "PICK_PERK", perkId: "L9", rng: makeRng(1) });
     expect(s.phase).toBe("target");
     const order = s.playerOrder;

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -27,19 +27,11 @@ describe("Reducer", () => {
     expect(initialState(makeRng(5)).playerOrder).toEqual(initialState(makeRng(5)).playerOrder);
   });
 
-  it("PICK_PERK wendet eine Deck-Mod an und kehrt in play zurück", () => {
-    const base = initialState(makeRng(1));
-    const s0 = { ...base, phase: "levelup", offer: ["A1", "C1", "E2"] };
-    const s1 = reducer(s0, { type: "PICK_PERK", perkId: "A1", rng });
-    expect(s1.phase).toBe("play");
-    expect(s1.perks).toEqual(["A1"]);
-    expect(s1.offer).toBeNull();
-    expect(s1.deck.filter((c) => c.value === 5)).toHaveLength(0); // A1 hat die 5er hochgezogen
-  });
-
+  // Deck-Mods beim Pick (früher flache Kat.-A-Perks) sind zu KUMULATIVEN Familien migriert (#167) — der
+  // Familien-Pick + Ziel-Fluss ist in test/families-engine.test.js geprüft; PICK_PERK verändert das Deck nicht mehr.
   it("PICK_PERK ignoriert Perks außerhalb des Angebots", () => {
-    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["A1", "C1", "E2"] };
-    expect(reducer(s0, { type: "PICK_PERK", perkId: "D5", rng })).toBe(s0);
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "C1", "E2"] };
+    expect(reducer(s0, { type: "PICK_PERK", perkId: "C3", rng })).toBe(s0);
   });
 
   it("L1 Überladung (Ziel-Perk): CONFIRM_TARGET gibt 5 gewählten Karten +6", () => {
@@ -60,7 +52,7 @@ describe("Reducer", () => {
   });
 
   it("RESET beginnt einen frischen Lauf mit Start-Pick = Stat (V2 §22.2)", () => {
-    const dirty = { ...initialState(makeRng(1)), score: 999, perks: ["A1", "D1"] };
+    const dirty = { ...initialState(makeRng(1)), score: 999, perks: ["E1", "C1"] };
     const fresh = reducer(dirty, { type: "RESET", rng });
     expect(fresh.score).toBe(0);
     expect(fresh.perks).toEqual([]);
@@ -85,7 +77,7 @@ describe("Reducer", () => {
 
 describe("PICK_PERK — nach jeder Runde zurück in play (Neuer Loop)", () => {
   it("Wahl aus dem levelup-Angebot → play, offer null, Perk übernommen", () => {
-    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["A1", "C1", "E2"] };
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "C1", "E2"] };
     const s1 = reducer(s0, { type: "PICK_PERK", perkId: "E2", rng });
     expect(s1.phase).toBe("play");
     expect(s1.offer).toBeNull();
@@ -243,7 +235,7 @@ describe("Skill-Auswahl — PICK_SKILL / DECLINE_SKILL (Stufe A)", () => {
 });
 
 describe("DECLINE_PERK — Perk-Angebot ablehnen → +Münze (#138)", () => {
-  const perkLevelup = (over = {}) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: ["A1", "C1", "E2"], ...over });
+  const perkLevelup = (over = {}) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: ["E1", "C1", "E2"], ...over });
 
   it("schreibt PERK_DECLINE_COINS gut, verwirft das Angebot und kehrt in play zurück", () => {
     const s0 = perkLevelup({ shop: { ...initialState(makeRng(1)).shop, coins: 3 } });
@@ -326,7 +318,7 @@ describe("Formationsphase — SWAP/UNDO/RESET/CONFIRM (V2 §22.8)", () => {
 });
 
 describe("Kartenrollen — Zielauswahl PICK_PERK/CONFIRM_TARGET (V2 §22.6 C)", () => {
-  const lvl = (over = {}) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: ["C1", "A1", "D1"], ...over });
+  const lvl = (over = {}) => ({ ...initialState(makeRng(1)), phase: "levelup", offer: ["C1", "E1", "E2"], ...over });
 
   it("PICK_PERK eines Ziel-Perks öffnet die Zielauswahl (phase target)", () => {
     const s = reducer(lvl(), { type: "PICK_PERK", perkId: "C1", rng });
@@ -348,7 +340,7 @@ describe("Kartenrollen — Zielauswahl PICK_PERK/CONFIRM_TARGET (V2 §22.6 C)", 
     expect(reducer(s, { type: "CONFIRM_TARGET", cardIds: two })).toBe(s); // zu wenige → wirkungslos
   });
   it("C9 Opfergabe: gewählte Karte −3, direkter Nachfolger +5 (dauerhaft)", () => {
-    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: ["C9", "A1", "D1"] };
+    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: ["C9", "E1", "E2"] };
     s = reducer(s, { type: "PICK_PERK", perkId: "C9", rng });
     const targetDi = s.playerOrder[0], succDi = s.playerOrder[1];
     const tv = s.deck[targetDi].value, sv = s.deck[succDi].value;
@@ -358,7 +350,7 @@ describe("Kartenrollen — Zielauswahl PICK_PERK/CONFIRM_TARGET (V2 §22.6 C)", 
   });
 
   it("L9 Blutvertrag: 4 gewählte Karten −2, ihre direkten Nachfolger +6 (dauerhaft)", () => {
-    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: ["L9", "A1", "D1"] };
+    let s = { ...initialState(makeRng(1)), phase: "levelup", offer: ["L9", "E1", "E2"] };
     s = reducer(s, { type: "PICK_PERK", perkId: "L9", rng: makeRng(1) });
     expect(s.phase).toBe("target");
     const order = s.playerOrder;

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -85,11 +85,11 @@ describe("Reducer", () => {
 
 describe("PICK_PERK — nach jeder Runde zurück in play (Neuer Loop)", () => {
   it("Wahl aus dem levelup-Angebot → play, offer null, Perk übernommen", () => {
-    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["A1", "B1", "D1"] };
-    const s1 = reducer(s0, { type: "PICK_PERK", perkId: "B1", rng });
+    const s0 = { ...initialState(makeRng(1)), phase: "levelup", offer: ["A1", "C1", "E2"] };
+    const s1 = reducer(s0, { type: "PICK_PERK", perkId: "E2", rng });
     expect(s1.phase).toBe("play");
     expect(s1.offer).toBeNull();
-    expect(s1.perks).toEqual(["B1"]);
+    expect(s1.perks).toEqual(["E2"]);
   });
 });
 


### PR DESCRIPTION
Setzt das Raritätssystem (Epic #167, Spec `docs/rarity-system.md`) für **alle regulären Perks** um: statt flacher Einzel-Perks gibt es jetzt aufwertbare **Familien mit vier Stufen (I–IV)**. Ein funktional geschlossener Block — die Perk-Migration (#163) und das UI-Familienbewusstsein (#166) sind vollständig.

## Was drin ist

**Fundament (#162)** — `rarity.js`: Stufen-Modell (TIER_META/TIER_WEIGHTS/ROMAN), Angebotsfilter, Familienzustand. L7 „Königsmacher" entfernt, E10 aus dem Perk-Pool (`offerable:false`).

**Alle regulären Perk-Kategorien sind jetzt Familien (#163):**
- **D · Score** (19) und **B · Stich** (10) — Regelersetzung (nur höchste Stufe aktiv), Score-/Wert-Hooks über `familySumHook`/`familyProdHook`.
- **A · Deck** (10) — KUMULATIV: jede Stufe führt ihr Deck-Paket einmalig aus (`onPick`), Boni stapeln, nur höchster Rang angezeigt.
- **C · Rolle** (10) — GEMISCHT: 8 ROLE (Kartenrollen), 1 REPLACEMENT (Überlebensvorteil), 1 CUMULATIVE (Opfergabe).
- **E · Form** (9) — Regelersetzung: Formations-Erkennungsregeln, `computeFormations` liest die Stufen-Parameter je gehaltener Familie.

**Familien-Ziel-Fluss** — neue `family-target`-Phase + `FamilyTargetSelect`: Farb-Ziele (A: A_SUIT_BOOST/A_SUIT_DUEL) und Karten-Ziele (C-Rollen, Opfergabe) via geteiltem CardGrid. ROLE-Upgrades wählen nur die zusätzlichen Ziele (§2.3).

**Engine/Formations familyTiers-bewusst** — `activeFamilyEntries`/`familyTierParam`: relay/triumph/segmentLow-Rang (C), Joker/Bindeglied + Gap-/Rückschritt-/Anker-/Grenz-Parameter (C/E). `computeFormations` nimmt `familyTiers` als Parameter (alle Aufrufstellen aktualisiert).

**Angebot/UI** — `buildPerkOffer` mischt Familien (nach TIER_WEIGHTS) + flache Legendäre; `PerkSelect`/`PerkList`/`BuildPanel` familienagnostisch. Flache A1–A10/B1–B10/C1–C10/D1–D19/E1–E9 entfernt (Legendäre L1–L11 bleiben flach).

**UI-Familienbewusstsein (#166):** Crit-Sichtbarkeit (`hasCritFamily` → StatusRail/PerkSelect), Aufstellungshilfe (`layoutFamilies` → LayoutPerks), E_QUICKSHOT IV Anker-Wertbonus.

## §10-Design-Entscheidungen (Spec ließ sie offen)
- Stufe IV intern `epic`, sichtbar „Rar"; Drop-Gewichte I100/II46/III20/IV8 (tunebar); kein Shop-Rabatt/Freischalt-Gating.
- C_JOKER III „Vorgänger-oder-Nachfolgerfarbe" ≈ Farbblock-Wildcard (der paarweise Scanner kann die Regel nicht ohne Falsch-Verschmelzung abbilden).
- C_SURVIVOR I „vier zufällige Segmente" → deterministisch die ersten vier (kein per-Run-Zufallszustand).
- E_GENTLE/E_BIGSTEP IV = unbegrenzte Budgets; E_SEGMENT I/II öffnen die ersten 1/2 Grenzen deterministisch.

## Tests & Verifikation
- **479 Tests grün**; jede Kategorie zusätzlich im laufenden App-Build end-to-end verifiziert (Familie gepickt → Ziel-Fluss → Deck/Rollen/Formationen wie spezifiziert, 0 Konsolenfehler).
- Additiv/inkrementell entwickelt; Tests bei jedem Schritt grün.

## NICHT in diesem PR (folgen separat)
- **#164 Shop-Familien** (inkl. E10 → Shop-Familie „Feinjustierung").
- **#165 Skills** (Skill-Erweiterungen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)