### PR TITLE
Balance/Pacing: SCORE_PER_WIN 100→400 + kleiner Blitz-Buff

### DIFF
--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -2,7 +2,7 @@
    TUNING-BLOCK  — hier dreht der Dev im Playtest
    ============================================================ */
 export const MAX_CYCLES       = 44;     // Shop-Spec (§2.1): fester Run über genau so viele Deck-Durchläufe, danach Ende [TUNING]
-export const SCORE_PER_WIN    = 100;    // Basispunkte je Sieg (Perks/Formationen skalieren darauf) [TUNING]
+export const SCORE_PER_WIN    = 400;    // Basispunkte je Sieg (Perks/Formationen skalieren darauf) [TUNING · Pacing-Pass: 100→400, flacht die Score-Kurve über den Run ab — flache Boni akkumulieren spät, höhere Basis hebt früh relativ stärker; Sim-validiert, siehe docs/sim-harness-plan]
 export const CRIT_BASE_MULT   = 1.5;    // V2 (§22.3): Basis-Crit-Multiplikator; der Crit-Mult-Stat baut darauf auf [TUNING]
 export const PERKS_OFFERED    = 3;      // Perks pro Level-Up-Auswahl [TUNING]
 

--- a/src/game/constants.js
+++ b/src/game/constants.js
@@ -89,7 +89,7 @@ export const SKILLS_OFFERED     = 6;   // Skills je Skill-Runde (Prototyp: 2+2+2
 export const MAX_ARCHETYPES     = 3;   // Prototyp: alle 3 Archetypen gleichzeitig aktivierbar (Cap aufgehoben)
 export const SKILL_EVERY_CYCLES = 3;   // jede N-te Runde ist eine Skill-Runde (3, 6, 9 …), sonst Perk
 export const LIGHTNING_CRIT_BASE      = 0.05; // Blitz: Aktivierungs-Sockel Crit-Chance (Abschnitt 2a)
-export const LIGHTNING_CRIT_PER_SKILL = 0.05; // Blitz: je gehaltenem Blitz-Skill
+export const LIGHTNING_CRIT_PER_SKILL = 0.08; // Blitz: je gehaltenem Blitz-Skill [Balance/Pacing: 0,05→0,08 — kleiner Blitz-Buff, Sim-validiert: hebt Blitz von 0,81× auf 0,89× des besten Archetyps bei SPW=400]
 export const LIGHTNING_MAX_CHARGE     = 10;   // Blitz: Ladungsmaximum
 // Ionisierung (Stufe B) — dauerhafte Kartenmarkierung
 export const ION_SCORE_PER_STACK  = 25; // +Score je Ionisierungsstapel bei Sieg mit der Karte

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -447,10 +447,10 @@ describe("Stat-System — Engine (V2 §22.3)", () => {
     // Serie 11 (winStreak 10 → 11), großer Serien-Stat: 0,5 × 11 = 5,5 → auf STREAK_STAT_CAP (3,0) gedeckelt.
     const serie = 11;
     const gained = resolveTrick(scenario(12, 0, { statStreakMult: 0.5, winStreak: 10 }), rng).lastTrick.gained;
-    expect(gained).toBeCloseTo(100 * streakBaseMult(serie) * statStreakFactor(0.5, serie));
-    expect(gained).toBeCloseTo(100 * streakBaseMult(serie) * (1 + STREAK_STAT_CAP));
+    expect(gained).toBeCloseTo(B * streakBaseMult(serie) * statStreakFactor(0.5, serie));
+    expect(gained).toBeCloseTo(B * streakBaseMult(serie) * (1 + STREAK_STAT_CAP));
     // Ohne den Cap wäre der Faktor (1 + 5,5) → der Cap senkt den Score echt.
-    expect(gained).toBeLessThan(100 * streakBaseMult(serie) * (1 + 0.5 * serie));
+    expect(gained).toBeLessThan(B * streakBaseMult(serie) * (1 + 0.5 * serie));
   });
   it("Formations-Stat: greift nur bei aktiver Formation (§22.3)", () => {
     // Ohne Formation (erste Karte) kein Effekt …

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -3,7 +3,7 @@ import { makeRng } from "../src/game/deck.js";
 import { initialState } from "../src/game/reducer.js";
 import { resolveTrick, rollCrit } from "../src/game/engine.js";
 import { SKILL_DEFS } from "../src/game/skills.js";
-import { MAX_CYCLES, FORMATION_ENERGY, TRICKS_PER_CYCLE, DECISION_SCHEDULE, STREAK_STAT_CAP } from "../src/game/constants.js";
+import { MAX_CYCLES, FORMATION_ENERGY, TRICKS_PER_CYCLE, DECISION_SCHEDULE, STREAK_STAT_CAP, SCORE_PER_WIN } from "../src/game/constants.js";
 import { computeFormations } from "../src/game/formations.js";
 import { STAT_IDS, statStreakFactor } from "../src/game/stats.js";
 import { streakBaseMult } from "../src/game/perks.js";
@@ -26,6 +26,7 @@ function scenario(pVal, oVal, over = {}) {
   };
 }
 const rng = makeRng(9);
+const B = SCORE_PER_WIN; // Basis-relativ: erwartete Scores skalieren mit der Sieg-Basis (Pacing-Pass 100→400)
 
 // Formationsneutrales Spielerdeck (Werte 12/11 abwechselnd, Farbe R/B abwechselnd): gewinnt immer gegen
 // Wert 0, bildet aber über die Positionen KEINE Formation → isoliert Score-Mechaniken in Multi-Stich-Tests.
@@ -38,7 +39,7 @@ describe("resolveTrick — Grundausgänge (V2: ohne Leben)", () => {
     const s = resolveTrick(scenario(12, 0), rng);
     expect(s.wins).toBe(1);
     expect(s.losses).toBe(0);
-    expect(s.score).toBe(102); // 100 × streakBaseMult(1)=1,02 (#39)
+    expect(s.score).toBeCloseTo(B * 1.02); // Basis × streakBaseMult(1)=1,02 (#39)
     expect(s.winStreak).toBe(1);
     expect(s.lastResult).toBe("win");
     expect(s.initiative).toBe("player");
@@ -63,7 +64,7 @@ describe("resolveTrick — Grundausgänge (V2: ohne Leben)", () => {
   it("lastTrick.breakdown: Basis 100 und die Faktoren multiplizieren exakt auf gained (§17)", () => {
     const s = resolveTrick(scenario(12, 0, { statCritChance: 1 }), rng); // erzwungener Crit → critMult > 1
     const b = s.lastTrick.breakdown;
-    expect(b.base).toBe(100);
+    expect(b.base).toBe(B);
     expect(b.critMult).toBeGreaterThan(1);
     expect((b.base + b.flats) * b.streakMult * b.perkMult * b.formMult * b.critMult).toBeCloseTo(b.total);
     expect(b.total).toBeCloseTo(s.lastTrick.gained);
@@ -99,18 +100,18 @@ describe("resolveTrick — Grundausgänge (V2: ohne Leben)", () => {
 
 describe("resolveTrick — Crit & globale Score-Formel (ohne Tempo)", () => {
   it("additive Boni (Familie D_TENTH_WIN) fließen in die Basis und werden mitmultipliziert", () => {
-    // 10. Sieg → D_TENTH_WIN II +800: (100+800)×streakBaseMult(1)=1,02 = 918
+    // 10. Sieg → D_TENTH_WIN II +800: (Basis+800)×streakBaseMult(1)=1,02
     const s = resolveTrick(scenario(12, 0, { familyTiers: { D_TENTH_WIN: 2 }, wins: 9 }), rng);
-    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo(918);
+    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo((B + 800) * 1.02);
   });
 
   it("Crit multipliziert den vollen scoreBeforeCrit mit der Basis 1,5", () => {
-    // statCritChance 1 → garantierter Crit (verbraucht rng). scoreBeforeCrit = 100×1,02 = 102, ×1,5 = 153.
+    // statCritChance 1 → garantierter Crit (verbraucht rng). scoreBeforeCrit = Basis×1,02, ×1,5 mit Crit.
     const s = resolveTrick(scenario(12, 0, { statCritChance: 1 }), rng);
     expect(s.lastTrick.isCrit).toBe(true);
-    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo(102);
-    expect(s.lastTrick.scoreGain).toBeCloseTo(153);
-    expect(s.lastTrick.critBonus).toBeCloseTo(51);
+    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo(B * 1.02);
+    expect(s.lastTrick.scoreGain).toBeCloseTo(B * 1.02 * 1.5);
+    expect(s.lastTrick.critBonus).toBeCloseTo(B * 1.02 * 0.5);
   });
 
   it("Niederlagen und Gleichstände lösen keinen Crit aus", () => {
@@ -129,8 +130,8 @@ describe("resolveTrick — Crit & globale Score-Formel (ohne Tempo)", () => {
   it("crits, critBonusScore und bestTrickScore werden geführt", () => {
     const s = resolveTrick(scenario(12, 0, { statCritChance: 1 }), rng);
     expect(s.crits).toBe(1);
-    expect(s.critBonusScore).toBeCloseTo(51); // 102×1,5=153, Bonus 51
-    expect(s.bestTrickScore).toBeCloseTo(153);
+    expect(s.critBonusScore).toBeCloseTo(B * 1.02 * 0.5); // Crit-Bonus = Basis×1,02×0,5
+    expect(s.bestTrickScore).toBeCloseTo(B * 1.02 * 1.5);
   });
 });
 
@@ -168,7 +169,7 @@ describe("Legendäre Perks — Engine-Integration (V2 §22.6 L)", () => {
   it("L5 Jackpot: erster Crit einer L5-Zufallskarte je Durchlauf → +1000 Score", () => {
     const s = resolveTrick(scenario(12, 0, { statCritChance: 1, perks: ["L5"], roles: { L5: ["X0"] } }), rng);
     expect(s.lastTrick.isCrit).toBe(true);
-    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo((100 + 1000) * 1.02); // Jackpot-Flat in der Basis
+    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo((B + 1000) * 1.02); // Jackpot-Flat in der Basis
     expect(s.l5Used).toContain("X0");
     // Zweite L5-Karte an pos1 wäre nötig; hier prüfen wir nur, dass die erste verbraucht ist.
   });
@@ -219,7 +220,7 @@ describe("resolveTrick — Durchlauf-Ende & persistente Reihenfolge (V2)", () =>
     expect(s.cycle).toBe(MAX_CYCLES);
     expect(s.phase).toBe("gameover");
     expect(s.offer).toBeNull();
-    expect(s.score).toBeCloseTo(5102); // 5000 + 100 × 1,02
+    expect(s.score).toBeCloseTo(5000 + B * 1.02); // 5000 + Basis × 1,02
   });
 
   it("ist deterministisch bei gleichem Seed", () => {
@@ -299,9 +300,9 @@ describe("Serien-/Crit-Rares — Engine (#71 Phase 2e)", () => {
     // D_OVERCRIT III: jeder Überschuss-Crit (rawCrit > 1) gibt +500. statCritChance 1,5 → rawCrit 1,5, Crit garantiert.
     const s = resolveTrick(scenario(12, 0, { familyTiers: { D_OVERCRIT: 3 }, statCritChance: 1.5 }), rng);
     expect(s.lastTrick.isCrit).toBe(true);
-    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo((100 + 500) * 1.02);
+    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo((B + 500) * 1.02);
     // rawCrit genau 1 (nicht >1) → kein Bonus.
-    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_OVERCRIT: 3 }, statCritChance: 1 }), rng).lastTrick.scoreBeforeCrit).toBeCloseTo(102);
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_OVERCRIT: 3 }, statCritChance: 1 }), rng).lastTrick.scoreBeforeCrit).toBeCloseTo(B * 1.02);
   });
 });
 
@@ -355,19 +356,19 @@ describe("Blitz-Archetyp — Engine (Stufe A)", () => {
   });
 
   it("Crit mit Blitzableiter: +2 Ladung (Basis 1 + Skill 1) und +50 in der multiplizierten Basis", () => {
-    // scoreBase = (100 + 50) × streakBaseMult(1)=1,02 = 153, ×1,5 (Crit-Basis) = 229,5.
+    // scoreBase = (Basis + 50) × streakBaseMult(1)=1,02, ×1,5 (Crit-Basis).
     const s = resolveTrick(scenario(12, 0, { statCritChance: 1, skills: [LR], lightning: lit() }), rng);
     expect(s.lastTrick.isCrit).toBe(true);
     expect(s.lightning.charge).toBe(2);
-    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo(153);
-    expect(s.lastTrick.scoreGain).toBeCloseTo(229.5);
+    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo((B + 50) * 1.02);
+    expect(s.lastTrick.scoreGain).toBeCloseTo((B + 50) * 1.02 * 1.5);
   });
 
   it("ohne Crit: keine Ladung, kein Crit-Flat", () => {
     const s = resolveTrick(scenario(12, 0, { skills: [LR], lightning: lit() }), () => 0.99);
     expect(s.lastTrick.isCrit).toBe(false);
     expect(s.lightning.charge).toBe(0);
-    expect(s.lastTrick.scoreGain).toBeCloseTo(102); // 100 × 1,02, kein +50
+    expect(s.lastTrick.scoreGain).toBeCloseTo(B * 1.02); // Basis × 1,02, kein +50
   });
 
   it("Ladung deckelt bei maxCharge (10)", () => {
@@ -433,14 +434,14 @@ describe("Stat-System — Engine (V2 §22.3)", () => {
     const s = resolveTrick(scenario(12, 0, { statCritChance: 1, statCritMult: 0.4 }), rng);
     expect(s.lastTrick.isCrit).toBe(true);
     expect(s.lastTrick.critMultiplier).toBeCloseTo(1.9);
-    expect(s.lastTrick.scoreGain).toBeCloseTo(102 * 1.9); // scoreBeforeCrit 102 × 1,9
+    expect(s.lastTrick.scoreGain).toBeCloseTo(B * 1.02 * 1.9); // scoreBeforeCrit Basis×1,02 × 1,9
   });
   it("Serien-Stat: statStreakMult pro Serienpunkt multipliziert den Stichscore", () => {
-    // statStreakMult 0,01 × Serie 1 → Faktor 1,01. 100 × 1,02(#39) × 1,01.
-    expect(resolveTrick(scenario(12, 0, { statStreakMult: 0.01 }), rng).lastTrick.gained).toBeCloseTo(100 * 1.02 * 1.01);
+    // statStreakMult 0,01 × Serie 1 → Faktor 1,01. Basis × 1,02(#39) × 1,01.
+    expect(resolveTrick(scenario(12, 0, { statStreakMult: 0.01 }), rng).lastTrick.gained).toBeCloseTo(B * 1.02 * 1.01);
     // Serie 4 (winStreak 3 → 4): streakBaseMult(4)=1,08 × Faktor (1 + 0,01×4)=1,04.
     expect(resolveTrick(scenario(12, 0, { statStreakMult: 0.01, winStreak: 3 }), rng).lastTrick.gained)
-      .toBeCloseTo(100 * 1.08 * 1.04);
+      .toBeCloseTo(B * 1.08 * 1.04);
   });
   it("Serien-Stat ist bei STREAK_STAT_CAP gedeckelt (#153: Runaway-Schutz greift auch in der Engine)", () => {
     // Serie 11 (winStreak 10 → 11), großer Serien-Stat: 0,5 × 11 = 5,5 → auf STREAK_STAT_CAP (3,0) gedeckelt.
@@ -453,14 +454,14 @@ describe("Stat-System — Engine (V2 §22.3)", () => {
   });
   it("Formations-Stat: greift nur bei aktiver Formation (§22.3)", () => {
     // Ohne Formation (erste Karte) kein Effekt …
-    expect(resolveTrick(scenario(12, 0, { statFormMult: 0.15 }), rng).lastTrick.gained).toBeCloseTo(102);
+    expect(resolveTrick(scenario(12, 0, { statFormMult: 0.15 }), rng).lastTrick.gained).toBeCloseTo(B * 1.02);
     // … mit Formation (2. Karte eines Wiederholungs-Paars) wirkt +15 % zusätzlich zur Wiederholung ×1,25.
     const deck = [{ id: "a", suit: "R", baseRank: 12, value: 12 }, { id: "b", suit: "R", baseRank: 12, value: 12 }];
     const opp = [{ id: "o0", suit: "R", baseRank: 0, value: 0 }, { id: "o1", suit: "R", baseRank: 0, value: 0 }];
     let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: [0, 1], oppOrder: [0, 1], statFormMult: 0.15 };
     s = resolveTrick(s, rng); // pos0: keine Formation
     s = resolveTrick(s, rng); // pos1: Wiederholung ×1,25 + Formations-Stat ×1,15
-    expect(s.lastTrick.gained).toBeCloseTo(100 * 1.04 * 1.25 * 1.15);
+    expect(s.lastTrick.gained).toBeCloseTo(B * 1.04 * 1.25 * 1.15);
   });
 });
 
@@ -474,7 +475,7 @@ describe("Formations-Engine — Integration (V2 §22.7)", () => {
     s = resolveTrick(s, rng); expect(s.lastTrick.formationMult).toBe(1);   // pos0 = 1. Karte, kein Bonus
     s = resolveTrick(s, rng);
     expect(s.lastTrick.formationMult).toBeCloseTo(1.25);                    // pos1 = 2. Karte
-    expect(s.lastTrick.gained).toBeCloseTo(100 * 1.04 * 1.25);             // 100 × streakBaseMult(2) × 1,25
+    expect(s.lastTrick.gained).toBeCloseTo(B * 1.04 * 1.25);              // Basis × streakBaseMult(2) × 1,25
   });
 
   it("Crit multipliziert NACH dem Formations-Multiplikator (§7.3)", () => {
@@ -483,8 +484,8 @@ describe("Formations-Engine — Integration (V2 §22.7)", () => {
     s = resolveTrick(s, rng); // pos0
     s = resolveTrick(s, rng); // pos1: Formation ×1,25, dann Crit ×1,5
     expect(s.lastTrick.isCrit).toBe(true);
-    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo(100 * 1.04 * 1.25);    // Formation IN der Basis
-    expect(s.lastTrick.scoreGain).toBeCloseTo(100 * 1.04 * 1.25 * 1.5);    // Crit ×1,5 danach
+    expect(s.lastTrick.scoreBeforeCrit).toBeCloseTo(B * 1.04 * 1.25);      // Formation IN der Basis
+    expect(s.lastTrick.scoreGain).toBeCloseTo(B * 1.04 * 1.25 * 1.5);      // Crit ×1,5 danach
   });
 
   it("Formationen werden persistent im State gehalten (je Durchlauf berechnet)", () => {
@@ -498,9 +499,9 @@ describe("Formations-Engine — Integration (V2 §22.7)", () => {
     s = resolveTrick(s, rng); // pos0: Layout steht → maxFormations gesampelt; kein Formations-Mult
     expect(s.maxFormations).toBe(1);          // eine aktive Formation (Wiederholung) im Layout
     expect(s.formationScore).toBeCloseTo(0);
-    s = resolveTrick(s, rng); // pos1: Sieg mit Wiederholung ×1,25 (gained = 100 × 1,04 × 1,25 = 130)
-    // Anteil aus Formationen = gained × (1 − 1/1,25) = 130 × 0,2 = 26.
-    expect(s.formationScore).toBeCloseTo(26);
+    s = resolveTrick(s, rng); // pos1: Sieg mit Wiederholung ×1,25 (gained = Basis × 1,04 × 1,25)
+    // Anteil aus Formationen = gained × (1 − 1/1,25) = gained × 0,2.
+    expect(s.formationScore).toBeCloseTo(B * 1.04 * 1.25 * (1 - 1 / 1.25));
   });
 });
 
@@ -511,9 +512,9 @@ describe("Ionisierung — Engine (Stufe B)", () => {
   const ionDeck = (v, stacks) => constDeck(v).map((c, i) => (i === 0 ? { ...c, id: "P0", ionStacks: stacks } : { ...c, id: `P${i}` }));
 
   it("ionScore der gespielten Karte fließt in die multiplizierte Basis (+25/Stapel)", () => {
-    // 2 Stapel → +50: (100+50) × streakBaseMult(1)=1,02 = 153 (kein Crit).
+    // 2 Stapel → +50: (Basis+50) × streakBaseMult(1)=1,02 (kein Crit).
     const s = resolveTrick(scenario(12, 0, { deck: ionDeck(12, 2), playerOrder: identity() }), () => 0.99);
-    expect(s.lastTrick.scoreGain).toBeCloseTo(153);
+    expect(s.lastTrick.scoreGain).toBeCloseTo((B + 50) * 1.02);
   });
 
   it("Sieg mit ionisierter Karte erhöht deren Stapel (+1, max 5 — #165 Skills-Spec §5.1)", () => {
@@ -556,7 +557,7 @@ describe("Reaktoren + Geladene Serie — Engine (Stufe C)", () => {
 
   it("Gewitterfront-Score: aktiver Stack gibt +100 in die Basis und wird je Sieg abgebaut", () => {
     const s = resolveTrick(scenario(12, 0, { skills: [LR, G], lightning: lit({ stormScoreWinsRemaining: 2 }) }), () => 0.99);
-    expect(s.lastTrick.scoreGain).toBeCloseTo(204); // (100+100) × streakBaseMult(1)=1,02
+    expect(s.lastTrick.scoreGain).toBeCloseTo((B + 100) * 1.02); // (Basis+100) × streakBaseMult(1)=1,02
     expect(s.lightning.stormScoreWinsRemaining).toBe(1);
   });
 

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -3,7 +3,7 @@ import { makeRng } from "../src/game/deck.js";
 import { initialState } from "../src/game/reducer.js";
 import { resolveTrick, rollCrit } from "../src/game/engine.js";
 import { SKILL_DEFS } from "../src/game/skills.js";
-import { MAX_CYCLES, FORMATION_ENERGY, TRICKS_PER_CYCLE, DECISION_SCHEDULE, STREAK_STAT_CAP, SCORE_PER_WIN } from "../src/game/constants.js";
+import { MAX_CYCLES, FORMATION_ENERGY, TRICKS_PER_CYCLE, DECISION_SCHEDULE, STREAK_STAT_CAP, SCORE_PER_WIN, LIGHTNING_CRIT_BASE, LIGHTNING_CRIT_PER_SKILL } from "../src/game/constants.js";
 import { computeFormations } from "../src/game/formations.js";
 import { STAT_IDS, statStreakFactor } from "../src/game/stats.js";
 import { streakBaseMult } from "../src/game/perks.js";
@@ -350,9 +350,9 @@ describe("Blitz-Archetyp — Engine (Stufe A)", () => {
   const LR = "SK_LIGHTNING_01";
   const lit = (over = {}) => ({ active: true, charge: 0, maxCharge: 10, ...over });
 
-  it("Crit-Basis: aktiver Blitz + 1 Skill → Sockel +5 pp + 5 pp/Skill = 10 % Crit-Chance", () => {
+  it("Crit-Basis: aktiver Blitz + 1 Skill → Sockel + 1× pro-Skill-Crit", () => {
     const s = resolveTrick(scenario(12, 0, { skills: [LR], lightning: lit() }), rng);
-    expect(s.lastTrick.critChance).toBeCloseTo(0.10);
+    expect(s.lastTrick.critChance).toBeCloseTo(LIGHTNING_CRIT_BASE + LIGHTNING_CRIT_PER_SKILL);
   });
 
   it("Crit mit Blitzableiter: +2 Ladung (Basis 1 + Skill 1) und +50 in der multiplizierten Basis", () => {

--- a/test/families-engine.test.js
+++ b/test/families-engine.test.js
@@ -4,6 +4,8 @@ import { initialState, reducer } from "../src/game/reducer.js";
 import { resolveTrick } from "../src/game/engine.js";
 import { applyFamilyPick, FAMILY_DEFS } from "../src/game/families.js";
 import { buildPerkOffer, isMigratedPerk, PERK_DEFS, PERK_LIST, isLegendary } from "../src/game/perks.js";
+import { SCORE_PER_WIN } from "../src/game/constants.js";
+const B = SCORE_PER_WIN; // Basis-relativ: erwartete Scores skalieren mit der Sieg-Basis (Pacing-Pass 100→400)
 
 /* Engine-Verdrahtung des Raritätssystems (Epic #167, Schritt 1): der End-to-End-Nachweis, dass eine
    gehaltene Familien-Stufe (state.familyTiers) über resolveTrick genauso in die multiplizierte Score-Basis
@@ -29,26 +31,26 @@ const never = () => 0.999999;
 
 describe("Familien-Engine-Verdrahtung — Kategorie D über resolveTrick (Schritt 1)", () => {
   it("D_HIGH IV: Stufe zahlt scoreFlat in die multiplizierte Basis (Wert ≥6)", () => {
-    // Wert 6 ≥ Schwelle 6 → +350; (100+350)×streakBaseMult(1)=1,02
-    expect(resolveTrick(scenario(6, 0, { familyTiers: { D_HIGH: 4 } }), rng).score).toBeCloseTo(459);
+    // Wert 6 ≥ Schwelle 6 → +350; (Basis+350)×streakBaseMult(1)=1,02
+    expect(resolveTrick(scenario(6, 0, { familyTiers: { D_HIGH: 4 } }), rng).score).toBeCloseTo((B + 350) * 1.02);
     // Wert 5 < 6 → nur Basis
-    expect(resolveTrick(scenario(5, 0, { familyTiers: { D_HIGH: 4 } }), rng).score).toBeCloseTo(102);
+    expect(resolveTrick(scenario(5, 0, { familyTiers: { D_HIGH: 4 } }), rng).score).toBeCloseTo(B * 1.02);
   });
 
   it("nur die gehaltene Stufe zählt — kein Doppel-Trigger über Stufen (Spec §2.3/§9)", () => {
     // D_HIGH auf Rang 2: Schwelle ≥8/+150. Rang 1 (≥9/+100) darf NICHT zusätzlich zählen.
-    expect(resolveTrick(scenario(8, 0, { familyTiers: { D_HIGH: 2 } }), rng).score).toBeCloseTo(255); // (100+150)×1,02
-    expect(resolveTrick(scenario(7, 0, { familyTiers: { D_HIGH: 2 } }), rng).score).toBeCloseTo(102);
+    expect(resolveTrick(scenario(8, 0, { familyTiers: { D_HIGH: 2 } }), rng).score).toBeCloseTo((B + 150) * 1.02); // (Basis+150)×1,02
+    expect(resolveTrick(scenario(7, 0, { familyTiers: { D_HIGH: 2 } }), rng).score).toBeCloseTo(B * 1.02);
   });
 
   it("D_FORMATION_BONUS: Familien-Flat stapelt mit dem Formations-Multiplikator (Wiederholung ×1,25)", () => {
     // Ohne Formation → nur Basis. Mit Formation (Pos 1 = Wiederholung) fließt der Flat in die multiplizierte Basis.
-    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_FORMATION_BONUS: 1 } }), rng).lastTrick.gained).toBeCloseTo(102);
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_FORMATION_BONUS: 1 } }), rng).lastTrick.gained).toBeCloseTo(B * 1.02);
     const deck = [{ id: "a", suit: "R", baseRank: 12, value: 12 }, { id: "b", suit: "R", baseRank: 12, value: 12 }];
     const opp = [{ id: "o0", suit: "R", baseRank: 0, value: 0 }, { id: "o1", suit: "R", baseRank: 0, value: 0 }];
     let s = { ...initialState(makeRng(1)), deck, oppDeck: opp, playerOrder: [0, 1], oppOrder: [0, 1], familyTiers: { D_FORMATION_BONUS: 1 } };
     s = resolveTrick(s, rng); s = resolveTrick(s, rng); // Pos 1 = Wiederholung (×1,25)
-    expect(s.lastTrick.gained).toBeCloseTo((100 + 50) * 1.04 * 1.25); // Stufe I: +50
+    expect(s.lastTrick.gained).toBeCloseTo((B +50) * 1.04 * 1.25); // Stufe I: +50
   });
 
   it("D_STREAK: Familien-Flat wächst über mehrere Stiche mit der Serie (Stufe I: +15/Serienpunkt)", () => {
@@ -56,27 +58,27 @@ describe("Familien-Engine-Verdrahtung — Kategorie D über resolveTrick (Schrit
     s = resolveTrick(s, rng); // (100+15)×1,02
     s = resolveTrick(s, rng); // (100+30)×1,04
     s = resolveTrick(s, rng); // (100+45)×1,06
-    expect(s.score).toBeCloseTo((100 + 15) * 1.02 + (100 + 30) * 1.04 + (100 + 45) * 1.06);
+    expect(s.score).toBeCloseTo((B +15) * 1.02 + (B +30) * 1.04 + (B +45) * 1.06);
   });
 
   it("scoreFlatOnCrit-Familie (D_CRIT_SCORE) zahlt nur bei einem Crit", () => {
     // erzwungener Crit via statCritChance:1 → Rang 2 gibt +175 in die Basis, dann Crit-Faktor.
     const s = resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_SCORE: 2 }, statCritChance: 1 }), rng);
     expect(s.lastTrick.isCrit).toBe(true);
-    expect(s.lastTrick.gained).toBeCloseTo((100 + 175) * 1.02 * s.lastTrick.critMultiplier);
+    expect(s.lastTrick.gained).toBeCloseTo((B +175) * 1.02 * s.lastTrick.critMultiplier);
     // Ohne Crit (keine Crit-Chance) trägt die Familie nichts bei → nur Basis.
-    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_SCORE: 2 } }), rng).score).toBeCloseTo(102);
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_SCORE: 2 } }), rng).score).toBeCloseTo(B * 1.02);
   });
 
   it("Zwei Familien gleichzeitig — additiv, kein gegenseitiges Überschreiben", () => {
     // D_HIGH IV (Wert ≥6 → +350) + D_OVERPOWER II (Vorsprung ≥8 → +400) auf einem Sieg mit Wert 8 / Vorsprung 8.
     const s = resolveTrick(scenario(8, 0, { familyTiers: { D_HIGH: 4, D_OVERPOWER: 2 } }), rng);
-    expect(s.score).toBeCloseTo((100 + 350 + 400) * 1.02);
+    expect(s.score).toBeCloseTo((B +350 + 400) * 1.02);
   });
 
   it("leere familyTiers verändern den Score nicht (reine Additivität)", () => {
-    expect(resolveTrick(scenario(12, 0, { familyTiers: {} }), rng).score).toBeCloseTo(102);
-    expect(resolveTrick(scenario(12, 0), rng).score).toBeCloseTo(102); // Feld ganz weggelassen
+    expect(resolveTrick(scenario(12, 0, { familyTiers: {} }), rng).score).toBeCloseTo(B * 1.02);
+    expect(resolveTrick(scenario(12, 0), rng).score).toBeCloseTo(B * 1.02); // Feld ganz weggelassen
   });
 });
 
@@ -351,7 +353,7 @@ describe("Engine-Parameter je Stufe (Schritt 2) — engine-gekoppelte D-Familien
     const paid = resolveTrick(scenario(12, 0, { familyTiers: { D_MISFIRE: 4 }, statCritChance: 1, misfireScore: 400 }), never);
     expect(paid.lastTrick.isCrit).toBe(true);
     expect(paid.misfireScore).toBe(100); // round(400 × 0,25)
-    expect(paid.lastTrick.gained).toBeCloseTo((100 + 400) * 1.02 * paid.lastTrick.critMultiplier); // volle 400 in die Basis
+    expect(paid.lastTrick.gained).toBeCloseTo((B +400) * 1.02 * paid.lastTrick.critMultiplier); // volle 400 in die Basis
   });
 
   it("D_WEAKNESS: Stufen-Schwelle rüstet (I: ≥7)", () => {
@@ -365,8 +367,8 @@ describe("Engine-Parameter je Stufe (Schritt 2) — engine-gekoppelte D-Familien
     const big = resolveTrick(scenario(5, 12, { familyTiers: { D_WEAKNESS: 4 } }), never); // Abstand 7 ≥5
     expect(big.weaknessBig).toBe(true);
     // Auszahlung am nächsten Sieg: big → +900, sonst +600.
-    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_WEAKNESS: 4 }, weaknessArmed: true, weaknessBig: true }), never).score).toBeCloseTo((100 + 900) * 1.02);
-    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_WEAKNESS: 4 }, weaknessArmed: true, weaknessBig: false }), never).score).toBeCloseTo((100 + 600) * 1.02);
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_WEAKNESS: 4 }, weaknessArmed: true, weaknessBig: true }), never).score).toBeCloseTo((B +900) * 1.02);
+    expect(resolveTrick(scenario(12, 0, { familyTiers: { D_WEAKNESS: 4 }, weaknessArmed: true, weaknessBig: false }), never).score).toBeCloseTo((B +600) * 1.02);
     expect(resolveTrick(scenario(12, 0, { familyTiers: { D_WEAKNESS: 4 }, weaknessArmed: true, weaknessBig: true }), never).weaknessBig).toBe(false); // Sieg verbraucht
   });
 
@@ -391,18 +393,18 @@ describe("Engine-Parameter je Stufe (Schritt 2) — engine-gekoppelte D-Familien
     expect(resolveTrick(scenario(0, 12, { familyTiers: { D_INTERPLAY: 3 } }), never).interplayStored).toBe(0);
     // Nächster Sieg nach Niederlage: 700 (Wechselspiel-Basis) + 200 (gespeichert) in die multiplizierte Basis; danach verbraucht.
     const win = resolveTrick(scenario(12, 0, { familyTiers: { D_INTERPLAY: 4 }, interplayStored: 200, lastResult: "loss" }), never);
-    expect(win.score).toBeCloseTo((100 + 700 + 200) * 1.02);
+    expect(win.score).toBeCloseTo((B +700 + 200) * 1.02);
     expect(win.interplayStored).toBe(0);
   });
 
   it("D_CRIT_FOLLOW IV: Crit-Folgesieg, der selbst Crit ist, gibt zusätzlich +300", () => {
     const cf = resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_FOLLOW: 4 }, critFollowArmed: true, statCritChance: 1 }), never);
     expect(cf.lastTrick.isCrit).toBe(true);
-    expect(cf.lastTrick.gained).toBeCloseTo((100 + 700 + 300) * 1.02 * cf.lastTrick.critMultiplier); // 700 (Folge) + 300 (Crit-Bonus)
+    expect(cf.lastTrick.gained).toBeCloseTo((B +700 + 300) * 1.02 * cf.lastTrick.critMultiplier); // 700 (Folge) + 300 (Crit-Bonus)
     // Folgesieg ohne Crit → nur die 700 (kein +300).
     const noCrit = resolveTrick(scenario(12, 0, { familyTiers: { D_CRIT_FOLLOW: 4 }, critFollowArmed: true } ), never);
     expect(noCrit.lastTrick.isCrit).toBe(false);
-    expect(noCrit.score).toBeCloseTo((100 + 700) * 1.02);
+    expect(noCrit.score).toBeCloseTo((B +700) * 1.02);
   });
 
   it("D_FULL_HOUSE: löst über den generischen Hook auf (fünfter Segment-Sieg → +500, Stufe I)", () => {

--- a/test/fire.test.js
+++ b/test/fire.test.js
@@ -6,6 +6,8 @@ import {
   initHeat, heatMaxFor, heatConsumerOf, heatConsumerCount, activeFireCount, fireFlag,
   heatGainFor, heatLossFor, fireScoreFor,
 } from "../src/game/skills.js";
+import { SCORE_PER_WIN } from "../src/game/constants.js";
+const B = SCORE_PER_WIN; // Basis-relativ: erwartete Scores skalieren mit der Sieg-Basis (Pacing-Pass 100→400)
 
 // Feuer-Skill-IDs (Flags siehe skills.js): F1 Glut · F2 Brennstoff · F3 Brandbeschleuniger · F4 Hitzeschild
 // F5 Nachglut · F6 Glühende Klinge · F7 Verbrennung · F8 Feuerwalze · F9 Flächenbrand · F10 Schmelzpunkt
@@ -80,7 +82,7 @@ describe("Feuer — Engine-Integration (#93 F1)", () => {
     const s = resolveTrick(scen(12, 0, { skills: [F4], heat: heat() }), rng);
     expect(s.heat.value).toBe(6);                        // (min(12,8)−2)×1 — Feuer-Flat-Score bleibt unverändert
     expect(s.lastTrick.breakdown.flats).toBe(250);        // Feuer-Flat 10×25
-    expect(s.lastTrick.gained).toBeCloseTo(350 * 1.02);   // (100 + 250) × streakBaseMult(1)
+    expect(s.lastTrick.gained).toBeCloseTo((B + 250) * 1.02);   // (Basis + 250) × streakBaseMult(1)
   });
   it("Niederlage: Hitzeverlust = min(Rückstand,10)", () => {
     expect(resolveTrick(scen(0, 12, { skills: [F7], heat: heat({ value: 50 }) }), rng).heat.value).toBe(40);

--- a/test/skills-165.test.js
+++ b/test/skills-165.test.js
@@ -5,7 +5,8 @@ import { resolveTrick } from "../src/game/engine.js";
 import { ionizeCards, ionizeCardsWithCatch, hasBlitzcatcher, hasVoltageArc, initHeat, heatLossFor, fireScoreFor,
   hasGlacierPush, hasIceBloom } from "../src/game/skills.js";
 import { computeFormations, baseFormationCount } from "../src/game/formations.js";
-import { ION_MAX_STACKS } from "../src/game/constants.js";
+import { ION_MAX_STACKS, SCORE_PER_WIN } from "../src/game/constants.js";
+const B = SCORE_PER_WIN; // Basis-relativ: erwartete Scores skalieren mit der Sieg-Basis (Pacing-Pass 100→400)
 
 /* ============================================================
    #165 Skills (Spec §5) — je Archetyp +2 neue Skills + Balance-Änderungen.
@@ -145,9 +146,9 @@ describe("#165 Feuer — Funkenflug (SK_FIRE_14)", () => {
     expect(s.heat.sparkStore).toBe(0);
   });
   it("nächster Sieg zahlt den Speicher als Flat aus und erzeugt keinen neuen", () => {
-    // Speicher 100 → scoreBase = 100 + Feuer-Flat 250 + Auszahlung 100 = 450; × streakBaseMult(1)=1,02.
+    // Speicher 100 → scoreBase = Basis + Feuer-Flat 250 + Auszahlung 100; × streakBaseMult(1)=1,02.
     const s = resolveTrick(scen(12, 0, { skills: [F14], heat: heat({ value: 50, sparkStore: 100 }) }), noCrit);
-    expect(s.lastTrick.gained).toBeCloseTo(450 * 1.02);
+    expect(s.lastTrick.gained).toBeCloseTo((B + 250 + 100) * 1.02);
     expect(s.heat.sparkStore).toBe(0); // ausgezahlt, kein neuer Speicher trotz Vorsprung ≥ 8
   });
   it("Niederlage löscht den Speicher nicht", () => {

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -31,7 +31,7 @@ describe("lightningCritRaw — Crit-Basis (Abschnitt 2a)", () => {
   });
   it("Sockel + je Skill, wenn aktiv", () => {
     expect(lightningCritRaw(active(), [])).toBeCloseTo(LIGHTNING_CRIT_BASE);                              // nur Sockel
-    expect(lightningCritRaw(active(), [LR])).toBeCloseTo(LIGHTNING_CRIT_BASE + LIGHTNING_CRIT_PER_SKILL); // → 0,10
+    expect(lightningCritRaw(active(), [LR])).toBeCloseTo(LIGHTNING_CRIT_BASE + LIGHTNING_CRIT_PER_SKILL); // Sockel + 1× pro-Skill
   });
 });
 
@@ -180,7 +180,7 @@ describe("Reaktoren + Geladene Serie — Helfer (Stufe C)", () => {
   });
   it("lightningCritRaw addiert den Gewitterfront-Bonus (stormCritBonus)", () => {
     const l = { active: true, charge: 0, maxCharge: 10, stormCritBonus: 0.08 };
-    expect(lightningCritRaw(l, [G])).toBeCloseTo(0.05 + 0.05 + 0.08); // Sockel + Skill-critChance + Storm
+    expect(lightningCritRaw(l, [G])).toBeCloseTo(LIGHTNING_CRIT_BASE + LIGHTNING_CRIT_PER_SKILL + 0.08); // Sockel + Skill-critChance + Storm(0,08)
   });
 });
 


### PR DESCRIPTION
Sim-validierter Balance-Pass (test/sim, `--mode pacing` + Archetyp-Sweeps). Zwei Hebel:

**1 · Pacing — `SCORE_PER_WIN` 100 → 400.** Entzerrt die stark hinten-lastige Score-Kurve, ohne die Explosion guter Builds zu nehmen (flache Boni akkumulieren spät → höhere Basis hebt Early/Mid relativ stärker).
- „Durch die Bank" (Runs >45 % Score im Finale): **57 % → 24 %**
- Mid-Game (Score-Anteil bis Runde 30): **41 % → 48 %**
- Spread starker Builds & Ceiling erhalten (gute Builds spiken weiter, Late/Early-Ø p90 = 3,4×)
- Kein Multiplikator-Cap nötig (die stauchen nur das Ceiling, flachen kaum ab)

**2 · Kleiner Blitz-Buff — `LIGHTNING_CRIT_PER_SKILL` 0,05 → 0,08.** Blitz war bei der höheren Basis der Nachzügler (flache Ion/Sturm/Ladungs-Boni relativ geschrumpft). Der Crit-Motor (multiplikativ, = Blitz-Identität) ist der wirksame Hebel.
- Blitz **0,81× → 0,89×** des besten Archetyps; Archetyp-Spread **1,22× → 1,12×**
- Mischen gesund (bester gemischt/rein = 1,03×), Winrate unverändert

**Tests:** basis-/konstanten-relativ gemacht (erwartete Basis = `SCORE_PER_WIN`, Crit aus `LIGHTNING_CRIT_*`) → robust bei jedem Wert. Der neue `#153`-Cap-Test aus diesem Branch-Stand wurde beim Merge mitgezogen. **587 Tests grün.** Sauberer Fast-Forward auf `Autostich_Test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)